### PR TITLE
feat(grammar): expand keyword highlighting to current Phel core

### DIFF
--- a/syntaxes/phel.tmLanguage.json
+++ b/syntaxes/phel.tmLanguage.json
@@ -50,7 +50,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.phel",
-					"match": "(?<=\\(|\\{|\\[|\\s)(definterface\\*?|defexception\\*?|defstruct\\*?|declare|defmacro-|defmacro|defn-|defn|def-|def|recur|fn|try|catch|finally|loop|ns|in-ns|quote|dofor|doseq|do|if-not|if-let|if|when-not|when-let|when|apply|let|foreach|for|case|cond|throw|set-var|comment|or|and|->|->>|some->|some->>|as->|doto|lazy-seq|lazy-cat|binding|time|with-output-buffer)(?=\\s|\\)|\\]|\\})"
+					"match": "(?<=\\(|\\{|\\[|\\s)(with-output-buffer|with-mock-wrapper|unquote-splicing|extend-protocol|definterface\\*?|defexception\\*?|with-bindings|future-fiber|with-redefs|with-config|symbol-info|extend-type|explain-sym|defprotocol|with-mocks|when-first|defstruct\\*?|when-some|instance\\?|defrecord|defmethod|defmacro-|when-not|when-let|lazy-seq|lazy-cat|hash-map|defmulti|defmacro|unquote|testing|some->>|set-var|require|if-some|foreach|finally|dotimes|deftype|deftest|defspec|declare|cond->>|comment|binding|vector|source|some->|reify\\*?|if-not|if-let|future|cond->|concat|assert|throw|recur|quote|match|letfn|in-ns|doseq|dofor|deref|delay|defn-|condp|catch|async|apply|when|time|loop|load|list|html|doto|defn|def-|conj|cond|case|as->|var|use|try|pop|new|let|for|doc|dir|def|are|and|->>|or|ns|is|if|fn|do|->)(?=\\s|\\)|\\]|\\})"
 				},
 				{
 					"name": "keyword.control.phel",


### PR DESCRIPTION
Re-opens #6 (auto-closed after the chore base branch was deleted).

## Summary
Refresh \`syntaxes/phel.tmLanguage.json\` so the highlighter recognises every special form from the current compiler and every public core macro:

- **Special forms added**: \`var\`, \`deref\`, \`new\`, \`conj\`, \`concat\`, \`list\`, \`vector\`, \`hash-map\`, \`load\`, \`use\`, \`reify*\`, \`unquote\`, \`unquote-splicing\`.
- **Macros added**: \`defprotocol\`, \`defrecord\`, \`defmethod\`, \`defmulti\`, \`defspec\`, \`deftest\`, \`deftype\`, \`are\`, \`assert\`, \`async\`, \`cond->\`, \`cond->>\`, \`condp\`, \`delay\`, \`dir\`, \`doc\`, \`dotimes\`, \`explain-sym\`, \`extend-protocol\`, \`extend-type\`, \`future\`, \`future-fiber\`, \`html\`, \`if-some\`, \`instance?\`, \`is\`, \`letfn\`, \`match\`, \`pop\`, \`reify\`, \`require\`, \`source\`, \`symbol-info\`, \`testing\`, \`when-first\`, \`when-some\`, \`with-bindings\`, \`with-config\`, \`with-mock-wrapper\`, \`with-mocks\`, \`with-redefs\`.

The alternation is sorted longest-first so e.g. \`defmacro-\` matches before \`defmacro\`, \`cond->>\` before \`cond->\` before \`cond\`.

## Why
Sources of truth: \`Symbol.php\` constants in phel-lang core (special forms) and \`defmacro\` declarations across \`src/phel/**/*.phel\`. Previously many common forms (\`defprotocol\`, \`deftest\`, threading variants, etc.) rendered as plain symbols.

## Test plan
- [x] Grammar still valid JSON.
- [x] \`npm test\` — 85 passing.
- [ ] Visual smoke check in VS Code (reviewer).