### PR TITLE
docs(release): bump to 0.3.0 and document new features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the "phel-lang" extension will be documented in this file.
 
+## [0.3.0] - 2026-05-06
+
+### Added
+
+- **Code completion** for the full public Phel core: 382 functions, all special forms, and every public macro. Special forms and macros surface as `Keyword`; plain functions as `Function`.
+- **Code snippets** for the most common forms — `ns`, `defn`, `defn-`, `def`, `fn`, `let`, `if`, `when`, `cond`, `case`, `doseq`, `for`, `loop`/`recur`, `try`/`catch`, `defmacro`, `defstruct`, `definterface`, `defprotocol`, `defexception`, `deftest`, `->`, `->>`, `comment`.
+- **Expanded syntax highlighting** with the rest of the current core: `var`, `deref`, `new`, `conj`, `concat`, `list`, `vector`, `hash-map`, `load`, `use`, `reify*`, `unquote`, `unquote-splicing`, plus macros `defprotocol`, `defrecord`, `defmethod`, `defmulti`, `defspec`, `deftest`, `deftype`, `are`, `assert`, `async`, `cond->`, `cond->>`, `condp`, `delay`, `dir`, `doc`, `dotimes`, `explain-sym`, `extend-protocol`, `extend-type`, `future`, `future-fiber`, `html`, `if-some`, `instance?`, `is`, `letfn`, `match`, `pop`, `reify`, `require`, `source`, `symbol-info`, `testing`, `when-first`, `when-some`, `with-bindings`, `with-config`, `with-mock-wrapper`, `with-mocks`, `with-redefs`. Alternation is sorted longest-first so e.g. `defmacro-` wins over `defmacro` and `cond->>` over `cond`.
+
+### Changed
+
+- Bumped `mocha` to `^11.7.5` and added npm `overrides` for `serialize-javascript` (`^7.0.5`) and `diff` (`^9.0.0`); `npm audit` now reports zero vulnerabilities.
+
 ## [0.2.0] - 2025-02-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,13 +4,19 @@ This VS Code extension provides syntax highlighting and language support for [Ph
 
 ## Features
 
-- **Syntax highlighting** for all Phel constructs:
-  - Special forms: `def`, `defn`, `fn`, `let`, `if`, `loop`, `recur`, etc.
-  - Macros: `when`, `cond`, `case`, `->`, `->>`, `for`, `doseq`, etc.
+- **Syntax highlighting** for the full Phel core:
+  - Special forms: `def`, `defn`, `fn`, `let`, `if`, `loop`, `recur`, `var`, `deref`, `new`, `quote`, `try`/`catch`/`finally`, all `php/*` interop forms, etc.
+  - Macros: `when`, `cond`, `cond->`, `cond->>`, `condp`, `case`, `->`, `->>`, `some->`, `some->>`, `as->`, `for`, `doseq`, `dotimes`, `match`, `defprotocol`, `defrecord`, `deftype`, `deftest`, `extend-type`, `extend-protocol`, `with-redefs`, etc.
   - Literals: keywords (`:keyword`), strings, numbers, booleans, `nil`
   - Collections: vectors `[]`, maps `{}`, sets `#{}`, lists `'()`
   - Short anonymous functions: `|(+ $1 $2)`
-  
+
+- **Code completion** for every public symbol shipped with phel-lang core:
+  - All special forms and macros (suggested as keywords)
+  - 382 public functions from `phel\core` and friends — `assoc`, `map`, `reduce`, `swap!`, `re-find`, `parse-uuid`, etc. (suggested as functions)
+
+- **Code snippets** for common scaffolding — type `defn`, `let`, `cond`, `try`, `deftest`, `->`, … and tab through the placeholders.
+
 - **Comment support**:
   - Line comments: `#` or `;`
   - Block comments: `#| ... |#`
@@ -175,13 +181,13 @@ Search for "Phel Lang" in the VS Code extensions marketplace.
    **macOS/Linux:**
    ```bash
    cd ~/.vscode/extensions
-   ln -s /path/to/phel-vs-code-extension phel-lang.phel-lang-0.2.0
+   ln -s /path/to/phel-vs-code-extension phel-lang.phel-lang-0.3.0
    ```
 
    **Windows (PowerShell as Administrator):**
    ```powershell
    cd $env:USERPROFILE\.vscode\extensions
-   New-Item -ItemType SymbolicLink -Target "C:\path\to\phel-vs-code-extension" -Path "phel-lang.phel-lang-0.2.0"
+   New-Item -ItemType SymbolicLink -Target "C:\path\to\phel-vs-code-extension" -Path "phel-lang.phel-lang-0.3.0"
    ```
 
 3. Restart VS Code

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "phel-lang",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "phel-lang",
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@vscode/debugadapter": "^1.64.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "phel-lang",
     "displayName": "Phel Lang",
     "description": "Full-featured Phel language support with debugging for VS Code",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "publisher": "phel-lang",
     "license": "MIT",
     "engines": {

--- a/src/phelCoreSymbols.ts
+++ b/src/phelCoreSymbols.ts
@@ -1,3 +1,9 @@
+// Snapshot of the phel-lang core public surface used by the completion
+// provider. Sources of truth (regenerate when bumping phel-lang):
+//   - SPECIAL_FORMS — `NAME_*` constants in phel-lang's `src/php/Lang/Symbol.php`
+//   - MACROS       — `^\(defmacro ` declarations across `src/phel/**/*.phel`
+//   - CORE_FNS     — `^\(defn `      declarations across `src/phel/**/*.phel`
+
 export const SPECIAL_FORMS: readonly string[] = [
     'apply',
     'catch',


### PR DESCRIPTION
## Summary
- Bump version to **0.3.0** in \`package.json\` + \`package-lock.json\`.
- Add a 0.3.0 entry to \`CHANGELOG.md\` covering the completion provider, snippets, expanded grammar, and the audit fix shipped in #5, #9, #10, #11.
- Refresh \`README.md\` so the Features section advertises completion + snippets and the manual-install symlink uses \`0.3.0\`.
- Add a header comment to \`src/phelCoreSymbols.ts\` documenting the source of truth for each list (regen instructions for the next maintainer).

## Test plan
- [x] \`npm install\` — clean.
- [x] \`npm run compile\` — clean.
- [x] \`npm test\` — 85 passing.