### PR TITLE
docs(contrib): add CONTRIBUTING.md and core symbol regen script

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -14,3 +14,5 @@ vsc-extension-quickstart.md
 node_modules/.bin/**
 node_modules/@types/**
 **/*.test.js
+CONTRIBUTING.md
+scripts/**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing
+
+Thanks for considering a contribution. This document captures the small set of conventions used in this repo.
+
+## Getting started
+
+```bash
+git clone git@github.com:phel-lang/phel-vs-code-extension.git
+cd phel-vs-code-extension
+npm install
+```
+
+Useful scripts:
+
+| Command | Purpose |
+|---------|---------|
+| `npm run compile` | TypeScript build (output in `out/`) |
+| `npm run watch` | Incremental build during development |
+| `npm run lint` / `npm run lint:fix` | ESLint |
+| `npm run format` / `npm run format:check` | Prettier |
+| `npm test` | Mocha test suite |
+
+`npm run compile && npm run lint && npm test` is the gate every PR has to pass.
+
+## Running the extension locally
+
+Open the repo in VS Code and press <kbd>F5</kbd>. That starts an Extension Development Host with this extension loaded and source-mapped — set breakpoints in `src/*.ts`, then exercise the extension by opening a `.phel` file in the Host window.
+
+## Branches
+
+The default branch is `main`. Topic branches use a `<type>/<short-slug>` shape, e.g.
+
+- `feat/hover-provider`
+- `fix/source-map-cache-race`
+- `chore/bump-typescript`
+- `docs/contributing`
+
+## Commits
+
+Use [Conventional Commits](https://www.conventionalcommits.org/). Common prefixes in this repo:
+
+- `feat(<area>): …` — new user-visible behaviour
+- `fix(<area>): …` — bug fix
+- `chore(deps): …` — dependency / tooling changes
+- `docs(<area>): …` — README, CHANGELOG, comments
+
+Keep the subject under ~70 characters; put the *why* in the body when it isn't obvious from the diff.
+
+## Pull requests
+
+- One concern per PR. Stack PRs if a feature naturally splits.
+- Link the source of truth when adding language features (e.g. point at the `phel-lang` file or commit that introduced the form).
+- Update `CHANGELOG.md` under an `## [Unreleased]` heading (or bump the version in a separate PR if the change ships immediately).
+- Make sure compile, lint, and tests pass.
+
+## Releasing
+
+1. Decide the new version (`MAJOR.MINOR.PATCH`).
+2. Bump it in `package.json` and run `npm install` so `package-lock.json` follows.
+3. Move the `Unreleased` block in `CHANGELOG.md` under the new version and date.
+4. Open a `chore(release): x.y.z` PR.
+5. After merge, tag `vX.Y.Z` on `main` and (if publishing) run `vsce package` / `vsce publish`.
+
+## Updating the language surface
+
+The completion and grammar features are driven by snapshots of the phel-lang core. When `phel-lang` adds or renames symbols:
+
+### Grammar (`syntaxes/phel.tmLanguage.json`)
+
+The `corelib` pattern in `syntaxes/phel.tmLanguage.json` is a single regex alternation of every special form and macro that should be highlighted as `keyword.control.phel`. **The order matters** — alternation is left-to-right, so longer names must come first (`defmacro-` before `defmacro`, `cond->>` before `cond->` before `cond`, `if-some` before `if`). When you edit the list, sort it longest-first.
+
+### Completion (`src/phelCoreSymbols.ts`)
+
+Three readonly arrays — `SPECIAL_FORMS`, `MACROS`, `CORE_FNS` — back the completion provider. To regenerate them from a phel-lang checkout:
+
+```bash
+scripts/regen-core-symbols.sh /path/to/phel-lang > /tmp/phel-symbols.txt
+```
+
+The script prints the three arrays to stdout. Review the output, then paste the relevant arrays into `src/phelCoreSymbols.ts`. The script does not write the file in place on purpose — manual review keeps surprises (private helpers leaking into completion) out of the published surface.
+
+### Snippets (`snippets/phel.code-snippets`)
+
+Snippets cover the common shapes a Phel programmer types from muscle memory (`defn`, `let`, `cond`, `try`/`catch`, …). Add or refine entries when a form is fiddly enough that scaffolding helps. Keep the `prefix` matching the form name so it composes naturally with completion.
+
+## Reporting issues
+
+Please file issues at <https://github.com/phel-lang/phel-vs-code-extension/issues>. Include:
+
+- VS Code version and OS
+- Extension version
+- A short `.phel` snippet that reproduces the problem
+- What you expected vs. what happened (screenshots help for highlighting/completion bugs)

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Press F5 in VS Code to launch an Extension Development Host with the extension l
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit issues or pull requests at [GitHub](https://github.com/phel-lang/phel-vs-code-extension).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, conventions, and how to refresh the language surface (grammar, completion, snippets) when phel-lang core changes. Issues and pull requests are welcome at [GitHub](https://github.com/phel-lang/phel-vs-code-extension).
 
 ## Release Notes
 

--- a/scripts/regen-core-symbols.sh
+++ b/scripts/regen-core-symbols.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Regenerate the body of src/phelCoreSymbols.ts from a phel-lang checkout.
+#
+# Usage:
+#   scripts/regen-core-symbols.sh /path/to/phel-lang
+#
+# Prints the three arrays (SPECIAL_FORMS, MACROS, CORE_FNS) to stdout so the
+# author can review and paste them into src/phelCoreSymbols.ts. The script does
+# not edit the file in place — manual review keeps surprises out of the public
+# completion surface.
+
+set -euo pipefail
+
+PHEL_LANG_ROOT=${1:-}
+if [[ -z "$PHEL_LANG_ROOT" ]]; then
+    echo "usage: $0 /path/to/phel-lang" >&2
+    exit 1
+fi
+
+SYMBOL_PHP="$PHEL_LANG_ROOT/src/php/Lang/Symbol.php"
+PHEL_SRC="$PHEL_LANG_ROOT/src/phel"
+
+if [[ ! -f "$SYMBOL_PHP" ]]; then
+    echo "Symbol.php not found at $SYMBOL_PHP" >&2
+    exit 1
+fi
+
+if [[ ! -d "$PHEL_SRC" ]]; then
+    echo "Phel source dir not found at $PHEL_SRC" >&2
+    exit 1
+fi
+
+format_array() {
+    local label="$1"
+    printf "// %s\n[\n" "$label"
+    while IFS= read -r value; do
+        printf "    '%s',\n" "$value"
+    done
+    printf "]\n\n"
+}
+
+extract_special_forms() {
+    grep -E "NAME_[A-Z_]+ = '" "$SYMBOL_PHP" |
+        sed -E "s/.*= '([^']+)'.*/\1/" |
+        sort -u
+}
+
+extract_macros() {
+    find "$PHEL_SRC" -name '*.phel' -exec grep -hE '^\(defmacro ' {} + |
+        awk '{print $2}' |
+        sort -u
+}
+
+extract_core_fns() {
+    find "$PHEL_SRC" -name '*.phel' -exec grep -hE '^\(defn ' {} + |
+        awk '{print $2}' |
+        sort -u
+}
+
+extract_special_forms | format_array "SPECIAL_FORMS"
+extract_macros | format_array "MACROS"
+extract_core_fns | format_array "CORE_FNS"

--- a/src/phelCoreSymbols.ts
+++ b/src/phelCoreSymbols.ts
@@ -3,6 +3,8 @@
 //   - SPECIAL_FORMS — `NAME_*` constants in phel-lang's `src/php/Lang/Symbol.php`
 //   - MACROS       — `^\(defmacro ` declarations across `src/phel/**/*.phel`
 //   - CORE_FNS     — `^\(defn `      declarations across `src/phel/**/*.phel`
+// To regenerate, run `scripts/regen-core-symbols.sh /path/to/phel-lang`
+// and paste the relevant arrays back here. See CONTRIBUTING.md.
 
 export const SPECIAL_FORMS: readonly string[] = [
     'apply',


### PR DESCRIPTION
## Summary
- Add \`CONTRIBUTING.md\` — setup, scripts, branch + commit conventions, release flow, and how to refresh the language surface.
- Add \`scripts/regen-core-symbols.sh\` — prints \`SPECIAL_FORMS\` / \`MACROS\` / \`CORE_FNS\` arrays from a phel-lang checkout. Does not edit \`phelCoreSymbols.ts\` in place; manual review keeps private helpers out of the public completion surface.
- Cross-link \`CONTRIBUTING.md\` from \`README.md\` and the header comment of \`src/phelCoreSymbols.ts\`.
- Update \`.vscodeignore\` so \`CONTRIBUTING.md\` and \`scripts/\` stay out of the published \`.vsix\`.

## Test plan
- [x] \`scripts/regen-core-symbols.sh ../phel-lang\` returns three populated arrays (775 entries total).
- [x] \`npm run compile\` — clean.
- [x] \`npm test\` — 85 passing.