### PR TITLE
fix(grammar): repair shadowed reader-prefix patterns + add tokenizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,18 @@ Sync with phel-lang `main` (commit `428c59f`).
 
 - **Anonymous function syntax `#(...)`** with `%`, `%1`, `%2`, …, `%&` placeholders — the form Phel now ships as the default. The legacy `|(...)` form with `$`-placeholders continues to highlight for older code.
 - **Preferred reader macros** `~` (unquote) and `~@` (unquote-splicing) now highlight as reader-macro punctuation alongside the legacy `,` and `,@`.
+- **Deref `@x`** now highlights `@` as reader-macro punctuation (previously it was absorbed into the symbol). Mutable collection literals `@(...)`, `@[...]`, `@{...}` still parse via the existing collection patterns.
 - `aset` macro added to grammar and completion (lives in `phel\core`'s `arrays.phel`).
 - Numeric / comparison core fns added to completion: `+`, `-`, `*`, `**`, `/`, `%`, `<`, `<=`, `=`, `==`, `>`, `>=`.
+- `npm run tokenize` and `scripts/tokenize-sample.mjs` — runs the same `vscode-textmate` engine VS Code uses to produce a token-by-token report for a sample `.phel` file. Used to verify highlighting changes without launching the editor.
+
+### Fixed
+
+- Set literals `#{...}`, anonymous functions `#(...)`, and inline form-comments `#_` were previously eaten by the line-comment pattern (`[#;]` matched any `#` first). The comment pattern now requires `#` to be followed by whitespace or end-of-line, so `#{`, `#(`, `#_`, `#|`, `#?`, and `#tag` literals all reach their proper patterns.
 
 ### Changed
 
+- README "Debug Trace Mode" section replaced with a "Inspecting Values with Taps" section that uses the current `add-tap` / `tap>` / `remove-tap` API in `phel\core`. The previous `(phel\debug/enable-trace)` API no longer exists upstream.
 - `CONTRIBUTING.md` and `scripts/regen-core-symbols.sh` now scope the `MACROS` and `CORE_FNS` extraction to `phel\core` only (`src/phel/core.phel` plus `src/phel/core/**/*.phel`). Library macros from `phel\test`, `phel\match`, `phel\repl`, `phel\html`, etc. remain in the curated list because they are commonly `:refer`'d unqualified.
 - README documents the new anonymous function and comment syntax (`;` / `;;` preferred over the deprecated `#`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,14 @@ The completion and grammar features are driven by snapshots of the phel-lang cor
 
 The `corelib` pattern in `syntaxes/phel.tmLanguage.json` is a single regex alternation of every special form and macro that should be highlighted as `keyword.control.phel`. **The order matters** — alternation is left-to-right, so longer names must come first (`defmacro-` before `defmacro`, `cond->>` before `cond->` before `cond`, `if-some` before `if`). When you edit the list, sort it longest-first.
 
+To verify highlighting changes without launching VS Code, run:
+
+```bash
+npm run tokenize
+```
+
+That uses the same `vscode-textmate` + `vscode-oniguruma` engine VS Code ships with to tokenise `scripts/sample.phel` and prints each token with its scope. Add new edge cases to `scripts/sample.phel` when fixing or extending grammar patterns.
+
 ### Completion (`src/phelCoreSymbols.ts`)
 
 Three readonly arrays — `SPECIAL_FORMS`, `MACROS`, `CORE_FNS` — back the completion provider. To regenerate them from a phel-lang checkout:

--- a/README.md
+++ b/README.md
@@ -159,22 +159,27 @@ For containerized environments, add path mappings:
 - **Multi-expression lines**: Correctly handles multiple expressions on one Phel line
 - **Exception breakpoints**: Break on all or uncaught PHP exceptions
 
-### Debug Trace Mode
+### Inspecting Values with Taps
 
-Phel also supports a built-in debug trace mode:
+For ad-hoc tracing without a debugger, Phel ships a Clojure-style tap registry in `phel\core`. Register a handler with `add-tap`, send values with `tap>`:
 
 ```phel
-(ns my-app
-  (:require phel\debug))
+(ns my-app\core)
 
-# Enable debug tracing (logs to ./phel-debug.log)
-(phel\debug/enable-trace)
+;; Print every tapped value (or push to a logger, atom, etc.).
+(add-tap println)
 
-# Your code here...
+(defn process [order]
+  (tap> {:event :process-start :id (:id order)})
+  (let [result (do-work order)]
+    (tap> {:event :process-end :id (:id order) :result result})
+    result))
 
-# Disable when done
-(phel\debug/disable-trace)
+;; Cleanup when done
+(remove-tap println)
 ```
+
+Taps run synchronously on the calling thread; exceptions thrown by a tap handler are swallowed so a buggy tap can't take down the producer.
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,9 @@
                 "glob": "^10.3.10",
                 "mocha": "^11.7.5",
                 "prettier": "^3.2.0",
-                "typescript": "^5.3.0"
+                "typescript": "^5.3.0",
+                "vscode-oniguruma": "^2.0.1",
+                "vscode-textmate": "^9.3.2"
             },
             "engines": {
                 "vscode": "^1.75.0"
@@ -2369,6 +2371,20 @@
             "dependencies": {
                 "punycode": "^2.1.0"
             }
+        },
+        "node_modules/vscode-oniguruma": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-2.0.1.tgz",
+            "integrity": "sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/vscode-textmate": {
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-9.3.2.tgz",
+            "integrity": "sha512-n2uGbUcrjhUEBH16uGA0TvUfhWwliFZ1e3+pTjrkim1Mt7ydB41lV08aUvsi70OlzDWp6X7Bx3w/x3fAXIsN0Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/which": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -187,7 +187,8 @@
         "format": "prettier --write \"src/**/*.ts\"",
         "format:check": "prettier --check \"src/**/*.ts\"",
         "pretest": "npm run compile && npm run lint",
-        "test": "mocha out/test/**/*.test.js"
+        "test": "mocha out/test/**/*.test.js",
+        "tokenize": "node scripts/tokenize-sample.mjs"
     },
     "devDependencies": {
         "@types/glob": "^8.1.0",
@@ -202,7 +203,9 @@
         "glob": "^10.3.10",
         "mocha": "^11.7.5",
         "prettier": "^3.2.0",
-        "typescript": "^5.3.0"
+        "typescript": "^5.3.0",
+        "vscode-oniguruma": "^2.0.1",
+        "vscode-textmate": "^9.3.2"
     },
     "dependencies": {
         "@vscode/debugadapter": "^1.64.0"

--- a/scripts/sample.phel
+++ b/scripts/sample.phel
@@ -1,0 +1,62 @@
+;; Sample Phel exercising the grammar features that 0.4.0 should highlight.
+
+(ns my-app\core
+  (:require phel\core :refer [filter map reduce])
+  (:require phel\test :refer [deftest is testing]))
+
+#| legacy block comment — deprecated upstream but still valid |#
+
+# legacy line comment — deprecated, should still highlight
+
+(def ^:private answer 42)
+(def numbers [1 2 3 4 5 0xff 0b1010 0o17 1_000 3.14 2e-3])
+(def ratios #{1/2 -3/4})
+
+(defn greet
+  "Public function with docstring."
+  [name & opts]
+  (str "Hello, " name "! " opts))
+
+(defn- private-helper [x]
+  (when (pos? x) (* x x)))
+
+(defmacro when-positive [x & body]
+  `(when (pos? ~x)
+     ~@body
+     :done))
+
+(deftest arithmetic
+  (testing "addition"
+    (is (= 5 (+ 2 3)))
+    (is (= -1 (- 1 2)))))
+
+(let [xs [1 2 3]]
+  (->> xs
+       (filter #(> % 1))
+       (map #(* %1 %1))
+       (reduce + 0)))
+
+(reduce |(+ $1 $2) 0 [1 2 3])
+
+(let [m {:a 1 :b 2}
+      a (atom 0)]
+  (swap! a inc)
+  (println @a)
+  (try
+    (php/->> m "missing")
+    (catch \Throwable e
+      (println (ex-message e)))))
+
+(defprotocol Greeter (greet [this]))
+(defrecord Person [name]
+  Greeter
+  (greet [this] (str "hi " name)))
+
+#_(comment-out-this-form 1 2 3)
+
+;; Tagged literals (highlighting is best-effort, future work)
+(def created #inst "2026-01-01T00:00:00Z")
+(def re #regex "\\d+")
+
+;; Reader conditional (future work — currently unscoped)
+#?(:phel (php/time) :clj 0)

--- a/scripts/tokenize-sample.mjs
+++ b/scripts/tokenize-sample.mjs
@@ -1,0 +1,63 @@
+// Tokenize a sample of Phel against syntaxes/phel.tmLanguage.json using the
+// same engine VS Code ships (vscode-textmate + vscode-oniguruma). Prints each
+// line with its tokens and scopes so highlighting can be verified without
+// opening the editor.
+//
+// Usage: node scripts/tokenize-sample.mjs [path/to/sample.phel]
+//        Defaults to scripts/sample.phel.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import vscodeTextmate from 'vscode-textmate';
+import onigPkg from 'vscode-oniguruma';
+
+const { Registry, parseRawGrammar, INITIAL } = vscodeTextmate;
+const oniguruma = onigPkg.default ?? onigPkg;
+
+const require = createRequire(import.meta.url);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+const wasmPath = require.resolve('vscode-oniguruma/release/onig.wasm');
+const wasmBin = readFileSync(wasmPath).buffer;
+await oniguruma.loadWASM(wasmBin);
+
+const grammarPath = join(repoRoot, 'syntaxes', 'phel.tmLanguage.json');
+const grammarRaw = readFileSync(grammarPath, 'utf-8');
+
+const registry = new Registry({
+    onigLib: Promise.resolve({
+        createOnigScanner: (sources) => new oniguruma.OnigScanner(sources),
+        createOnigString: (str) => new oniguruma.OnigString(str),
+    }),
+    loadGrammar: () => Promise.resolve(parseRawGrammar(grammarRaw, grammarPath)),
+});
+
+const grammar = await registry.loadGrammar('source.phel');
+if (!grammar) {
+    console.error('failed to load grammar');
+    process.exit(1);
+}
+
+const samplePath = process.argv[2]
+    ? resolve(process.argv[2])
+    : join(__dirname, 'sample.phel');
+const source = readFileSync(samplePath, 'utf-8');
+
+let ruleStack = INITIAL;
+const lines = source.split(/\r?\n/);
+
+for (const [idx, line] of lines.entries()) {
+    const result = grammar.tokenizeLine(line, ruleStack);
+    ruleStack = result.ruleStack;
+
+    process.stdout.write(`L${String(idx + 1).padStart(3, ' ')} | ${line}\n`);
+    for (const tok of result.tokens) {
+        const text = line.slice(tok.startIndex, tok.endIndex);
+        if (text.trim() === '') continue;
+        const scope = tok.scopes.filter((s) => s !== 'source.phel').join(' ');
+        process.stdout.write(`     | ${JSON.stringify(text).padEnd(28)} ${scope}\n`);
+    }
+}

--- a/syntaxes/phel.tmLanguage.json
+++ b/syntaxes/phel.tmLanguage.json
@@ -114,7 +114,7 @@
 				},
 				{
 					"name": "punctuation.other.phel",
-					"match": "[~`',^]"
+					"match": "[~`',^]|@(?![({\\[])"
 				}
 			]
 		},
@@ -234,7 +234,7 @@
 			"end": "\\|#"
 		},
 		"comment": {
-			"begin": "[#;]",
+			"begin": "(?:;|#(?=\\s|$))",
 			"beginCaptures": {
 				"0": {
 					"name": "punctuation.definition.comment.phel"


### PR DESCRIPTION
## Why
While verifying the 0.4.0 grammar I tokenised \`scripts/sample.phel\` against \`syntaxes/phel.tmLanguage.json\` with \`vscode-textmate\` (the same engine VS Code ships with) and found three real bugs:

| Input | Old result | Expected |
|---|---|---|
| \`#{1/2 -3/4}\` | \`#\` consumed as line comment, rest of line ignored | \`meta.set.phel\` + items |
| \`#(* %1 %1)\` | \`#\` consumed as line comment, body unscoped | \`meta.short-fn.phel\` |
| \`@a\` | absorbed into the symbol pattern | \`punctuation.other.phel\` + symbol |

Root cause: the \`comment\` pattern's \`begin\` was \`[#;]\`, which matched the leading \`#\` of every \`#{...}\`, \`#(...)\`, \`#_\`, \`#|...|#\`, etc. before the more specific patterns could fire.

## Fix
- \`comment.begin\` is now \`(?:;|#(?=\\s|\$))\` — a bare \`#\` only opens a line comment when followed by whitespace or end-of-line. Every other \`#X\` falls through to its real pattern.
- The \`readermac\` pattern now also matches bare \`@\` when not followed by \`(\`, \`[\`, or \`{\` (so mutable collection literals \`@(...)\`, \`@[...]\`, \`@{...}\` keep using the existing collection patterns).

## Verification tooling
This PR adds the verification workflow that caught the bugs:

- \`scripts/tokenize-sample.mjs\` loads the grammar via \`vscode-textmate\` + \`vscode-oniguruma\` and prints every token in \`scripts/sample.phel\` with its scope chain.
- \`npm run tokenize\` runs it.
- \`CONTRIBUTING.md\` documents the flow under "Updating the language surface".

The sample exercises: namespaces, comments (line, block, inline-form, legacy \`#\`), metadata \`^:private\`, sets, anonymous functions (\`#(...)\` and legacy \`|(...)\`), unquote / unquote-splicing (\`~\`, \`~@\`), deref \`@x\`, threading, \`defprotocol\` / \`defrecord\`, tagged literals, and reader conditionals.

## Docs
The \`Debug Trace Mode\` block in the README referenced \`(phel\\debug/enable-trace)\`, which no longer exists upstream. Replaced with an "Inspecting Values with Taps" section using the current \`add-tap\` / \`tap>\` / \`remove-tap\` API from \`phel\\core\`.

## Test plan
- [x] \`node -e "JSON.parse(...)"\` — grammar still valid JSON.
- [x] \`npm run tokenize\` — set / anon-fn / deref / legacy comment / inline-form-comment all carry the expected scopes.
- [x] \`npm run compile\` — clean.
- [x] \`npm test\` — 85 passing.