### PR TITLE
feat(grammar): highlight tagged literals and reader conditionals (0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "phel-lang" extension will be documented in this file.
 
+## [0.5.0] - 2026-05-06
+
+### Added
+
+- **Tagged literals** (`#inst`, `#regex`, `#php`, custom `#money`, …) now highlight: `#` as `punctuation.definition.tag.phel`, the tag name as `storage.type.tagged.phel`, and the following form keeps its normal scopes.
+- **Reader conditionals** `#?(:phel … :clj …)` and the splicing form `#?@(...)` now highlight: `#?` / `#?@` as `keyword.other.reader-conditional.phel`, the body wrapped in `meta.reader-conditional.phel` so editors can dim the inactive branch via theme rules.
+- Sample (`scripts/sample.phel`) covers the new patterns; `npm run tokenize` verifies them.
+
 ## [0.4.0] - 2026-05-06
 
 Sync with phel-lang `main` (commit `428c59f`).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This VS Code extension provides syntax highlighting and language support for [Ph
   - Literals: keywords (`:keyword`), strings, numbers, booleans, `nil`
   - Collections: vectors `[]`, maps `{}`, sets `#{}`, lists `'()`
   - Short anonymous functions: `#(+ %1 %2)` (and the deprecated `|(+ $1 $2)`)
-  - Reader macros: quote `'`, quasiquote `` ` ``, unquote `~`, unquote-splicing `~@`, metadata `^` (legacy `,` / `,@` still highlighted)
+  - Reader macros: quote `'`, quasiquote `` ` ``, unquote `~`, unquote-splicing `~@`, deref `@`, metadata `^` (legacy `,` / `,@` still highlighted)
+  - Tagged literals: `#inst "..."`, `#regex "..."`, `#php/...`, custom tags via `register-tag`
+  - Reader conditionals: `#?(:phel ... :clj ...)` and splicing form `#?@(...)`
 
 - **Code completion** for every public symbol shipped with phel-lang core:
   - All special forms and macros (suggested as keywords)
@@ -78,6 +80,17 @@ The legacy `|(...)` form with `$1`, `$2`, `$&` is still recognised for older cod
 `(1 ~x ~@xs)       ;; Quasiquote with unquote and unquote-splicing
 ^:private          ;; Metadata
 @my-atom           ;; Deref
+```
+
+### Tagged Literals and Reader Conditionals
+
+```phel
+(def t #inst "2026-01-01T00:00:00Z")    ;; Tagged literal
+(def re #regex "\\d+")                  ;; Built-in regex tag
+(def m #money "10.00 EUR")              ;; Custom tag (via register-tag)
+
+(def now #?(:phel (php/time) :clj 0))           ;; Reader conditional
+(def xs [1 2 #?@(:phel [3 4] :clj [99])])       ;; Splicing form
 ```
 
 ## Debugging Phel Code
@@ -195,7 +208,7 @@ code --install-extension phel-lang.phel-lang
 
 Download the latest `.vsix` from the [releases page](https://github.com/phel-lang/phel-vs-code-extension/releases) and install it:
 
-- **CLI:** `code --install-extension phel-lang-0.4.0.vsix`
+- **CLI:** `code --install-extension phel-lang-0.5.0.vsix`
 - **GUI:** Extensions sidebar → "..." menu → *Install from VSIX...*
 
 ### Option 3 — Build from source
@@ -218,7 +231,7 @@ Iterate on grammar / TypeScript without rebuilding the `.vsix` each time:
 **macOS / Linux**
 ```bash
 cd ~/.vscode/extensions
-ln -s /absolute/path/to/phel-vs-code-extension phel-lang.phel-lang-0.4.0
+ln -s /absolute/path/to/phel-vs-code-extension phel-lang.phel-lang-0.5.0
 ```
 
 **Windows** (PowerShell, Administrator)
@@ -226,7 +239,7 @@ ln -s /absolute/path/to/phel-vs-code-extension phel-lang.phel-lang-0.4.0
 cd $env:USERPROFILE\.vscode\extensions
 New-Item -ItemType SymbolicLink `
     -Target "C:\absolute\path\to\phel-vs-code-extension" `
-    -Path "phel-lang.phel-lang-0.4.0"
+    -Path "phel-lang.phel-lang-0.5.0"
 ```
 
 Restart VS Code (or use *Developer: Reload Window*) and changes to `syntaxes/`, `snippets/`, and the compiled `out/` directory take effect.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "phel-lang",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "phel-lang",
-            "version": "0.4.0",
+            "version": "0.5.0",
             "license": "MIT",
             "dependencies": {
                 "@vscode/debugadapter": "^1.64.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "phel-lang",
     "displayName": "Phel Lang",
     "description": "Full-featured Phel language support with debugging for VS Code",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "publisher": "phel-lang",
     "license": "MIT",
     "engines": {

--- a/scripts/sample.phel
+++ b/scripts/sample.phel
@@ -54,9 +54,12 @@
 
 #_(comment-out-this-form 1 2 3)
 
-;; Tagged literals (highlighting is best-effort, future work)
+;; Tagged literals
 (def created #inst "2026-01-01T00:00:00Z")
 (def re #regex "\\d+")
+(def m #money "10.00 EUR")
+(def php-call #php/Foo\Bar)
 
-;; Reader conditional (future work — currently unscoped)
-#?(:phel (php/time) :clj 0)
+;; Reader conditionals
+(def now #?(:phel (php/time) :clj 0))
+(def items [1 2 #?@(:phel [3 4] :clj [99])])

--- a/syntaxes/phel.tmLanguage.json
+++ b/syntaxes/phel.tmLanguage.json
@@ -12,6 +12,9 @@
 			"include": "#strings"
 		},
 		{
+			"include": "#reader-conditional"
+		},
+		{
 			"include": "#short-fn"
 		},
 		{
@@ -25,6 +28,9 @@
 		},
 		{
 			"include": "#sets"
+		},
+		{
+			"include": "#tagged-literal"
 		},
 		{
 			"include": "#readermac"
@@ -233,6 +239,40 @@
 			"begin": "#\\|",
 			"end": "\\|#"
 		},
+		"tagged-literal": {
+			"match": "(#)([a-zA-Z][\\w-]*)",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.tag.phel"
+				},
+				"2": {
+					"name": "storage.type.tagged.phel"
+				}
+			}
+		},
+		"reader-conditional": {
+			"begin": "(#\\?@?)(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.other.reader-conditional.phel"
+				},
+				"2": {
+					"name": "punctuation.definition.parens.begin.phel"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.parens.end.phel"
+				}
+			},
+			"name": "meta.reader-conditional.phel",
+			"patterns": [
+				{
+					"include": "#all"
+				}
+			]
+		},
 		"comment": {
 			"begin": "(?:;|#(?=\\s|$))",
 			"beginCaptures": {
@@ -266,6 +306,9 @@
 					"include": "#strings"
 				},
 				{
+					"include": "#reader-conditional"
+				},
+				{
 					"include": "#short-fn"
 				},
 				{
@@ -279,6 +322,9 @@
 				},
 				{
 					"include": "#sets"
+				},
+				{
+					"include": "#tagged-literal"
 				},
 				{
 					"include": "#readermac"


### PR DESCRIPTION
Closes the "future work" gap from #15.

## Summary
- **Tagged literals** — \`#inst\`, \`#regex\`, \`#php\`, and custom tags (\`#money\` etc.) now highlight as \`punctuation.definition.tag.phel\` + \`storage.type.tagged.phel\`. The form that follows keeps its normal scopes.
- **Reader conditionals** — \`#?(:phel … :clj …)\` and the splicing form \`#?@(...)\` are a proper region: \`#?\` / \`#?@\` scope as \`keyword.other.reader-conditional.phel\` and the body wraps as \`meta.reader-conditional.phel\` so themes can dim the inactive branch.
- Both patterns are wired into the top-level pattern list **and** the shared \`all\` repository entry, so they fire inside collection bodies.
- Pattern order keeps multi-char \`#\`-prefixes (\`#|\`, \`#_\`, \`#(\`, \`#{\`, \`#?\`) winning over the more general tagged-literal match.

## Verification
\`scripts/sample.phel\` exercises:

\`\`\`phel
(def created #inst "2026-01-01T00:00:00Z")
(def re #regex "\\\\d+")
(def m #money "10.00 EUR")
(def php-call #php/Foo\\Bar)

(def now #?(:phel (php/time) :clj 0))
(def items [1 2 #?@(:phel [3 4] :clj [99])])
\`\`\`

\`npm run tokenize\` reports the expected scopes for every line. See \`scripts/sample.phel\` for the regression set.

## Docs
- README features list mentions tagged literals + reader conditionals.
- New "Tagged Literals and Reader Conditionals" section in the README walks through both forms.
- CHANGELOG entry for 0.5.0; \`package.json\` + lock bumped.

## Test plan
- [x] \`node -e "JSON.parse(...)"\` — grammar still valid.
- [x] \`npm run tokenize\` — all six new lines carry the expected scopes.
- [x] \`npm run compile\` — clean.
- [x] \`npm test\` — 85 passing.