### PR TITLE
docs: split detailed docs into docs/, slim README to onboarding

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -18,4 +18,5 @@ node_modules/.bin/**
 node_modules/@types/**
 **/*.test.js
 CONTRIBUTING.md
+docs/**
 scripts/**

--- a/README.md
+++ b/README.md
@@ -1,109 +1,61 @@
-# Phel Lang Support for VS Code
+# Phel Lang for VS Code
 
-This VS Code extension provides syntax highlighting and language support for [Phel](https://phel-lang.org/), a functional programming language that compiles to PHP.
+Syntax highlighting, code completion, snippets, and a native debug adapter for [Phel](https://phel-lang.org/) — a functional Lisp that compiles to PHP.
 
-## Features
+## Install
 
-- **Syntax highlighting** for the full Phel core:
-  - Special forms: `def`, `defn`, `fn`, `let`, `if`, `loop`, `recur`, `var`, `deref`, `new`, `quote`, `try`/`catch`/`finally`, all `php/*` interop forms, etc.
-  - Macros: `when`, `cond`, `cond->`, `cond->>`, `condp`, `case`, `->`, `->>`, `some->`, `some->>`, `as->`, `for`, `doseq`, `dotimes`, `match`, `defprotocol`, `defrecord`, `deftype`, `deftest`, `extend-type`, `extend-protocol`, `with-redefs`, etc.
-  - Literals: keywords (`:keyword`), strings, numbers, booleans, `nil`
-  - Collections: vectors `[]`, maps `{}`, sets `#{}`, lists `'()`
-  - Short anonymous functions: `#(+ %1 %2)` (and the deprecated `|(+ $1 $2)`)
-  - Reader macros: quote `'`, quasiquote `` ` ``, unquote `~`, unquote-splicing `~@`, deref `@`, metadata `^` (legacy `,` / `,@` still highlighted)
-  - Tagged literals: `#inst "..."`, `#regex "..."`, `#php/...`, custom tags via `register-tag`
-  - Reader conditionals: `#?(:phel ... :clj ...)` and splicing form `#?@(...)`
+- **Marketplace** — Extensions sidebar → search **"Phel Lang"** → Install. Or `code --install-extension phel-lang.phel-lang`.
+- **Pre-built `.vsix`** — grab the latest from the [releases page](https://github.com/phel-lang/phel-vs-code-extension/releases) and run `code --install-extension phel-lang-*.vsix` (or *Install from VSIX...* in the Extensions menu).
+- **From source** — `git clone`, `npm install`, `npx @vscode/vsce package`, then install the resulting `.vsix`. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full dev loop.
 
-- **Code completion** for every public symbol shipped with phel-lang core:
-  - All special forms and macros (suggested as keywords)
-  - 394 public functions from `phel\core` (`assoc`, `map`, `reduce`, `swap!`, `re-find`, `parse-uuid`, …) suggested as functions
+Requires VS Code **1.75+**.
 
-- **Code snippets** for common scaffolding — type `defn`, `let`, `cond`, `try`, `deftest`, `->`, … and tab through the placeholders.
+## What you get
 
-- **Comment support**:
-  - Line comments: `;` or `;;` (legacy `#` still highlighted)
-  - Inline comments: `#_` (comments out next form)
-  - Block comments: `#| ... |#` (deprecated upstream — kept for legacy code)
+- **Syntax highlighting** for the full Phel core — special forms, ~70 macros, threading, interop (`php/...`), reader macros (`'`, `` ` ``, `~`, `~@`, `^`, `@`), tagged literals (`#inst`, `#regex`, `#php`, custom `#tag`), and reader conditionals (`#?(...)`, `#?@(...)`).
+- **Code completion** for every public symbol in `phel\core` — 47 special forms, ~70 macros, 394 functions (`assoc`, `map`, `reduce`, `swap!`, `re-find`, `parse-uuid`, …).
+- **Snippets** for the everyday forms — type `defn`, `let`, `cond`, `try`, `deftest`, `->` and tab through.
+- **Debug adapter** with source-level breakpoints, Phel-friendly variable display, multi-expression line handling, exception breakpoints, and Docker / remote path mapping.
+- Auto-closing pairs, smart Lisp indentation, and breakpoint gutters in `.phel` files.
 
-- **Breakpoint support**: Set breakpoints on Phel files for debugging
+Legacy syntax is still highlighted: `|(+ $1 $2)`, `,@xs`, `#` line comments, and `#| ... |#` block comments.
 
-- **Auto-closing pairs** for brackets, quotes, and comments
-
-- **Smart indentation** for Lisp-style code
-
-## Supported Syntax
-
-### Keywords and Special Forms
+## Syntax at a glance
 
 ```phel
-(ns my-app\core)
+(ns my-app\core
+  (:require phel\core :refer [filter map])
+  (:require phel\test :refer [deftest is]))
 
-(defn greet [name]
+(def ^:private answer 42)              ;; metadata + def
+
+(defn greet [name]                     ;; public fn
   (str "Hello, " name "!"))
 
-(def users [{:name "Alice"} {:name "Bob"}])
+(defn- helper [x]                      ;; private fn
+  (when (pos? x) (* x x)))
 
-(->> users
-     (filter #(> (count (:name %)) 3))
-     (map :name))
+(->> [1 2 3 4 5]                       ;; threading + anon-fn
+     (filter #(> % 2))
+     (map #(* %1 %1)))
+
+`(let [x# ~val] ~@body)                ;; quasiquote, unquote, splicing
+
+(def t  #inst "2026-01-01T00:00:00Z")  ;; tagged literals
+(def re #regex "\\d+")
+(def now #?(:phel (php/time) :clj 0))  ;; reader conditional
+
+;; preferred line comment
+(println 1 #_ skip 3)                  ;; skip middle form
 ```
 
-### Short Anonymous Functions
+## Debugging Phel code
 
-```phel
-#(+ %1 %2)        ;; Two args: %1, %2
-#(* % %)          ;; Single arg: % is shorthand for %1
-#(apply str %&)   ;; %& captures rest args
-```
+The bundled debug adapter (`type: "phel"`) translates between `.phel` source and the compiled PHP, so breakpoints, stack traces, and stepping all stay in your Phel files.
 
-The legacy `|(...)` form with `$1`, `$2`, `$&` is still recognised for older code:
+### Setup
 
-```phel
-|(+ $1 $2)        ;; Deprecated — prefer #(+ %1 %2)
-```
-
-### Comments
-
-```phel
-;; Standalone comment (preferred)
-;  Single-semi line comment
-
-(println 1 #_ 2 3)  ;; Prints: 1 3 (2 is commented out)
-
-#| Multiline comment — deprecated upstream, still highlighted. |#
-```
-
-### Reader Macros
-
-```phel
-'symbol            ;; Quote
-`(1 ~x ~@xs)       ;; Quasiquote with unquote and unquote-splicing
-^:private          ;; Metadata
-@my-atom           ;; Deref
-```
-
-### Tagged Literals and Reader Conditionals
-
-```phel
-(def t #inst "2026-01-01T00:00:00Z")    ;; Tagged literal
-(def re #regex "\\d+")                  ;; Built-in regex tag
-(def m #money "10.00 EUR")              ;; Custom tag (via register-tag)
-
-(def now #?(:phel (php/time) :clj 0))           ;; Reader conditional
-(def xs [1 2 #?@(:phel [3 4] :clj [99])])       ;; Splicing form
-```
-
-## Debugging Phel Code
-
-This extension includes a **native Phel debug adapter** that provides source-level debugging for Phel code. It automatically translates between your `.phel` source files and the compiled PHP code.
-
-### Prerequisites
-
-1. Install and configure **Xdebug** in your PHP installation
-
-### Setting Up Debugging
-
-1. **Enable Xdebug** in your `php.ini`:
+1. Enable Xdebug in `php.ini`:
    ```ini
    [xdebug]
    zend_extension=xdebug
@@ -111,8 +63,7 @@ This extension includes a **native Phel debug adapter** that provides source-lev
    xdebug.start_with_request=yes
    xdebug.client_port=9003
    ```
-
-2. **Create a launch configuration** (`.vscode/launch.json`):
+2. Add a launch config (`.vscode/launch.json`):
    ```json
    {
      "version": "0.2.0",
@@ -120,180 +71,64 @@ This extension includes a **native Phel debug adapter** that provides source-lev
        {
          "type": "phel",
          "request": "launch",
-         "name": "Debug Phel (Listen for Xdebug)",
+         "name": "Debug Phel",
          "phpDebugPort": 9003
        }
      ]
    }
    ```
+3. Set breakpoints in `.phel` files, press <kbd>F5</kbd>, run your app (e.g. `vendor/bin/phel run src/main.phel`).
 
-3. **Set breakpoints** in your `.phel` files (click in the gutter)
+### Configuration options
 
-4. **Start debugging**:
-   - Press F5 or select "Run > Start Debugging"
-   - Run your Phel application (e.g., `vendor/bin/phel run src/main.phel`)
-   - Breakpoints will hit and show your Phel source code
+| Option | Default | Description |
+|---|---|---|
+| `phpDebugPort` | `9003` | Xdebug listen port |
+| `cacheDir` | auto-detected | Phel cache directory |
+| `pathMappings` | `{}` | Container / remote path mappings |
+| `skipPhelInternals` | `true` | Skip stepping through Phel runtime |
+| `skipFiles` | `[]` | Glob patterns to skip when stepping |
 
-### Debug Configuration Options
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `phpDebugPort` | Xdebug port to listen on | `9003` |
-| `cacheDir` | Path to Phel cache directory | Auto-detected |
-| `pathMappings` | Path mappings for Docker/remote debugging | `{}` |
-| `skipPhelInternals` | Skip stepping through Phel runtime code | `true` |
-| `skipFiles` | Glob patterns for files to skip | `[]` |
-
-### Docker/Remote Debugging
-
-For containerized environments, add path mappings:
+For Docker / remote work, add `pathMappings`:
 
 ```json
-{
-  "type": "phel",
-  "request": "launch",
-  "name": "Debug Phel (Docker)",
-  "phpDebugPort": 9003,
-  "pathMappings": {
-    "/var/www/html": "${workspaceFolder}"
-  }
-}
+"pathMappings": { "/var/www/html": "${workspaceFolder}" }
 ```
 
 ### Commands
 
-- **Phel: Show Compiled PHP Location** - Shows where the current Phel line maps to in compiled PHP
-- **Phel: Clear Source Map Cache** - Clears cached source maps (useful after recompiling)
+- **Phel: Show Compiled PHP Location** — jump from a `.phel` line to the compiled PHP.
+- **Phel: Clear Source Map Cache** — drop cached source maps after a recompile.
 
-### Features
+## Inspecting values with taps
 
-- **Source-level debugging**: Breakpoints and stack traces show Phel source locations
-- **Phel-friendly variables**: Collections display as `[3 items]`, keywords as `:name`, etc.
-- **Multi-expression lines**: Correctly handles multiple expressions on one Phel line
-- **Exception breakpoints**: Break on all or uncaught PHP exceptions
-
-### Inspecting Values with Taps
-
-For ad-hoc tracing without a debugger, Phel ships a Clojure-style tap registry in `phel\core`. Register a handler with `add-tap`, send values with `tap>`:
+For ad-hoc tracing without a debugger, use the Clojure-style tap registry from `phel\core`:
 
 ```phel
-(ns my-app\core)
-
-;; Print every tapped value (or push to a logger, atom, etc.).
 (add-tap println)
 
 (defn process [order]
-  (tap> {:event :process-start :id (:id order)})
+  (tap> {:event :start :id (:id order)})
   (let [result (do-work order)]
-    (tap> {:event :process-end :id (:id order) :result result})
+    (tap> {:event :end :id (:id order) :result result})
     result))
 
-;; Cleanup when done
 (remove-tap println)
 ```
 
-Taps run synchronously on the calling thread; exceptions thrown by a tap handler are swallowed so a buggy tap can't take down the producer.
+Taps run synchronously on the calling thread. Exceptions thrown by a tap handler are swallowed so a buggy tap can't take down the producer.
 
-## Installation
+## Settings
 
-### Option 1 — VS Code Marketplace
-
-Open the Extensions sidebar (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd> / <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>), search for **"Phel Lang"**, and click **Install**. Or from the terminal:
-
-```bash
-code --install-extension phel-lang.phel-lang
-```
-
-### Option 2 — Pre-built `.vsix`
-
-Download the latest `.vsix` from the [releases page](https://github.com/phel-lang/phel-vs-code-extension/releases) and install it:
-
-- **CLI:** `code --install-extension phel-lang-0.5.0.vsix`
-- **GUI:** Extensions sidebar → "..." menu → *Install from VSIX...*
-
-### Option 3 — Build from source
-
-For the very latest changes on `main` (or to develop the extension), build the `.vsix` yourself:
-
-```bash
-git clone https://github.com/phel-lang/phel-vs-code-extension.git
-cd phel-vs-code-extension
-npm install
-npm run compile
-npx @vscode/vsce package      # produces phel-lang-<version>.vsix
-code --install-extension phel-lang-*.vsix
-```
-
-### Option 4 — Symlink for live development
-
-Iterate on grammar / TypeScript without rebuilding the `.vsix` each time:
-
-**macOS / Linux**
-```bash
-cd ~/.vscode/extensions
-ln -s /absolute/path/to/phel-vs-code-extension phel-lang.phel-lang-0.5.0
-```
-
-**Windows** (PowerShell, Administrator)
-```powershell
-cd $env:USERPROFILE\.vscode\extensions
-New-Item -ItemType SymbolicLink `
-    -Target "C:\absolute\path\to\phel-vs-code-extension" `
-    -Path "phel-lang.phel-lang-0.5.0"
-```
-
-Restart VS Code (or use *Developer: Reload Window*) and changes to `syntaxes/`, `snippets/`, and the compiled `out/` directory take effect.
-
-> Press <kbd>F5</kbd> inside the cloned repo to launch an Extension Development Host with the extension loaded and source-mapped — the recommended setup when developing.
-
-## Requirements
-
-- VS Code 1.75.0 or higher
-
-## Extension Settings
-
-| Setting | Description | Default |
-|---------|-------------|---------|
-| `phel.cacheDirectory` | Path to Phel cache directory. If empty, uses system temp directory. | `""` |
-| `phel.debug.enabled` | Enable Phel debug adapter for source-level debugging | `true` |
-
-## Known Issues
-
-None at this time.
-
-## Development
-
-### Setup
-
-```bash
-git clone https://github.com/phel-lang/phel-vs-code-extension.git
-cd phel-vs-code-extension
-npm install
-```
-
-### Scripts
-
-| Command | Description |
-|---------|-------------|
-| `npm run compile` | Compile TypeScript to JavaScript |
-| `npm run watch` | Watch for changes and recompile |
-| `npm run lint` | Run ESLint |
-| `npm run lint:fix` | Run ESLint with auto-fix |
-| `npm run format` | Format code with Prettier |
-| `npm test` | Run tests |
-
-### Testing
-
-Press F5 in VS Code to launch an Extension Development Host with the extension loaded.
+| Setting | Default | Description |
+|---|---|---|
+| `phel.cacheDirectory` | `""` | Path to Phel cache directory. Empty → system temp dir. |
+| `phel.debug.enabled` | `true` | Enable the Phel debug adapter. |
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, conventions, and how to refresh the language surface (grammar, completion, snippets) when phel-lang core changes. Issues and pull requests are welcome at [GitHub](https://github.com/phel-lang/phel-vs-code-extension).
+Bug reports, pull requests, and language-surface refreshes welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## Release Notes
+## Changelog · License
 
-See [CHANGELOG.md](CHANGELOG.md) for release notes.
-
-## License
-
-MIT License - see [LICENSE](LICENSE) for details.
+History in [CHANGELOG.md](CHANGELOG.md). MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,134 +1,48 @@
 # Phel Lang for VS Code
 
-Syntax highlighting, code completion, snippets, and a native debug adapter for [Phel](https://phel-lang.org/) — a functional Lisp that compiles to PHP.
+[![Release](https://img.shields.io/github/v/release/phel-lang/phel-vs-code-extension?label=release)](https://github.com/phel-lang/phel-vs-code-extension/releases)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+VS Code support for [Phel](https://phel-lang.org/) — a functional Lisp that compiles to PHP.
+
+## Why this extension
+
+Writing Phel without editor support means colourless code, no completion for the 400+ symbols in `phel\core`, and dropping back to PHP-level debugging. This extension fixes all three.
+
+- **Highlighting** — full coverage of forms, macros, reader macros, tagged literals (`#inst`, `#regex`, `#php`, …) and reader conditionals (`#?(...)`).
+- **Completion** for every public symbol in `phel\core` (47 special forms, ~70 macros, 394 functions).
+- **Snippets** for everyday scaffolding — `defn`, `let`, `cond`, `try`, `deftest`, `->`, …
+- **Native debug adapter** — set breakpoints in `.phel` files; the adapter translates between Phel and the compiled PHP via Xdebug.
 
 ## Install
 
-- **Marketplace** — Extensions sidebar → search **"Phel Lang"** → Install. Or `code --install-extension phel-lang.phel-lang`.
-- **Pre-built `.vsix`** — grab the latest from the [releases page](https://github.com/phel-lang/phel-vs-code-extension/releases) and run `code --install-extension phel-lang-*.vsix` (or *Install from VSIX...* in the Extensions menu).
-- **From source** — `git clone`, `npm install`, `npx @vscode/vsce package`, then install the resulting `.vsix`. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full dev loop.
-
-Requires VS Code **1.75+**.
-
-## What you get
-
-- **Syntax highlighting** for the full Phel core — special forms, ~70 macros, threading, interop (`php/...`), reader macros (`'`, `` ` ``, `~`, `~@`, `^`, `@`), tagged literals (`#inst`, `#regex`, `#php`, custom `#tag`), and reader conditionals (`#?(...)`, `#?@(...)`).
-- **Code completion** for every public symbol in `phel\core` — 47 special forms, ~70 macros, 394 functions (`assoc`, `map`, `reduce`, `swap!`, `re-find`, `parse-uuid`, …).
-- **Snippets** for the everyday forms — type `defn`, `let`, `cond`, `try`, `deftest`, `->` and tab through.
-- **Debug adapter** with source-level breakpoints, Phel-friendly variable display, multi-expression line handling, exception breakpoints, and Docker / remote path mapping.
-- Auto-closing pairs, smart Lisp indentation, and breakpoint gutters in `.phel` files.
-
-Legacy syntax is still highlighted: `|(+ $1 $2)`, `,@xs`, `#` line comments, and `#| ... |#` block comments.
-
-## Syntax at a glance
-
-```phel
-(ns my-app\core
-  (:require phel\core :refer [filter map])
-  (:require phel\test :refer [deftest is]))
-
-(def ^:private answer 42)              ;; metadata + def
-
-(defn greet [name]                     ;; public fn
-  (str "Hello, " name "!"))
-
-(defn- helper [x]                      ;; private fn
-  (when (pos? x) (* x x)))
-
-(->> [1 2 3 4 5]                       ;; threading + anon-fn
-     (filter #(> % 2))
-     (map #(* %1 %1)))
-
-`(let [x# ~val] ~@body)                ;; quasiquote, unquote, splicing
-
-(def t  #inst "2026-01-01T00:00:00Z")  ;; tagged literals
-(def re #regex "\\d+")
-(def now #?(:phel (php/time) :clj 0))  ;; reader conditional
-
-;; preferred line comment
-(println 1 #_ skip 3)                  ;; skip middle form
+```bash
+code --install-extension phel-lang.phel-lang
 ```
 
-## Debugging Phel code
+Or grab a `.vsix` from the [releases page](https://github.com/phel-lang/phel-vs-code-extension/releases) and run `code --install-extension phel-lang-*.vsix`. Requires VS Code **1.75+**.
 
-The bundled debug adapter (`type: "phel"`) translates between `.phel` source and the compiled PHP, so breakpoints, stack traces, and stepping all stay in your Phel files.
+Other paths (build from source, symlink for live development): see [docs/installation.md](docs/installation.md).
 
-### Setup
+## First steps
 
-1. Enable Xdebug in `php.ini`:
-   ```ini
-   [xdebug]
-   zend_extension=xdebug
-   xdebug.mode=debug
-   xdebug.start_with_request=yes
-   xdebug.client_port=9003
-   ```
-2. Add a launch config (`.vscode/launch.json`):
-   ```json
-   {
-     "version": "0.2.0",
-     "configurations": [
-       {
-         "type": "phel",
-         "request": "launch",
-         "name": "Debug Phel",
-         "phpDebugPort": 9003
-       }
-     ]
-   }
-   ```
-3. Set breakpoints in `.phel` files, press <kbd>F5</kbd>, run your app (e.g. `vendor/bin/phel run src/main.phel`).
+1. **Open any `.phel` file** — highlighting kicks in automatically.
+2. **Try completion** — start typing `re-` or `swap` and accept a suggestion.
+3. **Expand a snippet** — type `defn` <kbd>Tab</kbd> and tab through the placeholders.
+4. **Set a breakpoint** in `.phel`, add a launch config (see [docs/debugging.md](docs/debugging.md)), press <kbd>F5</kbd>.
 
-### Configuration options
+## Documentation
 
-| Option | Default | Description |
-|---|---|---|
-| `phpDebugPort` | `9003` | Xdebug listen port |
-| `cacheDir` | auto-detected | Phel cache directory |
-| `pathMappings` | `{}` | Container / remote path mappings |
-| `skipPhelInternals` | `true` | Skip stepping through Phel runtime |
-| `skipFiles` | `[]` | Glob patterns to skip when stepping |
+| Topic | Link |
+|---|---|
+| Installation paths | [docs/installation.md](docs/installation.md) |
+| Syntax highlighting reference | [docs/syntax.md](docs/syntax.md) |
+| Completion & snippets | [docs/completion.md](docs/completion.md) |
+| Debugging with Xdebug | [docs/debugging.md](docs/debugging.md) |
+| Tracing with `tap>` | [docs/taps.md](docs/taps.md) |
+| Settings reference | [docs/settings.md](docs/settings.md) |
+| Troubleshooting | [docs/troubleshooting.md](docs/troubleshooting.md) |
 
-For Docker / remote work, add `pathMappings`:
+## Contributing · Changelog · License
 
-```json
-"pathMappings": { "/var/www/html": "${workspaceFolder}" }
-```
-
-### Commands
-
-- **Phel: Show Compiled PHP Location** — jump from a `.phel` line to the compiled PHP.
-- **Phel: Clear Source Map Cache** — drop cached source maps after a recompile.
-
-## Inspecting values with taps
-
-For ad-hoc tracing without a debugger, use the Clojure-style tap registry from `phel\core`:
-
-```phel
-(add-tap println)
-
-(defn process [order]
-  (tap> {:event :start :id (:id order)})
-  (let [result (do-work order)]
-    (tap> {:event :end :id (:id order) :result result})
-    result))
-
-(remove-tap println)
-```
-
-Taps run synchronously on the calling thread. Exceptions thrown by a tap handler are swallowed so a buggy tap can't take down the producer.
-
-## Settings
-
-| Setting | Default | Description |
-|---|---|---|
-| `phel.cacheDirectory` | `""` | Path to Phel cache directory. Empty → system temp dir. |
-| `phel.debug.enabled` | `true` | Enable the Phel debug adapter. |
-
-## Contributing
-
-Bug reports, pull requests, and language-surface refreshes welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).
-
-## Changelog · License
-
-History in [CHANGELOG.md](CHANGELOG.md). MIT — see [LICENSE](LICENSE).
+[CONTRIBUTING.md](CONTRIBUTING.md) · [CHANGELOG.md](CHANGELOG.md) · [LICENSE](LICENSE) (MIT)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,18 @@
+# Phel Lang for VS Code — Documentation
+
+User-facing docs that go beyond the project [README](../README.md).
+
+| Topic | What's inside |
+|---|---|
+| [Installation](installation.md) | Marketplace, pre-built `.vsix`, build from source, symlink-for-dev |
+| [Syntax highlighting](syntax.md) | Special forms, macros, reader macros, tagged literals, reader conditionals |
+| [Code completion & snippets](completion.md) | What's offered, where the data comes from, how to extend |
+| [Debugging](debugging.md) | Native debug adapter, Xdebug setup, configuration options, Docker / remote |
+| [Tracing with taps](taps.md) | `add-tap` / `tap>` / `remove-tap` for ad-hoc inspection |
+| [Settings reference](settings.md) | Every `phel.*` setting and what it does |
+| [Troubleshooting](troubleshooting.md) | Common problems and fixes |
+
+For repo-level docs see:
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — dev setup, conventions, how to refresh the language surface
+- [CHANGELOG.md](../CHANGELOG.md) — release history

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -1,0 +1,48 @@
+# Code completion & snippets
+
+## Completion
+
+The extension ships a static `CompletionItemProvider` for the `phel` language. It suggests every public symbol from `phel\core`:
+
+- **47 special forms** — `def`, `fn`, `let`, `loop`, `recur`, `try` / `catch` / `finally`, `ns`, `quote`, `var`, `deref`, all `php/*` interop forms, etc. (kind: `Keyword`)
+- **~70 macros** — `defn`, `defmacro`, `defprotocol`, `defrecord`, `cond`, `when-some`, `with-redefs`, `match`, threading variants, etc. (kind: `Keyword`)
+- **394 functions** — `assoc`, `map`, `reduce`, `swap!`, `re-find`, `parse-uuid`, the full numeric tower (`+`, `-`, `*`, `**`, `/`, `%`, `<`, `<=`, `=`, `==`, `>`, `>=`, …), and the rest of `phel\core`. (kind: `Function`)
+
+The provider respects the word range so `defn|` completes correctly without duplicating the prefix.
+
+### Why not a language server?
+
+A real LSP (hover docs, go-to-def, namespace-aware suggestions) is the long-term answer and is on the roadmap. The static list covers ~80% of the daily friction with zero runtime cost — works offline, no extra processes, no warmup latency.
+
+### Why isn't symbol X suggested?
+
+The list is scoped to **`phel\core`** only — symbols from `phel\test`, `phel\match`, `phel\repl`, `phel\html`, `phel\mock`, etc. are not in the function list because they are typically used qualified (`test/is`, `match/match`) after a `(:require ... :as ...)`. Macros from those namespaces *are* in the macro list because they are commonly `:refer`'d unqualified.
+
+Tagged literals (`#inst`, `#regex`) and PHP class names are not in completion — they are handled by syntax highlighting instead.
+
+### Refreshing after a phel-lang bump
+
+```bash
+scripts/regen-core-symbols.sh /path/to/phel-lang > /tmp/phel-symbols.txt
+```
+
+Review the printed arrays and paste them into `src/phelCoreSymbols.ts`. The script does not write the file in place on purpose — manual review keeps private helpers out of the public completion surface. See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full procedure.
+
+## Snippets
+
+`snippets/phel.code-snippets` ships templates for the everyday forms. Type the prefix, accept the suggestion, and tab through the placeholders.
+
+| Prefix | Expands to |
+|---|---|
+| `ns` | `(ns my-app\core (:require ...))` |
+| `defn`, `defn-` | Public / private function with docstring + args |
+| `def`, `fn`, `let` | Top-level binding, anonymous fn, local bindings |
+| `if`, `when`, `cond`, `case` | Conditionals |
+| `doseq`, `for`, `loop` | Iteration (with `recur` skeleton) |
+| `try` | `try` + `catch \Throwable e` |
+| `defmacro`, `defstruct`, `definterface`, `defprotocol`, `defexception` | Definitions |
+| `deftest` | Test case with `(is ...)` |
+| `->`, `->>` | Threading skeletons |
+| `comment` | Form-aware comment block |
+
+Add or refine entries when a form is fiddly enough that scaffolding helps. Keep the `prefix` matching the form name so it composes with completion.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,94 @@
+# Debugging Phel code
+
+The extension bundles a native debug adapter (`type: "phel"`) that translates between `.phel` source and the compiled PHP. Breakpoints, stack traces, and stepping all stay in your Phel files.
+
+## Prerequisites
+
+Install and configure **Xdebug** in your PHP installation. The adapter speaks Xdebug's DBGP protocol over TCP — no PHP Debug extension required.
+
+## Setup
+
+1. **Enable Xdebug** in `php.ini`:
+   ```ini
+   [xdebug]
+   zend_extension=xdebug
+   xdebug.mode=debug
+   xdebug.start_with_request=yes
+   xdebug.client_port=9003
+   ```
+
+2. **Add a launch configuration** (`.vscode/launch.json`):
+   ```json
+   {
+     "version": "0.2.0",
+     "configurations": [
+       {
+         "type": "phel",
+         "request": "launch",
+         "name": "Debug Phel (Listen for Xdebug)",
+         "phpDebugPort": 9003
+       }
+     ]
+   }
+   ```
+
+3. **Set breakpoints** in `.phel` files (click in the gutter).
+
+4. **Start debugging**:
+   - Press <kbd>F5</kbd> or **Run → Start Debugging**.
+   - Run your Phel application — e.g. `vendor/bin/phel run src/main.phel`.
+   - Breakpoints hit and show your Phel source code.
+
+## Configuration options
+
+| Option | Default | Description |
+|---|---|---|
+| `phpDebugPort` | `9003` | Xdebug listen port |
+| `cacheDir` | auto-detected from `phel-config.php` | Phel cache directory (where compiled PHP lands) |
+| `pathMappings` | `{}` | Container / remote path mappings |
+| `skipPhelInternals` | `true` | Skip stepping through Phel runtime code |
+| `skipFiles` | `[]` | Glob patterns for files to skip |
+
+`cacheDir` is auto-detected from the `setTempDir(...)` call in `phel-config.php`. If you use `sys_get_temp_dir()`, the adapter resolves it to `${os.tmpdir()}/phel`.
+
+## Docker / remote debugging
+
+Mount your project inside the container and add `pathMappings` so the adapter can map container paths back to your workstation:
+
+```json
+{
+  "type": "phel",
+  "request": "launch",
+  "name": "Debug Phel (Docker)",
+  "phpDebugPort": 9003,
+  "pathMappings": {
+    "/var/www/html": "${workspaceFolder}"
+  }
+}
+```
+
+In the container, set `xdebug.client_host=host.docker.internal` (macOS / Windows) or the host's bridge IP (Linux).
+
+## What you get
+
+- **Source-level breakpoints** — set them in `.phel`, hit them with the original Phel line + column.
+- **Phel-friendly variables** — vectors render as `[3 items]`, hash maps as `{:k v}`, keywords as `:name`. Internal Phel runtime structures stay collapsed unless you opt in.
+- **Multi-expression line handling** — when a single Phel line compiles to several PHP statements, the adapter consolidates breakpoints so the line behaves as one unit.
+- **Exception breakpoints** — break on all PHP exceptions or just uncaught ones (configure in the Run & Debug sidebar).
+- **Step filter** — `skipPhelInternals: true` (default) keeps stepping inside *your* code, not Phel's runtime.
+
+## Commands
+
+- **Phel: Show Compiled PHP Location** — jump from the current `.phel` line to its compiled PHP equivalent.
+- **Phel: Clear Source Map Cache** — drop cached source maps after a Phel rebuild.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Breakpoints show as hollow circles | Phel hasn't been compiled yet, or the cache directory is wrong |
+| Adapter reports "no source map for `X.php`" | The `.phel` file was not compiled with source maps enabled |
+| Steps land in unexpected files | `skipPhelInternals` is false, or `skipFiles` is empty — add globs |
+| Container debugging hangs | Missing `pathMappings`, or `xdebug.client_host` not set inside the container |
+
+For ad-hoc tracing without setting up a full debug session, see [Tracing with taps](taps.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,64 @@
+# Installation
+
+Requires **VS Code 1.75+**.
+
+## Option 1 — VS Code Marketplace
+
+Open the Extensions sidebar (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd> / <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>), search for **"Phel Lang"**, click **Install**. Or from the terminal:
+
+```bash
+code --install-extension phel-lang.phel-lang
+```
+
+## Option 2 — Pre-built `.vsix`
+
+Each tagged release publishes a `.vsix` you can install directly. Useful for offline machines or when you want a specific version.
+
+1. Download the latest `phel-lang-<version>.vsix` from the [releases page](https://github.com/phel-lang/phel-vs-code-extension/releases).
+2. Install it:
+   - **CLI:** `code --install-extension phel-lang-<version>.vsix`
+   - **GUI:** Extensions sidebar → **`...`** menu → *Install from VSIX...*
+
+## Option 3 — Build from source
+
+Use this when you want changes from `main` that haven't been released yet.
+
+```bash
+git clone https://github.com/phel-lang/phel-vs-code-extension.git
+cd phel-vs-code-extension
+npm install
+npm run compile
+npx @vscode/vsce package        # produces phel-lang-<version>.vsix
+code --install-extension phel-lang-*.vsix
+```
+
+## Option 4 — Symlink for live development
+
+Iterate on grammar / TypeScript without rebuilding the `.vsix` each time. Pair this with <kbd>F5</kbd> from inside the cloned repo (launches an Extension Development Host with source maps).
+
+**macOS / Linux**
+```bash
+cd ~/.vscode/extensions
+ln -s /absolute/path/to/phel-vs-code-extension phel-lang.phel-lang-0.5.0
+```
+
+**Windows** (PowerShell, Administrator)
+```powershell
+cd $env:USERPROFILE\.vscode\extensions
+New-Item -ItemType SymbolicLink `
+    -Target "C:\absolute\path\to\phel-vs-code-extension" `
+    -Path "phel-lang.phel-lang-0.5.0"
+```
+
+Restart VS Code (or run **Developer: Reload Window**) and changes to `syntaxes/`, `snippets/`, and the compiled `out/` directory pick up immediately.
+
+## Verifying the install
+
+Open any `.phel` file. You should see:
+
+- Forms like `defn`, `let`, `cond`, `try` rendered as keywords.
+- Inline form-comment `#_` highlighted as a comment.
+- Completion suggestions when you type `re-` or `swap`.
+- Hovering over a breakpoint gutter on a `.phel` line shows the compiled-PHP location (after a Phel build).
+
+If any of those are missing, see [Troubleshooting](troubleshooting.md).

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,0 +1,40 @@
+# Settings reference
+
+All settings live under `phel.*` in VS Code's settings (workspace or user level). Set them via the Settings UI, by editing `settings.json`, or per-folder in `.vscode/settings.json`.
+
+| Setting | Type | Default | Description |
+|---|---|---|---|
+| `phel.cacheDirectory` | string | `""` | Path to the Phel cache directory (where compiled PHP files land). Empty value → the system temp directory (`${os.tmpdir()}/phel`). |
+| `phel.debug.enabled` | boolean | `true` | Enable the bundled Phel debug adapter for source-level debugging. Disable if you want to fall back to a vanilla PHP debug session. |
+
+## Examples
+
+**Project-local cache** (`.vscode/settings.json`):
+
+```jsonc
+{
+  "phel.cacheDirectory": "${workspaceFolder}/var/cache/phel"
+}
+```
+
+**Disable the debug adapter** for a project that doesn't need it:
+
+```jsonc
+{
+  "phel.debug.enabled": false
+}
+```
+
+## Theming `meta.reader-conditional.phel`
+
+Reader conditionals carry a `meta.reader-conditional.phel` scope so themes can dim the inactive branch:
+
+```jsonc
+"editor.tokenColorCustomizations": {
+    "textMateRules": [
+        { "scope": "meta.reader-conditional.phel", "settings": { "foreground": "#888" } }
+    ]
+}
+```
+
+The full scope vocabulary used by the grammar lives in [docs/syntax.md](syntax.md).

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -1,0 +1,97 @@
+# Syntax highlighting
+
+Coverage tracks [phel-lang](https://github.com/phel-lang/phel-lang) `main` (last refreshed at `428c59f`). Legacy forms are still recognised so older codebases keep highlighting.
+
+## Special forms
+
+`def`, `def-`, `defn`, `defn-`, `defmacro`, `defmacro-`, `definterface*`, `defexception*`, `defstruct*`, `reify*`, `fn`, `let`, `loop`, `recur`, `if`, `do`, `quote`, `var`, `deref`, `new`, `apply`, `concat`, `conj`, `list`, `vector`, `hash-map`, `ns`, `in-ns`, `use`, `load`, `set-var`, `try`/`catch`/`finally`, `throw`, `foreach`, `unquote`, `unquote-splicing`, plus the `php/` interop family (`php/->`, `php/::`, `php/aget`, `php/aset`, `php/apush`, `php/aunset`, `php/new`, `php/oset`, and `*-in` variants).
+
+## Macros (~70)
+
+Threading: `->`, `->>`, `some->`, `some->>`, `as->`, `cond->`, `cond->>`.
+Conditionals: `if-let`, `if-not`, `if-some`, `when`, `when-let`, `when-not`, `when-some`, `when-first`, `cond`, `condp`, `case`.
+Iteration: `for`, `doseq`, `dofor`, `dotimes`, `doto`.
+Bindings: `binding`, `letfn`, `with-bindings`, `with-redefs`, `with-output-buffer`.
+Definitions: `defprotocol`, `defrecord`, `defmethod`, `defmulti`, `defspec`, `defstruct`, `definterface`, `defexception`, `deftype`, `declare`.
+Testing: `deftest`, `is`, `are`, `testing`, `assert`, `with-mocks`, `with-mock-wrapper`.
+REPL helpers: `dir`, `doc`, `source`, `require`, `symbol-info`, `explain-sym`.
+Other: `comment`, `time`, `lazy-seq`, `lazy-cat`, `match`, `instance?`, `pop`, `reify`, `delay`, `future`, `future-fiber`, `extend-protocol`, `extend-type`, `html`, `with-config`, `async`.
+
+## Literals
+
+- Keywords: `:keyword`, `::auto-resolved`
+- Numbers: `42`, `3.14`, `2e-3`, `0xff`, `0b1010`, `1_000`
+- Booleans / nil: `true`, `false`, `nil`
+- Strings: `"hello"` with `\\` escapes
+- Collections: `[1 2]`, `{:a 1}`, `#{1 2}`, `'(a b)`
+
+## Anonymous functions
+
+```phel
+#(+ %1 %2)        ;; preferred — Clojure-style
+#(* % %)          ;; % is shorthand for %1
+#(apply str %&)   ;; %& captures rest
+
+|(+ $1 $2)        ;; legacy — deprecated upstream, still highlighted
+```
+
+## Comments
+
+```phel
+;; preferred line comment
+; also a line comment
+# legacy line comment — deprecated, still highlighted
+
+#| legacy block comment |#
+;; (deprecated, still highlighted)
+
+(println 1 #_ skipped 3)   ;; #_ comments out the next form
+```
+
+## Reader macros
+
+```phel
+'symbol            ;; quote
+`(1 ~x ~@xs)       ;; quasiquote, unquote, unquote-splicing
+^:private          ;; metadata
+@my-atom           ;; deref
+,form  ,@xs        ;; legacy unquote / splicing — still highlighted
+```
+
+## Tagged literals
+
+```phel
+#inst "2026-01-01T00:00:00Z"
+#regex "\\d+"
+#php/Foo\Bar
+#money "10.00 EUR"            ;; custom tag via register-tag
+```
+
+`#` highlights as `punctuation.definition.tag.phel`; the tag name as `storage.type.tagged.phel`.
+
+## Reader conditionals
+
+```phel
+#?(:phel (php/time) :clj 0)
+[1 2 #?@(:phel [3 4] :clj [99])]
+```
+
+`#?` / `#?@` scope as `keyword.other.reader-conditional.phel` and the body wraps as `meta.reader-conditional.phel`, so themes can dim the inactive branch with a rule like:
+
+```jsonc
+"editor.tokenColorCustomizations": {
+    "textMateRules": [
+        { "scope": "meta.reader-conditional.phel", "settings": { "foreground": "#888" } }
+    ]
+}
+```
+
+## Verifying highlighting changes
+
+The grammar is verified end-to-end with the same engine VS Code ships:
+
+```bash
+npm run tokenize
+```
+
+That tokenises `scripts/sample.phel` against `syntaxes/phel.tmLanguage.json` via `vscode-textmate` + `vscode-oniguruma` and prints every token with its scope. Edit the sample to add new edge cases.

--- a/docs/taps.md
+++ b/docs/taps.md
@@ -1,0 +1,54 @@
+# Tracing with taps
+
+For ad-hoc inspection without setting up a full debug session, Phel ships a Clojure-style **tap registry** in `phel\core`.
+
+## API
+
+| Fn | What it does |
+|---|---|
+| `(add-tap f)` | Register a one-arg function `f` to receive tapped values. Returns `nil`. |
+| `(remove-tap f)` | Deregister a previously registered tap. Returns `nil`. |
+| `(tap> x)` | Send `x` to every registered tap. Returns `true`. |
+
+## Example
+
+```phel
+(ns my-app\core)
+
+;; Print every tapped value (or push to a logger, atom, file, etc.)
+(add-tap println)
+
+(defn process [order]
+  (tap> {:event :process-start :id (:id order)})
+  (let [result (do-work order)]
+    (tap> {:event :process-end :id (:id order) :result result})
+    result))
+
+;; Cleanup when done
+(remove-tap println)
+```
+
+## Semantics
+
+- **Synchronous.** Unlike Clojure, taps run inline on the calling thread — Phel has no background queue.
+- **Fault-isolated.** Exceptions thrown by individual tap handlers are swallowed so a buggy tap can't take down the producer or other taps.
+- **Set-based.** Adding the same function twice still registers it once (`add-tap` `conj`'s into a set).
+
+## Idioms
+
+**Capture into an atom for later inspection:**
+```phel
+(def captured (atom []))
+(add-tap (fn [x] (swap! captured conj x)))
+```
+
+**Conditional tracing in production:**
+```phel
+(when (env "DEBUG_TRACE")
+  (add-tap println))
+```
+
+**Pretty-print structured events:**
+```phel
+(add-tap (fn [x] (println (pprint/pprint x))))
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,54 @@
+# Troubleshooting
+
+Common problems and fixes. If your issue isn't here, open one at [GitHub Issues](https://github.com/phel-lang/phel-vs-code-extension/issues).
+
+## Highlighting
+
+**No highlighting in `.phel` files.**
+The extension activates on language `phel`. Confirm the file's language mode in the bottom-right status bar. If it says **Plain Text**, click it and pick *Phel*. If *Phel* isn't in the list, the extension didn't install — see [Installation](installation.md).
+
+**Some forms render as plain symbols.**
+The grammar tracks `phel-lang` `main`. If you're using a bleeding-edge form added after the last extension release, it may not be in the keyword list yet — file an issue with a code sample, or refresh the grammar yourself (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
+
+**`#tag` literals show with a default colour.**
+Tagged literals scope as `storage.type.tagged.phel`. Most themes don't style that scope explicitly. Add a rule in your settings:
+
+```jsonc
+"editor.tokenColorCustomizations": {
+    "textMateRules": [
+        { "scope": "storage.type.tagged.phel", "settings": { "foreground": "#c586c0" } }
+    ]
+}
+```
+
+## Completion
+
+**No suggestions when I type.**
+Confirm the language mode is `phel` (see above). Completion lives in `src/phelCompletionProvider.ts` and registers on the `phel` language ID — if the file isn't recognised as Phel, the provider doesn't fire.
+
+**Suggestion list misses a function I just added in `phel-lang`.**
+The list is a static snapshot. Refresh it via `scripts/regen-core-symbols.sh` and rebuild — see [completion.md](completion.md).
+
+## Debugging
+
+**Breakpoints show as hollow circles.**
+Phel hasn't compiled the file yet, or the cache directory is wrong. Run a Phel build first, then verify `phel.cacheDirectory` (or the `setTempDir(...)` call in `phel-config.php`).
+
+**Adapter reports "no source map for X.php".**
+The `.phel` file was compiled without source maps. Make sure your Phel build emits them.
+
+**Steps land in Phel runtime files.**
+Set `skipPhelInternals: true` (the default) and add additional globs to `skipFiles` if needed.
+
+**Container debugging hangs.**
+Missing `pathMappings`, or `xdebug.client_host` isn't set to the host's address from inside the container. On macOS / Windows use `host.docker.internal`. On Linux, the bridge IP (often `172.17.0.1`).
+
+## Reporting issues
+
+When filing a bug, include:
+
+- VS Code version and OS
+- Extension version (run **Phel Lang** in Extensions sidebar)
+- A minimal `.phel` snippet that reproduces the problem
+- What you expected vs. what happened (a screenshot helps for highlighting / completion bugs)
+- Relevant settings (`phel.*`) and `launch.json` config (debugging issues)


### PR DESCRIPTION
Supersedes the earlier "tighten README" iteration on this branch. The README is now an onboarding card; everything detailed lives under \`docs/\`.

## README — onboarding card (~50 lines)

Covers only what a new user needs in the first 30 seconds:

- **What** — one-sentence tagline.
- **Why** — short bullet list of the four capabilities.
- **Install** — one-liner \`code --install-extension\` (with a fallback to the \`.vsix\` from releases).
- **First steps** — four numbered actions to verify each capability.
- **Documentation** — a table of links into \`docs/\`.
- One-line links to CONTRIBUTING / CHANGELOG / LICENSE.

## New \`docs/\` folder

| File | Purpose |
|---|---|
| \`docs/README.md\` | Index with one-line summaries |
| \`docs/installation.md\` | Four install paths + "verifying the install" sanity check |
| \`docs/syntax.md\` | Full grammar reference (special forms, macros, literals, reader macros, tagged literals, reader conditionals) and the \`npm run tokenize\` loop |
| \`docs/completion.md\` | Completion contents, scoping rationale, regen procedure, snippet table |
| \`docs/debugging.md\` | Xdebug setup, options table, Docker / remote, capabilities, commands, troubleshooting |
| \`docs/taps.md\` | \`add-tap\` / \`tap>\` / \`remove-tap\` with semantics + idioms |
| \`docs/settings.md\` | Every \`phel.*\` setting plus theming example for \`meta.reader-conditional.phel\` |
| \`docs/troubleshooting.md\` | Common problems and fixes |

## Packaging

\`docs/**\` added to \`.vscodeignore\` so the published \`.vsix\` stays small. Marketplace renders the README and resolves relative links (\`docs/installation.md\` etc.) against \`repository.url\` from \`package.json\`, so the links work in both the Marketplace listing and on GitHub.

## Test plan
- [x] \`npm run compile\` clean.
- [x] \`npm test\` — 85 passing.
- [x] \`npx @vscode/vsce ls\` shows 13 files; no \`docs/\`, no \`CONTRIBUTING.md\`.
- [x] Every link from README points at an existing file under \`docs/\`.