### PR TITLE
fix(docs): drop unverified marketplace install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ Writing Phel without editor support means colourless code, no completion for the
 
 ## Install
 
+Grab the latest `.vsix` from the [releases page](https://github.com/phel-lang/phel-vs-code-extension/releases) and run:
+
 ```bash
-code --install-extension phel-lang.phel-lang
+code --install-extension phel-lang-0.5.0.vsix
 ```
 
-Or grab a `.vsix` from the [releases page](https://github.com/phel-lang/phel-vs-code-extension/releases) and run `code --install-extension phel-lang-*.vsix`. Requires VS Code **1.75+**.
+Or in VS Code: Extensions sidebar → **`...`** menu → *Install from VSIX...*
 
-Other paths (build from source, symlink for live development): see [docs/installation.md](docs/installation.md).
+Requires VS Code **1.75+**. Marketplace publication is on the roadmap. Other paths (build from source, symlink for live development): see [docs/installation.md](docs/installation.md).
 
 ## First steps
 
@@ -42,7 +44,3 @@ Other paths (build from source, symlink for live development): see [docs/install
 | Tracing with `tap>` | [docs/taps.md](docs/taps.md) |
 | Settings reference | [docs/settings.md](docs/settings.md) |
 | Troubleshooting | [docs/troubleshooting.md](docs/troubleshooting.md) |
-
-## Contributing · Changelog · License
-
-[CONTRIBUTING.md](CONTRIBUTING.md) · [CHANGELOG.md](CHANGELOG.md) · [LICENSE](LICENSE) (MIT)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,24 +2,18 @@
 
 Requires **VS Code 1.75+**.
 
-## Option 1 — VS Code Marketplace
+> **Note:** the extension is not yet on the VS Code Marketplace. Marketplace publication is on the roadmap; for now use one of the paths below. The `.vsix` from the GitHub releases page is the recommended option for end users.
 
-Open the Extensions sidebar (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd> / <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>), search for **"Phel Lang"**, click **Install**. Or from the terminal:
+## Option 1 — Pre-built `.vsix` (recommended)
 
-```bash
-code --install-extension phel-lang.phel-lang
-```
-
-## Option 2 — Pre-built `.vsix`
-
-Each tagged release publishes a `.vsix` you can install directly. Useful for offline machines or when you want a specific version.
+Each tagged release publishes a `.vsix` you can install directly.
 
 1. Download the latest `phel-lang-<version>.vsix` from the [releases page](https://github.com/phel-lang/phel-vs-code-extension/releases).
 2. Install it:
    - **CLI:** `code --install-extension phel-lang-<version>.vsix`
    - **GUI:** Extensions sidebar → **`...`** menu → *Install from VSIX...*
 
-## Option 3 — Build from source
+## Option 2 — Build from source
 
 Use this when you want changes from `main` that haven't been released yet.
 
@@ -32,7 +26,7 @@ npx @vscode/vsce package        # produces phel-lang-<version>.vsix
 code --install-extension phel-lang-*.vsix
 ```
 
-## Option 4 — Symlink for live development
+## Option 3 — Symlink for live development
 
 Iterate on grammar / TypeScript without rebuilding the `.vsix` each time. Pair this with <kbd>F5</kbd> from inside the cloned repo (launches an Extension Development Host with source maps).
 


### PR DESCRIPTION
## Why
\`code --install-extension phel-lang.phel-lang\` returns **404** on the Marketplace — verified:

\`\`\`
$ curl -s -o /dev/null -w '%{http_code}\\n' \\
    https://marketplace.visualstudio.com/items?itemName=phel-lang.phel-lang
404
\`\`\`

Searching the gallery API for "phel" returns no Phel-language extension either. The README was advertising a command users couldn't run.

## Change
- README and \`docs/installation.md\` now lead with the \`.vsix\` install path (works today) and explicitly note that Marketplace publication is on the roadmap.
- Renumber install options 1–3 (was 1–4) since the marketplace step is gone.

## Test plan
- [x] \`grep marketplace\` and \`grep phel-lang.phel-lang\` against the docs returns only the "roadmap" mention.
- [x] \`.vsix\` install command matches the actual filename produced by \`vsce package\` for 0.5.0.