### PR TITLE
chore(publish): switch publisher to chemaclass and document flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,39 @@ Keep the subject under ~70 characters; put the *why* in the body when it isn't o
 2. Bump it in `package.json` and run `npm install` so `package-lock.json` follows.
 3. Move the `Unreleased` block in `CHANGELOG.md` under the new version and date.
 4. Open a `chore(release): x.y.z` PR.
-5. After merge, tag `vX.Y.Z` on `main` and (if publishing) run `vsce package` / `vsce publish`.
+5. After merge, tag `vX.Y.Z` on `main`.
+6. Build the package and publish:
+   ```bash
+   npx @vscode/vsce package                 # produces phel-lang-x.y.z.vsix
+   gh release create vX.Y.Z phel-lang-*.vsix --notes-file release-notes.md
+   npx @vscode/vsce publish                 # pushes to the Marketplace
+   ```
+
+### Marketplace setup (one-time)
+
+The extension's `publisher` field is `chemaclass`. To publish you need a Personal Access Token (PAT) tied to that account:
+
+1. Go to <https://dev.azure.com>, sign in with the same account that owns the [`chemaclass` publisher](https://marketplace.visualstudio.com/manage/publishers/chemaclass).
+2. **User settings → Personal Access Tokens → New Token**:
+   - Organization: **All accessible organizations**
+   - Expiration: pick what you're comfortable with (max 1 year)
+   - Scopes → **Custom defined** → check **Marketplace > Manage**
+3. Copy the token (shown once).
+4. Cache it locally:
+   ```bash
+   npx @vscode/vsce login chemaclass
+   # paste the PAT when prompted
+   ```
+
+Subsequent `vsce publish` calls reuse the cached credentials. To rotate, run `vsce logout chemaclass` and repeat.
+
+### Marketplace assets
+
+Listed in `package.json` and shipped inside the `.vsix`:
+
+- `displayName`, `description`, `categories`, `keywords` — surface in search.
+- `repository.url`, `bugs.url`, `homepage` — render as sidebar links.
+- `icon` — 128×128 PNG (currently absent; add one before the first publish for a better listing).
 
 ## Updating the language surface
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ code --install-extension phel-lang-0.5.0.vsix
 
 Or in VS Code: Extensions sidebar → **`...`** menu → *Install from VSIX...*
 
-Requires VS Code **1.75+**. Marketplace publication is on the roadmap. Other paths (build from source, symlink for live development): see [docs/installation.md](docs/installation.md).
+Once published to the [VS Code Marketplace](https://marketplace.visualstudio.com/manage/publishers/chemaclass) the install will be:
+
+```bash
+code --install-extension chemaclass.phel-lang
+```
+
+Requires VS Code **1.75+**. Other paths (build from source, symlink for live development): see [docs/installation.md](docs/installation.md).
 
 ## First steps
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 Requires **VS Code 1.75+**.
 
-> **Note:** the extension is not yet on the VS Code Marketplace. Marketplace publication is on the roadmap; for now use one of the paths below. The `.vsix` from the GitHub releases page is the recommended option for end users.
+> **Note:** Marketplace publication is in progress. Once published under publisher [`chemaclass`](https://marketplace.visualstudio.com/manage/publishers/chemaclass), `code --install-extension chemaclass.phel-lang` will work. Until then, use one of the paths below.
 
 ## Option 1 — Pre-built `.vsix` (recommended)
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Phel Lang",
     "description": "Full-featured Phel language support with debugging for VS Code",
     "version": "0.5.0",
-    "publisher": "phel-lang",
+    "publisher": "chemaclass",
     "license": "MIT",
     "engines": {
         "vscode": "^1.75.0"


### PR DESCRIPTION
Sets the repo up for first Marketplace publish.

## Why
The previous \`publisher: phel-lang\` did not exist on the Marketplace (verified with a 404 against \`marketplace.visualstudio.com/items?itemName=phel-lang.phel-lang\`). The publisher actually owned by the maintainer is [\`chemaclass\`](https://marketplace.visualstudio.com/manage/publishers/chemaclass).

## Changes
- \`package.json\`: \`publisher: phel-lang\` → \`publisher: chemaclass\`.
- README + \`docs/installation.md\`: surface the post-publish install command (\`code --install-extension chemaclass.phel-lang\`) next to the \`.vsix\` path that already works.
- \`CONTRIBUTING.md\` release section now spells out:
  - The concrete \`vsce package\` → \`gh release create\` → \`vsce publish\` sequence.
  - One-time Marketplace PAT setup (scopes: **Marketplace > Manage**) and \`vsce login chemaclass\`.
  - Marketplace asset checklist; flagged the missing 128×128 \`icon\` as something to add before the first publish.

## After this merges
Maintainer needs to run interactively:

\`\`\`bash
npx @vscode/vsce login chemaclass    # paste PAT
npx @vscode/vsce publish             # pushes 0.5.0 to the Marketplace
\`\`\`

(Or just \`vsce publish patch\` etc. for an automatic version bump.)

## Test plan
- [x] \`vsce package\` builds cleanly with the new publisher (15 files, 36 KB).
- [x] \`grep -r 'phel-lang.phel-lang'\` returns no matches.
- [ ] Post-publish: \`curl https://marketplace.visualstudio.com/items?itemName=chemaclass.phel-lang\` returns 200 (manual after first \`vsce publish\`).