### PR TITLE
chore(publish): correct publisher to Phel-Lang

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,9 +69,9 @@ Keep the subject under ~70 characters; put the *why* in the body when it isn't o
 
 ### Marketplace setup (one-time)
 
-The extension's `publisher` field is `chemaclass`. To publish you need a Personal Access Token (PAT) tied to that account:
+The extension's `publisher` field is `Phel-Lang`. To publish you need a Personal Access Token (PAT) tied to that account:
 
-1. Go to <https://dev.azure.com>, sign in with the same account that owns the [`chemaclass` publisher](https://marketplace.visualstudio.com/manage/publishers/chemaclass).
+1. Go to <https://dev.azure.com>, sign in with the same account that owns the [`Phel-Lang` publisher](https://marketplace.visualstudio.com/manage/publishers/Phel-Lang).
 2. **User settings → Personal Access Tokens → New Token**:
    - Organization: **All accessible organizations**
    - Expiration: pick what you're comfortable with (max 1 year)
@@ -79,11 +79,11 @@ The extension's `publisher` field is `chemaclass`. To publish you need a Persona
 3. Copy the token (shown once).
 4. Cache it locally:
    ```bash
-   npx @vscode/vsce login chemaclass
+   npx @vscode/vsce login Phel-Lang
    # paste the PAT when prompted
    ```
 
-Subsequent `vsce publish` calls reuse the cached credentials. To rotate, run `vsce logout chemaclass` and repeat.
+Subsequent `vsce publish` calls reuse the cached credentials. To rotate, run `vsce logout Phel-Lang` and repeat.
 
 ### Marketplace assets
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ code --install-extension phel-lang-0.5.0.vsix
 
 Or in VS Code: Extensions sidebar → **`...`** menu → *Install from VSIX...*
 
-Once published to the [VS Code Marketplace](https://marketplace.visualstudio.com/manage/publishers/chemaclass) the install will be:
+Once published to the [VS Code Marketplace](https://marketplace.visualstudio.com/manage/publishers/Phel-Lang) the install will be:
 
 ```bash
-code --install-extension chemaclass.phel-lang
+code --install-extension Phel-Lang.phel-lang
 ```
 
 Requires VS Code **1.75+**. Other paths (build from source, symlink for live development): see [docs/installation.md](docs/installation.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 Requires **VS Code 1.75+**.
 
-> **Note:** Marketplace publication is in progress. Once published under publisher [`chemaclass`](https://marketplace.visualstudio.com/manage/publishers/chemaclass), `code --install-extension chemaclass.phel-lang` will work. Until then, use one of the paths below.
+> **Note:** Marketplace publication is in progress. Once published under publisher [`Phel-Lang`](https://marketplace.visualstudio.com/manage/publishers/Phel-Lang), `code --install-extension Phel-Lang.phel-lang` will work. Until then, use one of the paths below.
 
 ## Option 1 — Pre-built `.vsix` (recommended)
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Phel Lang",
     "description": "Full-featured Phel language support with debugging for VS Code",
     "version": "0.5.0",
-    "publisher": "chemaclass",
+    "publisher": "Phel-Lang",
     "license": "MIT",
     "engines": {
         "vscode": "^1.75.0"


### PR DESCRIPTION
Follow-up to #20.

The maintainer actually owns the [\`Phel-Lang\`](https://marketplace.visualstudio.com/manage/publishers/Phel-Lang) publisher, not \`chemaclass\`. Updates \`package.json\`, README, \`docs/installation.md\`, and \`CONTRIBUTING.md\` to use the correct publisher.

After this lands, the post-publish install command is:

\`\`\`bash
code --install-extension Phel-Lang.phel-lang
\`\`\`

PAT login becomes \`vsce login Phel-Lang\`.

## Test plan
- [x] \`vsce package\` builds cleanly with the new publisher (15 files, 36 KB).
- [x] \`grep -r chemaclass\` returns no matches.