### PR TITLE
docs: surface live Marketplace listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Phel Lang for VS Code
 
+[![Marketplace](https://img.shields.io/visual-studio-marketplace/v/Phel-Lang.phel-lang?label=marketplace)](https://marketplace.visualstudio.com/items?itemName=Phel-Lang.phel-lang)
+[![Installs](https://img.shields.io/visual-studio-marketplace/i/Phel-Lang.phel-lang)](https://marketplace.visualstudio.com/items?itemName=Phel-Lang.phel-lang)
 [![Release](https://img.shields.io/github/v/release/phel-lang/phel-vs-code-extension?label=release)](https://github.com/phel-lang/phel-vs-code-extension/releases)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
@@ -16,21 +18,13 @@ Writing Phel without editor support means colourless code, no completion for the
 
 ## Install
 
-Grab the latest `.vsix` from the [releases page](https://github.com/phel-lang/phel-vs-code-extension/releases) and run:
-
-```bash
-code --install-extension phel-lang-0.5.0.vsix
-```
-
-Or in VS Code: Extensions sidebar → **`...`** menu → *Install from VSIX...*
-
-Once published to the [VS Code Marketplace](https://marketplace.visualstudio.com/manage/publishers/Phel-Lang) the install will be:
+In VS Code, open the Extensions sidebar (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd> / <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>), search for **"Phel Lang"**, click **Install**. Or from the terminal:
 
 ```bash
 code --install-extension Phel-Lang.phel-lang
 ```
 
-Requires VS Code **1.75+**. Other paths (build from source, symlink for live development): see [docs/installation.md](docs/installation.md).
+Requires VS Code **1.75+**. Other paths (`.vsix` from GitHub releases, build from source, symlink for live development): see [docs/installation.md](docs/installation.md).
 
 ## First steps
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,19 +1,25 @@
 # Installation
 
-Requires **VS Code 1.75+**.
+Requires **VS Code 1.75+**. Published on the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Phel-Lang.phel-lang) under publisher `Phel-Lang`.
 
-> **Note:** Marketplace publication is in progress. Once published under publisher [`Phel-Lang`](https://marketplace.visualstudio.com/manage/publishers/Phel-Lang), `code --install-extension Phel-Lang.phel-lang` will work. Until then, use one of the paths below.
+## Option 1 — Marketplace (recommended)
 
-## Option 1 — Pre-built `.vsix` (recommended)
+In VS Code, open the Extensions sidebar (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd> / <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>), search for **"Phel Lang"**, click **Install**. Or from the terminal:
 
-Each tagged release publishes a `.vsix` you can install directly.
+```bash
+code --install-extension Phel-Lang.phel-lang
+```
 
-1. Download the latest `phel-lang-<version>.vsix` from the [releases page](https://github.com/phel-lang/phel-vs-code-extension/releases).
+## Option 2 — Pre-built `.vsix`
+
+Useful for offline machines or when you want a specific version.
+
+1. Download `phel-lang-<version>.vsix` from the [releases page](https://github.com/phel-lang/phel-vs-code-extension/releases).
 2. Install it:
    - **CLI:** `code --install-extension phel-lang-<version>.vsix`
    - **GUI:** Extensions sidebar → **`...`** menu → *Install from VSIX...*
 
-## Option 2 — Build from source
+## Option 3 — Build from source
 
 Use this when you want changes from `main` that haven't been released yet.
 
@@ -26,7 +32,7 @@ npx @vscode/vsce package        # produces phel-lang-<version>.vsix
 code --install-extension phel-lang-*.vsix
 ```
 
-## Option 3 — Symlink for live development
+## Option 4 — Symlink for live development
 
 Iterate on grammar / TypeScript without rebuilding the `.vsix` each time. Pair this with <kbd>F5</kbd> from inside the cloned repo (launches an Extension Development Host with source maps).
 


### PR DESCRIPTION
Extension is now live: <https://marketplace.visualstudio.com/items?itemName=Phel-Lang.phel-lang>.

## Changes
- README install section leads with the Marketplace search + \`code --install-extension Phel-Lang.phel-lang\` one-liner; demotes the \`.vsix\` to a docs/installation.md fallback.
- README badges: Marketplace version + install count + GitHub release + license.
- \`docs/installation.md\` reorders to Marketplace → \`.vsix\` → build-from-source → symlink, drops the "publication in progress" note.

## Test plan
- [x] \`curl -o /dev/null -w '%{http_code}' https://marketplace.visualstudio.com/items?itemName=Phel-Lang.phel-lang\` → 200.
- [x] All install paths still documented somewhere reachable from the README.