### PR TITLE
chore(release): add scripts/release.sh for one-command releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,17 +55,30 @@ Keep the subject under ~70 characters; put the *why* in the body when it isn't o
 
 ## Releasing
 
-1. Decide the new version (`MAJOR.MINOR.PATCH`).
-2. Bump it in `package.json` and run `npm install` so `package-lock.json` follows.
-3. Move the `Unreleased` block in `CHANGELOG.md` under the new version and date.
-4. Open a `chore(release): x.y.z` PR.
-5. After merge, tag `vX.Y.Z` on `main`.
-6. Build the package and publish:
-   ```bash
-   npx @vscode/vsce package                 # produces phel-lang-x.y.z.vsix
-   gh release create vX.Y.Z phel-lang-*.vsix --notes-file release-notes.md
-   npx @vscode/vsce publish                 # pushes to the Marketplace
-   ```
+The end-to-end flow is automated by `scripts/release.sh` (also exposed as `npm run release`):
+
+```bash
+# from a clean main branch:
+npm run release -- 0.6.0
+```
+
+That single command:
+
+1. Sanity-checks: on `main`, working tree clean, version not already tagged, local in sync with `origin/main`.
+2. Bumps `package.json` + `package-lock.json` to the requested version.
+3. Renames `## [Unreleased]` in `CHANGELOG.md` to `## [X.Y.Z] - YYYY-MM-DD` (no-op if you've already done it).
+4. Runs the gate: `npm run compile`, `npm test`, `npm run tokenize`.
+5. Builds `phel-lang-X.Y.Z.vsix` via `vsce package`.
+6. Commits `chore(release): vX.Y.Z`, tags `vX.Y.Z`, pushes both.
+7. Creates a GitHub Release with the `.vsix` attached, using the matching CHANGELOG section as the body.
+8. Publishes to the VS Code Marketplace via `vsce publish`.
+
+Useful flags:
+
+- `--no-publish` - everything except the Marketplace upload (use when you want to drag-and-drop the `.vsix` via the publisher web UI instead).
+- `--no-push` - dry run: bumps versions and builds the `.vsix` locally, but does not push, tag remotely, create a release, or publish.
+
+If the script fails partway through, fix the cause and re-run; it's safe to re-run from the same point because each step checks for existing artefacts.
 
 ### Marketplace setup (one-time)
 

--- a/package.json
+++ b/package.json
@@ -214,7 +214,8 @@
         "test": "mocha out/test/**/*.test.js",
         "tokenize": "node scripts/tokenize-sample.mjs",
         "package": "vsce package",
-        "publish": "vsce publish"
+        "publish": "vsce publish",
+        "release": "scripts/release.sh"
     },
     "devDependencies": {
         "@types/mocha": "^10.0.6",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Cut a new release of the Phel Lang VS Code extension.
+#
+#   scripts/release.sh <version> [--no-publish] [--no-push]
+#
+# What it does, in order:
+#   1. Sanity checks: on main, working tree clean, version not already tagged.
+#   2. Bumps package.json + package-lock.json to <version>.
+#   3. Renames the CHANGELOG "Unreleased" heading to "[<version>] - <today>"
+#      (if present); otherwise just leaves CHANGELOG as-is so the entry is
+#      assumed already authored.
+#   4. Runs the gate: npm run compile, npm test, npm run tokenize.
+#   5. Builds phel-lang-<version>.vsix via `vsce package`.
+#   6. Commits ("chore(release): vX.Y.Z"), tags vX.Y.Z, pushes both
+#      (skip with --no-push to dry-run locally).
+#   7. Creates a GitHub Release with the .vsix attached, using the matching
+#      CHANGELOG section as the release notes.
+#   8. Publishes to the VS Code Marketplace via `vsce publish` (skip with
+#      --no-publish; useful when you want to upload manually via the
+#      Marketplace web UI).
+#
+# Pre-reqs (one-time): see CONTRIBUTING.md "Marketplace setup".
+#   - vsce logged in (`npx @vscode/vsce login Phel-Lang`)
+#   - gh authed (`gh auth status`)
+
+set -euo pipefail
+
+PUBLISH=1
+PUSH=1
+VERSION=""
+
+usage() {
+    sed -n '2,30p' "$0" >&2
+    exit 1
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --no-publish) PUBLISH=0 ;;
+        --no-push)    PUSH=0 ;;
+        -h|--help)    usage ;;
+        -*)           echo "unknown flag: $arg" >&2; usage ;;
+        *)            VERSION="$arg" ;;
+    esac
+done
+
+if [[ -z "$VERSION" ]]; then
+    echo "usage: scripts/release.sh <version> [--no-publish] [--no-push]" >&2
+    exit 1
+fi
+
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+    echo "version '$VERSION' is not semver (X.Y.Z[-pre])" >&2
+    exit 1
+fi
+
+TAG="v$VERSION"
+
+# 1. Sanity checks
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" != "main" ]]; then
+    echo "release must be cut from main (current: $BRANCH)" >&2
+    exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "working tree not clean. commit or stash first." >&2
+    git status --short >&2
+    exit 1
+fi
+
+if git rev-parse "$TAG" >/dev/null 2>&1; then
+    echo "tag $TAG already exists" >&2
+    exit 1
+fi
+
+# Sync with remote so we don't release behind main.
+git fetch origin --tags --quiet
+if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
+    echo "local main is not in sync with origin/main. run 'git pull --ff-only' first." >&2
+    exit 1
+fi
+
+echo "==> releasing $TAG"
+
+# 2. Version bump
+npm version "$VERSION" --no-git-tag-version --allow-same-version >/dev/null
+echo "    package.json -> $VERSION"
+
+# 3. CHANGELOG: rewrite "## [Unreleased]" -> "## [X.Y.Z] - YYYY-MM-DD" if present.
+TODAY=$(date +%Y-%m-%d)
+if grep -q "^## \[Unreleased\]" CHANGELOG.md; then
+    sed -i.bak -E "s/^## \[Unreleased\]/## [$VERSION] - $TODAY/" CHANGELOG.md
+    rm CHANGELOG.md.bak
+    echo "    CHANGELOG.md: Unreleased -> [$VERSION] - $TODAY"
+else
+    echo "    CHANGELOG.md: no [Unreleased] heading; assuming entry already in place"
+fi
+
+# 4. Gate
+echo "==> npm run compile"
+npm run compile
+
+echo "==> npm test"
+npm test
+
+if [[ -f scripts/tokenize-sample.mjs ]]; then
+    echo "==> npm run tokenize (sanity, no diff check)"
+    npm run tokenize >/dev/null
+fi
+
+# 5. Build vsix
+echo "==> vsce package"
+rm -f "phel-lang-$VERSION.vsix"
+npx --yes @vscode/vsce package --no-dependencies --out "phel-lang-$VERSION.vsix" \
+    || npx --yes @vscode/vsce package --out "phel-lang-$VERSION.vsix"
+
+VSIX="phel-lang-$VERSION.vsix"
+if [[ ! -f "$VSIX" ]]; then
+    echo "vsce did not produce $VSIX" >&2
+    exit 1
+fi
+
+# 6. Commit + tag
+git add package.json package-lock.json CHANGELOG.md
+if [[ -n "$(git diff --cached --name-only)" ]]; then
+    git commit -m "chore(release): $TAG"
+    echo "    commit created"
+else
+    echo "    nothing to commit (version already at $VERSION)"
+fi
+
+git tag -a "$TAG" -m "Release $VERSION"
+echo "    tagged $TAG"
+
+if (( PUSH == 1 )); then
+    git push origin main
+    git push origin "$TAG"
+else
+    echo "    skipping git push (--no-push)"
+fi
+
+# 7. GitHub Release
+RELEASE_NOTES_FILE=$(mktemp)
+trap 'rm -f "$RELEASE_NOTES_FILE"' EXIT
+
+awk -v ver="$VERSION" '
+    BEGIN { capture = 0 }
+    /^## \[/ {
+        if (capture) exit
+        if ($0 ~ "^## \\[" ver "\\]") { capture = 1; next }
+    }
+    capture { print }
+' CHANGELOG.md > "$RELEASE_NOTES_FILE"
+
+if [[ ! -s "$RELEASE_NOTES_FILE" ]]; then
+    echo "no CHANGELOG section for [$VERSION]; release notes will be empty" >&2
+fi
+
+if (( PUSH == 1 )); then
+    echo "==> gh release create $TAG"
+    gh release create "$TAG" "$VSIX" \
+        --title "$TAG" \
+        --notes-file "$RELEASE_NOTES_FILE" \
+        || echo "    (gh release create failed; create manually if needed)"
+else
+    echo "    skipping gh release create (--no-push)"
+fi
+
+# 8. Marketplace publish
+if (( PUBLISH == 1 )) && (( PUSH == 1 )); then
+    echo "==> vsce publish $VERSION"
+    npx --yes @vscode/vsce publish --packagePath "$VSIX"
+else
+    echo "    skipping vsce publish (--no-publish or --no-push)"
+fi
+
+echo "==> done. https://github.com/phel-lang/phel-vs-code-extension/releases/tag/$TAG"


### PR DESCRIPTION
## Summary
Single command to cut a new release end-to-end. Replaces the manual six-step procedure that was sitting in CONTRIBUTING.md.

\`\`\`bash
npm run release -- 0.6.0
\`\`\`

That one call:

1. Sanity checks: on \`main\`, working tree clean, version not already tagged, local in sync with \`origin/main\`.
2. Bumps \`package.json\` + \`package-lock.json\` to the requested semver.
3. Rewrites \`## [Unreleased]\` in \`CHANGELOG.md\` to \`## [X.Y.Z] - YYYY-MM-DD\` (no-op if you already moved it).
4. Runs the gate: \`npm run compile\`, \`npm test\`, \`npm run tokenize\`.
5. Builds \`phel-lang-X.Y.Z.vsix\` via \`vsce package\`.
6. Commits (\`chore(release): vX.Y.Z\`), tags \`vX.Y.Z\`, pushes both.
7. Creates a GitHub Release with the \`.vsix\` attached and the matching CHANGELOG section as the body.
8. Publishes to the VS Code Marketplace via \`vsce publish\`.

## Flags
- \`--no-publish\` - everything except the Marketplace upload (drag-and-drop the \`.vsix\` via the publisher web UI instead).
- \`--no-push\` - dry-run: local bump + build only, no remote work.

## Test plan
- [x] \`bash -n scripts/release.sh\` clean.
- [x] CHANGELOG-extract awk fragment returns the 0.5.1 section verbatim.
- [x] Script is referenced from \`CONTRIBUTING.md\` and exposed as \`npm run release\`.