### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - run: npm ci
+      - run: npm run format:check
+      - run: npm run compile
+      - run: npm run lint
+      - run: npm test
+      - run: npm run tokenize
+      - name: vsce package (sanity)
+        run: npx --yes @vscode/vsce package --out /tmp/phel-lang.vsix

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Phel Lang for VS Code
 
+[![CI](https://github.com/phel-lang/phel-vs-code-extension/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/phel-lang/phel-vs-code-extension/actions/workflows/ci.yml)
 [![Marketplace](https://img.shields.io/visual-studio-marketplace/v/Phel-Lang.phel-lang?label=marketplace)](https://marketplace.visualstudio.com/items?itemName=Phel-Lang.phel-lang)
 [![Installs](https://img.shields.io/visual-studio-marketplace/i/Phel-Lang.phel-lang)](https://marketplace.visualstudio.com/items?itemName=Phel-Lang.phel-lang)
 [![Release](https://img.shields.io/github/v/release/phel-lang/phel-vs-code-extension?label=release)](https://github.com/phel-lang/phel-vs-code-extension/releases)


### PR DESCRIPTION
First step of the rolling roadmap (PR0). Future PRs depend on green CI to merge.

## Workflow
- Triggers: push to \`main\` and every PR.
- Matrix: Node 20 + Node 22.
- Steps: \`npm ci\` -> \`format:check\` -> \`compile\` -> \`lint\` -> \`test\` -> \`tokenize\` -> \`vsce package\` (sanity).
- Concurrency: cancels superseded runs on the same ref.
- Permissions: \`contents: read\` only.

## Test plan
- [x] \`npm run format:check\` passes locally.
- [x] \`npm test\` passes (85 tests).
- [x] \`npm run tokenize\` exits 0.
- [x] \`npx @vscode/vsce package\` produces a valid \`.vsix\`.
- [ ] CI runs green on this PR (will verify after push).