### PR TITLE
feat(hover): rich hover docs + completion documentation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import * as net from 'net';
 import { SourceMapManager } from './sourceMapManager';
 import { PhelDebugSession } from './phelDebugAdapter';
 import { PhelCompletionProvider } from './phelCompletionProvider';
+import { PhelHoverProvider } from './phelHoverProvider';
 
 let sourceMapManager: SourceMapManager;
 
@@ -107,6 +108,10 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(
         vscode.languages.registerCompletionItemProvider('phel', new PhelCompletionProvider())
+    );
+
+    context.subscriptions.push(
+        vscode.languages.registerHoverProvider('phel', new PhelHoverProvider())
     );
 
     // Provide hover information for breakpoints

--- a/src/phelCompletionProvider.ts
+++ b/src/phelCompletionProvider.ts
@@ -1,34 +1,61 @@
 import * as vscode from 'vscode';
+import { PHEL_DOCS } from './phelCoreDocs';
 import { CORE_FNS, MACROS, SPECIAL_FORMS } from './phelCoreSymbols';
+import { lookupSymbol, renderDocMarkdown } from './phelDocsLookup';
 
 const SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;
 
-function buildItems(): vscode.CompletionItem[] {
-    const items: vscode.CompletionItem[] = [];
+interface ItemSpec {
+    label: string;
+    kind: vscode.CompletionItemKind;
+    detail: string;
+}
 
+function buildSpecs(): ItemSpec[] {
+    const specs: ItemSpec[] = [];
     for (const name of SPECIAL_FORMS) {
-        const item = new vscode.CompletionItem(name, vscode.CompletionItemKind.Keyword);
-        item.detail = 'Phel special form';
-        items.push(item);
+        specs.push({
+            label: name,
+            kind: vscode.CompletionItemKind.Keyword,
+            detail: 'Phel special form',
+        });
     }
-
     for (const name of MACROS) {
-        const item = new vscode.CompletionItem(name, vscode.CompletionItemKind.Keyword);
-        item.detail = 'Phel macro';
-        items.push(item);
+        specs.push({
+            label: name,
+            kind: vscode.CompletionItemKind.Keyword,
+            detail: 'Phel macro',
+        });
     }
-
     for (const name of CORE_FNS) {
-        const item = new vscode.CompletionItem(name, vscode.CompletionItemKind.Function);
-        item.detail = 'Phel core function';
-        items.push(item);
+        specs.push({
+            label: name,
+            kind: vscode.CompletionItemKind.Function,
+            detail: 'Phel core function',
+        });
     }
+    return specs;
+}
 
-    return items;
+function buildItem(spec: ItemSpec, range?: vscode.Range): vscode.CompletionItem {
+    const item = new vscode.CompletionItem(spec.label, spec.kind);
+    item.detail = spec.detail;
+    const doc = lookupSymbol(spec.label, PHEL_DOCS);
+    if (doc) {
+        const md = new vscode.MarkdownString(renderDocMarkdown(doc));
+        md.isTrusted = false;
+        md.supportHtml = false;
+        item.documentation = md;
+    }
+    if (range) {
+        item.range = range;
+    }
+    return item;
 }
 
 export class PhelCompletionProvider implements vscode.CompletionItemProvider {
-    private readonly items: vscode.CompletionItem[] = buildItems();
+    private readonly specs: ItemSpec[] = buildSpecs();
+    private readonly bareItems: vscode.CompletionItem[] = this.specs.map((spec) => buildItem(spec));
 
     provideCompletionItems(
         document: vscode.TextDocument,
@@ -36,13 +63,8 @@ export class PhelCompletionProvider implements vscode.CompletionItemProvider {
     ): vscode.ProviderResult<vscode.CompletionItem[]> {
         const range = document.getWordRangeAtPosition(position, SYMBOL_RE);
         if (!range) {
-            return this.items;
+            return this.bareItems;
         }
-        return this.items.map((item) => {
-            const cloned = new vscode.CompletionItem(item.label, item.kind);
-            cloned.detail = item.detail;
-            cloned.range = range;
-            return cloned;
-        });
+        return this.specs.map((spec) => buildItem(spec, range));
     }
 }

--- a/src/phelDocsLookup.ts
+++ b/src/phelDocsLookup.ts
@@ -1,0 +1,105 @@
+// Pure helpers that turn `PhelDoc` records into the things providers need:
+// resolve a typed symbol to a doc, and render a doc as Markdown for hover /
+// completion popups. Kept free of `vscode` imports so they can be unit-tested
+// without booting the editor.
+
+import type { PhelDoc } from './phelDocs';
+
+/**
+ * Find the best `PhelDoc` for a typed symbol.
+ *
+ * - An exact `<ns>/<name>` match always wins.
+ * - Otherwise look for a public symbol with that bare `name`. Prefer
+ *   `phel.core` (the auto-imported namespace), then any other public
+ *   namespace, then private definitions as a last resort.
+ *
+ * Returns `undefined` if nothing matches.
+ */
+export function lookupSymbol(symbol: string, docs: readonly PhelDoc[]): PhelDoc | undefined {
+    if (!symbol) {
+        return undefined;
+    }
+
+    const exact = docs.find((d) => d.qualifiedName === symbol);
+    if (exact) {
+        return exact;
+    }
+
+    const matches = docs.filter((d) => d.name === symbol);
+    if (matches.length === 0) {
+        return undefined;
+    }
+
+    const publicCore = matches.find((d) => !d.private && d.ns === 'phel.core');
+    if (publicCore) {
+        return publicCore;
+    }
+
+    const anyPublic = matches.find((d) => !d.private);
+    if (anyPublic) {
+        return anyPublic;
+    }
+
+    return matches[0];
+}
+
+/**
+ * Render a `PhelDoc` as a Markdown string suitable for hover popups and
+ * completion-item documentation. Each section is omitted if absent.
+ */
+export function renderDocMarkdown(doc: PhelDoc): string {
+    const lines: string[] = [];
+
+    const kindLabel = describeKind(doc);
+    lines.push(`**\`${doc.qualifiedName}\`** _${kindLabel}_`);
+    lines.push('');
+
+    if (doc.signature) {
+        lines.push('```phel');
+        lines.push(doc.signature);
+        if (doc.arities && doc.arities.length > 1) {
+            for (const arity of doc.arities.slice(1)) {
+                lines.push(arity);
+            }
+        }
+        lines.push('```');
+        lines.push('');
+    }
+
+    if (doc.doc) {
+        lines.push(doc.doc.trim());
+        lines.push('');
+    }
+
+    if (doc.example) {
+        lines.push('**Example**');
+        lines.push('');
+        lines.push('```phel');
+        lines.push(doc.example.trim());
+        lines.push('```');
+        lines.push('');
+    }
+
+    if (doc.seeAlso && doc.seeAlso.length > 0) {
+        lines.push('**See also:** ' + doc.seeAlso.map((s) => `\`${s}\``).join(', '));
+        lines.push('');
+    }
+
+    if (doc.sourceUrl) {
+        lines.push(`[View source](${doc.sourceUrl})`);
+    }
+
+    return lines.join('\n').trimEnd();
+}
+
+function describeKind(doc: PhelDoc): string {
+    const visibility = doc.private ? 'private ' : '';
+    switch (doc.kind) {
+        case 'fn':
+            return `${visibility}function`;
+        case 'macro':
+            return `${visibility}macro`;
+        case 'def':
+            return `${visibility}def`;
+    }
+}

--- a/src/phelHoverProvider.ts
+++ b/src/phelHoverProvider.ts
@@ -1,0 +1,26 @@
+import * as vscode from 'vscode';
+import { PHEL_DOCS } from './phelCoreDocs';
+import { lookupSymbol, renderDocMarkdown } from './phelDocsLookup';
+
+const SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;
+
+export class PhelHoverProvider implements vscode.HoverProvider {
+    provideHover(
+        document: vscode.TextDocument,
+        position: vscode.Position
+    ): vscode.ProviderResult<vscode.Hover> {
+        const range = document.getWordRangeAtPosition(position, SYMBOL_RE);
+        if (!range) {
+            return null;
+        }
+        const word = document.getText(range);
+        const doc = lookupSymbol(word, PHEL_DOCS);
+        if (!doc) {
+            return null;
+        }
+        const md = new vscode.MarkdownString(renderDocMarkdown(doc));
+        md.isTrusted = false;
+        md.supportHtml = false;
+        return new vscode.Hover(md, range);
+    }
+}

--- a/src/test/phelDocsLookup.test.ts
+++ b/src/test/phelDocsLookup.test.ts
@@ -1,0 +1,142 @@
+import * as assert from 'assert';
+import type { PhelDoc } from '../phelDocs';
+import { lookupSymbol, renderDocMarkdown } from '../phelDocsLookup';
+
+const corpus: PhelDoc[] = [
+    {
+        name: 'assoc',
+        ns: 'phel.core',
+        qualifiedName: 'phel.core/assoc',
+        kind: 'fn',
+        private: false,
+        signature: '(assoc m k v)',
+        doc: 'Associates a key/value pair.',
+        example: '(assoc {:a 1} :b 2) ; => {:a 1 :b 2}',
+        seeAlso: ['dissoc', 'update'],
+        sourceUrl:
+            'https://github.com/phel-lang/phel-lang/blob/v0.35.0/src/phel/core/sequences.phel',
+    },
+    {
+        name: 'is',
+        ns: 'phel.test',
+        qualifiedName: 'phel.test/is',
+        kind: 'macro',
+        private: false,
+        signature: '(is form)',
+        doc: 'Asserts that form evaluates truthy.',
+    },
+    {
+        name: 'assoc',
+        ns: 'phel.legacy',
+        qualifiedName: 'phel.legacy/assoc',
+        kind: 'fn',
+        private: false,
+        signature: '(assoc x)',
+    },
+    {
+        name: 'helper',
+        ns: 'phel.core',
+        qualifiedName: 'phel.core/helper',
+        kind: 'fn',
+        private: true,
+        signature: '(helper x)',
+    },
+    {
+        name: 'orphan',
+        ns: 'phel.misc',
+        qualifiedName: 'phel.misc/orphan',
+        kind: 'def',
+        private: true,
+    },
+];
+
+describe('lookupSymbol', function () {
+    it('matches an exact qualified name first', function () {
+        const r = lookupSymbol('phel.legacy/assoc', corpus);
+        assert.ok(r);
+        assert.strictEqual(r!.qualifiedName, 'phel.legacy/assoc');
+    });
+
+    it('prefers phel.core for unqualified names', function () {
+        const r = lookupSymbol('assoc', corpus);
+        assert.ok(r);
+        assert.strictEqual(r!.ns, 'phel.core');
+    });
+
+    it('falls back to any public namespace when phel.core is absent', function () {
+        const r = lookupSymbol('is', corpus);
+        assert.ok(r);
+        assert.strictEqual(r!.ns, 'phel.test');
+    });
+
+    it('falls back to a private definition as a last resort', function () {
+        const r = lookupSymbol('orphan', corpus);
+        assert.ok(r);
+        assert.strictEqual(r!.qualifiedName, 'phel.misc/orphan');
+    });
+
+    it('returns undefined when nothing matches', function () {
+        const r = lookupSymbol('nonexistent', corpus);
+        assert.strictEqual(r, undefined);
+    });
+
+    it('returns undefined for an empty input', function () {
+        assert.strictEqual(lookupSymbol('', corpus), undefined);
+    });
+});
+
+describe('renderDocMarkdown', function () {
+    it('includes signature, doc, example, see-also, and source link for a fn', function () {
+        const md = renderDocMarkdown(corpus[0]);
+        assert.match(md, /\*\*`phel\.core\/assoc`\*\* _function_/);
+        assert.match(md, /```phel\n\(assoc m k v\)\n```/);
+        assert.match(md, /Associates a key\/value pair\./);
+        assert.match(md, /\*\*Example\*\*/);
+        assert.match(md, /\(assoc \{:a 1\} :b 2\)/);
+        assert.match(md, /\*\*See also:\*\* `dissoc`, `update`/);
+        assert.match(
+            md,
+            /\[View source\]\(https:\/\/github\.com\/phel-lang\/phel-lang\/blob\/v0\.35\.0\/src\/phel\/core\/sequences\.phel\)/
+        );
+    });
+
+    it('labels macros and private symbols correctly', function () {
+        assert.match(renderDocMarkdown(corpus[1]), /_macro_/);
+        assert.match(renderDocMarkdown(corpus[3]), /_private function_/);
+    });
+
+    it('renders def without a signature block', function () {
+        const md = renderDocMarkdown(corpus[4]);
+        assert.match(md, /_private def_/);
+        assert.ok(!md.includes('```phel\n'), 'def without signature should not emit a code fence');
+    });
+
+    it('emits all arities when more than one is present', function () {
+        const doc: PhelDoc = {
+            name: 'multi',
+            ns: 'phel.core',
+            qualifiedName: 'phel.core/multi',
+            kind: 'fn',
+            private: false,
+            signature: '(multi)',
+            arities: ['(multi)', '(multi a)', '(multi a b)'],
+        };
+        const md = renderDocMarkdown(doc);
+        assert.match(md, /```phel\n\(multi\)\n\(multi a\)\n\(multi a b\)\n```/);
+    });
+
+    it('omits sections when fields are missing', function () {
+        const doc: PhelDoc = {
+            name: 'bare',
+            ns: 'phel.core',
+            qualifiedName: 'phel.core/bare',
+            kind: 'fn',
+            private: false,
+        };
+        const md = renderDocMarkdown(doc);
+        assert.match(md, /\*\*`phel\.core\/bare`\*\* _function_/);
+        assert.ok(!md.includes('Example'));
+        assert.ok(!md.includes('See also'));
+        assert.ok(!md.includes('View source'));
+    });
+});


### PR DESCRIPTION
PR2 of the rolling roadmap. Built on top of #27 (the docs DB).

## What
- **\`src/phelDocsLookup.ts\`** (pure, testable):
  - \`lookupSymbol(word, docs)\` resolves a typed symbol to a \`PhelDoc\`. Exact qualified match wins; otherwise prefer \`phel.core\`, then any other public namespace, then private as a last resort.
  - \`renderDocMarkdown(doc)\` turns a \`PhelDoc\` into Markdown with name + kind, signature(s) inside a fenced \`phel\` block, docstring, example, see-also, and a \"View source\" link.
- **\`src/phelHoverProvider.ts\`** - \`HoverProvider\` for the \`phel\` language. Resolves the word under cursor through \`lookupSymbol\` and returns the rendered Markdown.
- **\`src/phelCompletionProvider.ts\`** - every \`CompletionItem\` now carries the same rendered Markdown as its \`documentation\`, so the completion details panel shows the full doc instead of just \"Phel core function\".

## Tests
11 new tests in \`src/test/phelDocsLookup.test.ts\` covering:
- Lookup precedence: exact qualified > \`phel.core\` > any public > private
- Empty / missing input
- Renderer: kind labelling (function / macro / def, with private prefix), signature fence, multi-arity, missing-section omission, see-also, source link

Total suite: **110 passing** (was 99).

## Editor behaviour
- Hover on \`map\` shows: \`**\\\`phel.core/map\\\`** _function_\`, signature, docstring, example, see-also, view source.
- Completion popup details panel renders the same content.
- Multiple hover providers coexist: the existing breakpoint hover keeps working.

## Test plan
- [x] \`npm run compile\` clean.
- [x] \`npm run format:check\` clean.
- [x] \`npm run lint\` clean.
- [x] \`npm test\` - 110 passing.
- [ ] CI confirms.