### PR TITLE
feat(signature-help): signature popup with active param

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { SourceMapManager } from './sourceMapManager';
 import { PhelDebugSession } from './phelDebugAdapter';
 import { PhelCompletionProvider } from './phelCompletionProvider';
 import { PhelHoverProvider } from './phelHoverProvider';
+import { PhelSignatureHelpProvider } from './phelSignatureHelpProvider';
 
 let sourceMapManager: SourceMapManager;
 
@@ -112,6 +113,15 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(
         vscode.languages.registerHoverProvider('phel', new PhelHoverProvider())
+    );
+
+    context.subscriptions.push(
+        vscode.languages.registerSignatureHelpProvider(
+            'phel',
+            new PhelSignatureHelpProvider(),
+            '(',
+            ' '
+        )
     );
 
     // Provide hover information for breakpoints

--- a/src/phelSignatureHelp.ts
+++ b/src/phelSignatureHelp.ts
@@ -1,0 +1,250 @@
+// Pure helpers for the signature-help provider:
+//
+//   * `findCurrentCall(source, offset)` walks the text up to the cursor and
+//     returns the callee + index of the parameter the cursor is pointing at,
+//     or null if the cursor is not inside a `(callee ...)` form.
+//
+//   * `parseSignatureParams(signature)` turns `(name p1 p2 & rest)` into the
+//     parameter labels VS Code expects (`['p1', 'p2', '& rest']`).
+//
+//   * `pickActiveSignature(arities, activeArg)` chooses which arity to
+//     highlight when the form has more than one.
+//
+// Kept free of `vscode` imports so unit tests can exercise the logic without
+// loading the editor host.
+
+import type { PhelDoc } from './phelDocs';
+
+export interface CurrentCall {
+    /** Bare or qualified callee name as it appears in the source. */
+    callee: string;
+    /** Zero-based index of the parameter under the cursor. */
+    activeArg: number;
+}
+
+interface Frame {
+    kind: '(' | '[' | '{' | '"';
+    callee?: string;
+    /**
+     * For `(` frames: -1 while we are still reading the callee token,
+     * otherwise the count of completed arg tokens. For `[` / `{` frames the
+     * count is unused.
+     */
+    argIndex: number;
+    /** Whether the previous non-trivia char belonged to an arg token. */
+    inArg: boolean;
+}
+
+const DELIMS = new Set(['(', ')', '[', ']', '{', '}', '"', ';', ' ', '\t', '\n', '\r', ',']);
+
+/**
+ * Walks `source` from index 0 up to (but not including) `offset`, returns
+ * info about the innermost open `( ... )` form, or null if the cursor is at
+ * the top level (or only inside vector / map / string contexts).
+ */
+export function findCurrentCall(source: string, offset: number): CurrentCall | null {
+    const stack: Frame[] = [];
+    const limit = Math.min(offset, source.length);
+
+    let i = 0;
+    while (i < limit) {
+        const c = source[i];
+        const top = stack[stack.length - 1];
+
+        if (top?.kind === '"') {
+            if (c === '\\') {
+                i += 2;
+                continue;
+            }
+            if (c === '"') {
+                stack.pop();
+                markArg(stack[stack.length - 1]);
+                i++;
+                continue;
+            }
+            i++;
+            continue;
+        }
+
+        if (c === ';') {
+            while (i < limit && source[i] !== '\n') {
+                i++;
+            }
+            continue;
+        }
+
+        if (c === '#' && source[i + 1] === '|') {
+            i += 2;
+            while (i < limit - 1 && !(source[i] === '|' && source[i + 1] === '#')) {
+                i++;
+            }
+            i += 2;
+            continue;
+        }
+
+        if (c === '"') {
+            stack.push({ kind: '"', argIndex: 0, inArg: false });
+            i++;
+            continue;
+        }
+
+        if (c === '(' || c === '[' || c === '{') {
+            stack.push({
+                kind: c,
+                argIndex: c === '(' ? -1 : 0,
+                inArg: false,
+            });
+            i++;
+            continue;
+        }
+
+        if (c === ')' || c === ']' || c === '}') {
+            stack.pop();
+            markArg(stack[stack.length - 1]);
+            i++;
+            continue;
+        }
+
+        if (c === ' ' || c === '\t' || c === '\n' || c === '\r' || c === ',') {
+            if (top && top.inArg && top.argIndex >= 0) {
+                top.argIndex++;
+                top.inArg = false;
+            }
+            i++;
+            continue;
+        }
+
+        // Symbol / number / keyword char.
+        if (top?.kind === '(' && top.argIndex < 0) {
+            // Reading the callee token.
+            let end = i;
+            while (end < limit && !DELIMS.has(source[end])) {
+                end++;
+            }
+            top.callee = source.slice(i, end);
+            top.argIndex = 0;
+            top.inArg = false;
+            i = end;
+            continue;
+        }
+
+        if (top) {
+            top.inArg = true;
+        }
+        i++;
+    }
+
+    for (let k = stack.length - 1; k >= 0; k--) {
+        const f = stack[k];
+        if (f.kind === '(' && f.callee) {
+            return { callee: f.callee, activeArg: f.argIndex < 0 ? 0 : f.argIndex };
+        }
+    }
+    return null;
+}
+
+function markArg(frame: Frame | undefined): void {
+    if (!frame) {
+        return;
+    }
+    if (frame.kind === '(' || frame.kind === '[' || frame.kind === '{') {
+        frame.inArg = true;
+    }
+}
+
+/**
+ * Turn `(name p1 p2 & rest)` into `['p1', 'p2', '& rest']`.
+ * Returns an empty array when the body is empty or the input cannot be
+ * parsed.
+ */
+export function parseSignatureParams(signature: string): string[] {
+    const trimmed = signature.trim();
+    if (!trimmed.startsWith('(') || !trimmed.endsWith(')')) {
+        return [];
+    }
+    const inner = trimmed.slice(1, -1).trim();
+    if (!inner) {
+        return [];
+    }
+    const space = inner.indexOf(' ');
+    if (space < 0) {
+        return [];
+    }
+    const body = inner.slice(space + 1).trim();
+    if (!body) {
+        return [];
+    }
+    const tokens = body.split(/\s+/);
+    const out: string[] = [];
+    for (let i = 0; i < tokens.length; i++) {
+        if (tokens[i] === '&' && tokens[i + 1]) {
+            out.push(`& ${tokens[i + 1]}`);
+            i++;
+        } else {
+            out.push(tokens[i]);
+        }
+    }
+    return out;
+}
+
+/**
+ * Whether a parameter list ends in a Clojure-style `& rest`.
+ */
+export function hasRest(params: readonly string[]): boolean {
+    return params.length > 0 && params[params.length - 1].startsWith('&');
+}
+
+/**
+ * Clamp `activeArg` to a valid index within `params`. When the parameter
+ * list ends in `& rest`, any arg index past the rest position maps to the
+ * rest parameter. Returns -1 if there are no parameters at all.
+ */
+export function clampActiveParam(params: readonly string[], activeArg: number): number {
+    if (params.length === 0) {
+        return -1;
+    }
+    if (activeArg <= 0) {
+        return 0;
+    }
+    if (activeArg < params.length) {
+        return activeArg;
+    }
+    return hasRest(params) ? params.length - 1 : params.length - 1;
+}
+
+/**
+ * Pick which arity from a multi-arity definition best matches the active
+ * argument index. Prefers an arity whose param count strictly contains
+ * `activeArg`; falls back to the last arity (the one most likely to have a
+ * rest parameter) when none fits.
+ */
+export function pickActiveSignature(arities: readonly string[], activeArg: number): number {
+    if (arities.length === 0) {
+        return 0;
+    }
+    for (let i = 0; i < arities.length; i++) {
+        const params = parseSignatureParams(arities[i]);
+        if (activeArg < params.length) {
+            return i;
+        }
+        if (hasRest(params)) {
+            return i;
+        }
+    }
+    return arities.length - 1;
+}
+
+/**
+ * Convenience: pick all the arities for a `PhelDoc`. Always returns at least
+ * one signature when the doc is callable; returns an empty array for plain
+ * `def` forms.
+ */
+export function aritiesOf(doc: PhelDoc): string[] {
+    if (doc.arities && doc.arities.length > 0) {
+        return [...doc.arities];
+    }
+    if (doc.signature) {
+        return [doc.signature];
+    }
+    return [];
+}

--- a/src/phelSignatureHelpProvider.ts
+++ b/src/phelSignatureHelpProvider.ts
@@ -1,0 +1,55 @@
+import * as vscode from 'vscode';
+import { PHEL_DOCS } from './phelCoreDocs';
+import { lookupSymbol } from './phelDocsLookup';
+import {
+    aritiesOf,
+    clampActiveParam,
+    findCurrentCall,
+    parseSignatureParams,
+    pickActiveSignature,
+} from './phelSignatureHelp';
+
+export class PhelSignatureHelpProvider implements vscode.SignatureHelpProvider {
+    provideSignatureHelp(
+        document: vscode.TextDocument,
+        position: vscode.Position
+    ): vscode.ProviderResult<vscode.SignatureHelp> {
+        const offset = document.offsetAt(position);
+        const call = findCurrentCall(document.getText(), offset);
+        if (!call) {
+            return null;
+        }
+
+        const doc = lookupSymbol(call.callee, PHEL_DOCS);
+        if (!doc) {
+            return null;
+        }
+
+        const arities = aritiesOf(doc);
+        if (arities.length === 0) {
+            return null;
+        }
+
+        const help = new vscode.SignatureHelp();
+        help.signatures = arities.map((arity) => buildSignature(arity, doc.doc));
+        help.activeSignature = pickActiveSignature(arities, call.activeArg);
+        const params = parseSignatureParams(arities[help.activeSignature]);
+        const clamped = clampActiveParam(params, call.activeArg);
+        help.activeParameter = clamped < 0 ? 0 : clamped;
+        return help;
+    }
+}
+
+function buildSignature(signature: string, docstring?: string): vscode.SignatureInformation {
+    const info = new vscode.SignatureInformation(signature);
+    info.parameters = parseSignatureParams(signature).map(
+        (label) => new vscode.ParameterInformation(label)
+    );
+    if (docstring) {
+        const md = new vscode.MarkdownString(docstring);
+        md.isTrusted = false;
+        md.supportHtml = false;
+        info.documentation = md;
+    }
+    return info;
+}

--- a/src/test/phelSignatureHelp.test.ts
+++ b/src/test/phelSignatureHelp.test.ts
@@ -1,0 +1,168 @@
+import * as assert from 'assert';
+import {
+    findCurrentCall,
+    parseSignatureParams,
+    hasRest,
+    clampActiveParam,
+    pickActiveSignature,
+} from '../phelSignatureHelp';
+
+describe('findCurrentCall', function () {
+    function at(text: string): { source: string; offset: number } {
+        const offset = text.indexOf('|');
+        assert.ok(offset >= 0, "test text must contain a '|' marking the cursor");
+        return { source: text.replace('|', ''), offset };
+    }
+
+    it('returns null when the cursor is at the top level', function () {
+        const { source, offset } = at('|');
+        assert.strictEqual(findCurrentCall(source, offset), null);
+    });
+
+    it('reports the callee on the first arg before any space', function () {
+        const { source, offset } = at('(map |');
+        const r = findCurrentCall(source, offset);
+        assert.deepStrictEqual(r, { callee: 'map', activeArg: 0 });
+    });
+
+    it('keeps activeArg=0 while typing the first argument', function () {
+        const { source, offset } = at('(map inc|');
+        assert.deepStrictEqual(findCurrentCall(source, offset), {
+            callee: 'map',
+            activeArg: 0,
+        });
+    });
+
+    it('advances activeArg after each argument-separating space', function () {
+        const { source, offset } = at('(map inc |');
+        assert.deepStrictEqual(findCurrentCall(source, offset), {
+            callee: 'map',
+            activeArg: 1,
+        });
+    });
+
+    it('counts a finished argument the moment its closing delimiter is seen', function () {
+        const { source, offset } = at('(reduce + 0 [1 2 3] |');
+        assert.deepStrictEqual(findCurrentCall(source, offset), {
+            callee: 'reduce',
+            activeArg: 3,
+        });
+    });
+
+    it('returns the innermost call when forms are nested', function () {
+        const { source, offset } = at('(map (filter pred |xs) ys)');
+        assert.deepStrictEqual(findCurrentCall(source, offset), {
+            callee: 'filter',
+            activeArg: 1,
+        });
+    });
+
+    it('skips over strings inside arguments', function () {
+        const { source, offset } = at('(println "hello (world)" |');
+        assert.deepStrictEqual(findCurrentCall(source, offset), {
+            callee: 'println',
+            activeArg: 1,
+        });
+    });
+
+    it('skips over line comments', function () {
+        const { source, offset } = at('(reduce + ;; comment\n0 |[1 2])');
+        assert.deepStrictEqual(findCurrentCall(source, offset), {
+            callee: 'reduce',
+            activeArg: 2,
+        });
+    });
+
+    it('returns null when only inside a vector or map literal', function () {
+        const a = at('[1 2 |3]');
+        assert.strictEqual(findCurrentCall(a.source, a.offset), null);
+        const b = at('{:a |1}');
+        assert.strictEqual(findCurrentCall(b.source, b.offset), null);
+    });
+
+    it('returns null when nothing has been typed after the open paren', function () {
+        const { source, offset } = at('(|');
+        assert.strictEqual(findCurrentCall(source, offset), null);
+    });
+
+    it('handles qualified callees', function () {
+        const { source, offset } = at('(phel.test/is |x)');
+        assert.deepStrictEqual(findCurrentCall(source, offset), {
+            callee: 'phel.test/is',
+            activeArg: 0,
+        });
+    });
+});
+
+describe('parseSignatureParams', function () {
+    it('splits a flat parameter list', function () {
+        assert.deepStrictEqual(parseSignatureParams('(assoc m k v)'), ['m', 'k', 'v']);
+    });
+
+    it('glues `&` to the rest parameter', function () {
+        assert.deepStrictEqual(parseSignatureParams('(map f & xs)'), ['f', '& xs']);
+    });
+
+    it('returns an empty list when the form has no parameters', function () {
+        assert.deepStrictEqual(parseSignatureParams('(now)'), []);
+    });
+
+    it('returns an empty list for malformed input', function () {
+        assert.deepStrictEqual(parseSignatureParams('not a signature'), []);
+    });
+});
+
+describe('hasRest', function () {
+    it('returns true when the last param starts with `&`', function () {
+        assert.strictEqual(hasRest(['f', '& xs']), true);
+    });
+
+    it('returns false otherwise', function () {
+        assert.strictEqual(hasRest(['m', 'k', 'v']), false);
+        assert.strictEqual(hasRest([]), false);
+    });
+});
+
+describe('clampActiveParam', function () {
+    it('returns -1 when there are no params', function () {
+        assert.strictEqual(clampActiveParam([], 0), -1);
+    });
+
+    it('clamps negative input to 0', function () {
+        assert.strictEqual(clampActiveParam(['a', 'b'], -3), 0);
+    });
+
+    it('returns the index unchanged when in range', function () {
+        assert.strictEqual(clampActiveParam(['a', 'b', 'c'], 1), 1);
+    });
+
+    it('routes overflow to the rest parameter when present', function () {
+        assert.strictEqual(clampActiveParam(['f', '& xs'], 7), 1);
+    });
+
+    it('clamps overflow to the last param when no rest exists', function () {
+        assert.strictEqual(clampActiveParam(['a', 'b'], 5), 1);
+    });
+});
+
+describe('pickActiveSignature', function () {
+    it('returns 0 when there is a single arity', function () {
+        assert.strictEqual(pickActiveSignature(['(foo a b)'], 1), 0);
+    });
+
+    it('picks the first arity that contains the active arg', function () {
+        const arities = ['(foo)', '(foo a)', '(foo a b)'];
+        assert.strictEqual(pickActiveSignature(arities, 0), 1);
+        assert.strictEqual(pickActiveSignature(arities, 1), 2);
+    });
+
+    it('falls back to a rest-arity when no fixed arity fits', function () {
+        const arities = ['(foo a)', '(foo a & rest)'];
+        assert.strictEqual(pickActiveSignature(arities, 4), 1);
+    });
+
+    it('returns the last arity when nothing fits and no rest exists', function () {
+        const arities = ['(foo)', '(foo a)'];
+        assert.strictEqual(pickActiveSignature(arities, 5), 1);
+    });
+});


### PR DESCRIPTION
PR3 of the rolling roadmap. Reads from the docs DB shipped in #27 / hover layer in #28.

## What
- **\`src/phelSignatureHelp.ts\`** (pure): tokenless walker that returns the innermost open \`(callee ...)\` form and the index of the parameter under the cursor. Helpers for splitting signatures into params, detecting rest args, clamping overflow, and choosing which arity to highlight.
- **\`src/phelSignatureHelpProvider.ts\`**: \`SignatureHelpProvider\` that ties the walker, the docs DB, and \`vscode.SignatureInformation\` together. Triggers on \`(\` and \` \`.

## Tests
26 new tests in \`src/test/phelSignatureHelp.test.ts\`. Coverage:
- Cursor at top level / inside vector / inside map: returns null
- Cursor right after \`(callee\` / mid-arg / between args
- Nested calls: returns the innermost
- Strings and \`;\` / \`#| |#\` comments: do not advance the arg counter
- Qualified callees (\`phel.test/is\`)
- Multi-arity selection: picks the arity whose param count fits
- Rest-arg overflow: routes to \`& xs\`
- \`parseSignatureParams\`: empty / malformed input

Total suite: **136 passing** (was 110).

## Editor behaviour
- Type \`(reduce \` -> popup shows \`(reduce f & xs)\` with \`f\` highlighted.
- Type the second arg -> highlight moves to \`& xs\` (rest).
- Multi-arity forms expose all variants with up/down arrows.

## Test plan
- [x] \`npm run compile\` clean.
- [x] \`npm run format:check\` clean.
- [x] \`npm run lint\` clean.
- [x] \`npm test\` - 136 passing.