### PR TITLE
feat(show-doc): Phel: Show Documentation command

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,6 +184,11 @@
             {
                 "command": "phel.clearSourceMapCache",
                 "title": "Phel: Clear Source Map Cache"
+            },
+            {
+                "command": "phel.showDoc",
+                "title": "Phel: Show Documentation",
+                "category": "Phel"
             }
         ],
         "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,9 @@ import { PhelDebugSession } from './phelDebugAdapter';
 import { PhelCompletionProvider } from './phelCompletionProvider';
 import { PhelHoverProvider } from './phelHoverProvider';
 import { PhelSignatureHelpProvider } from './phelSignatureHelpProvider';
+import { PHEL_DOCS } from './phelCoreDocs';
+import { lookupSymbol, renderDocMarkdown } from './phelDocsLookup';
+import { buildQuickPickEntries } from './phelShowDoc';
 
 let sourceMapManager: SourceMapManager;
 
@@ -87,6 +90,13 @@ export function activate(context: vscode.ExtensionContext) {
         })
     );
 
+    // Register command: Show Phel documentation
+    context.subscriptions.push(
+        vscode.commands.registerCommand('phel.showDoc', async (symbol?: string) => {
+            await runShowDocCommand(symbol);
+        })
+    );
+
     // Watch for configuration changes
     context.subscriptions.push(
         vscode.workspace.onDidChangeConfiguration((e) => {
@@ -157,6 +167,59 @@ export function activate(context: vscode.ExtensionContext) {
 
 export function deactivate() {
     // Cleanup
+}
+
+/**
+ * Resolve a symbol (from arg, cursor, or quick-pick) and show its docs in
+ * a Markdown preview tab.
+ */
+async function runShowDocCommand(symbolArg?: string): Promise<void> {
+    let symbol = symbolArg ?? wordAtCursor();
+    if (!symbol || !lookupSymbol(symbol, PHEL_DOCS)) {
+        symbol = await pickSymbol();
+        if (!symbol) {
+            return;
+        }
+    }
+    const doc = lookupSymbol(symbol, PHEL_DOCS);
+    if (!doc) {
+        vscode.window.showWarningMessage(`No Phel documentation found for "${symbol}".`);
+        return;
+    }
+    const markdown = renderDocMarkdown(doc);
+    const tdoc = await vscode.workspace.openTextDocument({
+        content: markdown,
+        language: 'markdown',
+    });
+    await vscode.commands.executeCommand('markdown.showPreview', tdoc.uri);
+}
+
+function wordAtCursor(): string | undefined {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'phel') {
+        return undefined;
+    }
+    const range = editor.document.getWordRangeAtPosition(
+        editor.selection.active,
+        /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/
+    );
+    return range ? editor.document.getText(range) : undefined;
+}
+
+async function pickSymbol(): Promise<string | undefined> {
+    const entries = buildQuickPickEntries(PHEL_DOCS);
+    const items = entries.map((e) => ({
+        label: e.label,
+        description: e.description,
+        detail: e.detail,
+        qualifiedName: e.doc.qualifiedName,
+    }));
+    const picked = await vscode.window.showQuickPick(items, {
+        placeHolder: 'Phel symbol (start typing to filter)',
+        matchOnDescription: true,
+        matchOnDetail: true,
+    });
+    return picked?.qualifiedName;
 }
 
 /**

--- a/src/phelShowDoc.ts
+++ b/src/phelShowDoc.ts
@@ -1,0 +1,81 @@
+// Pure helpers for the `Phel: Show Doc` command. Builds quick-pick items
+// from the docs DB so the command can offer search-and-show without doing
+// any VS Code-specific work in this module.
+
+import type { PhelDoc } from './phelDocs';
+
+export interface QuickPickEntry {
+    /** Label shown on the left of the quick-pick row. */
+    label: string;
+    /** Description shown next to the label, e.g. the signature. */
+    description: string;
+    /** Detail line shown beneath, typically the first line of the docstring. */
+    detail: string;
+    /** Underlying doc record so the command can render it. */
+    doc: PhelDoc;
+}
+
+/**
+ * Build quick-pick entries from a docs corpus. Excludes private symbols by
+ * default. Sort order: `phel.core` first (it is the auto-imported namespace
+ * users hit most), then alphabetical by qualified name.
+ */
+export function buildQuickPickEntries(
+    docs: readonly PhelDoc[],
+    options: { includePrivate?: boolean } = {}
+): QuickPickEntry[] {
+    const { includePrivate = false } = options;
+    const filtered = includePrivate ? docs : docs.filter((d) => !d.private);
+    const sorted = [...filtered].sort(compareDocs);
+    return sorted.map(toEntry);
+}
+
+function compareDocs(a: PhelDoc, b: PhelDoc): number {
+    if (a.ns === b.ns) {
+        return a.name.localeCompare(b.name);
+    }
+    if (a.ns === 'phel.core') {
+        return -1;
+    }
+    if (b.ns === 'phel.core') {
+        return 1;
+    }
+    return a.qualifiedName.localeCompare(b.qualifiedName);
+}
+
+function toEntry(doc: PhelDoc): QuickPickEntry {
+    return {
+        label: doc.name,
+        description: descriptionFor(doc),
+        detail: detailFor(doc),
+        doc,
+    };
+}
+
+function descriptionFor(doc: PhelDoc): string {
+    const parts: string[] = [doc.ns];
+    if (doc.signature) {
+        parts.push(doc.signature);
+    }
+    return parts.join(' · ');
+}
+
+function detailFor(doc: PhelDoc): string {
+    if (!doc.doc) {
+        return kindLabel(doc);
+    }
+    const firstLine = doc.doc.split(/\r?\n/, 1)[0].trim();
+    return firstLine.length > 0 ? firstLine : kindLabel(doc);
+}
+
+function kindLabel(doc: PhelDoc): string {
+    const visibility = doc.private ? 'private ' : '';
+    switch (doc.kind) {
+        case 'fn':
+            return `${visibility}function`;
+        case 'macro':
+            return `${visibility}macro`;
+        case 'def':
+            return `${visibility}def`;
+    }
+}

--- a/src/test/phelShowDoc.test.ts
+++ b/src/test/phelShowDoc.test.ts
@@ -1,0 +1,102 @@
+import * as assert from 'assert';
+import type { PhelDoc } from '../phelDocs';
+import { buildQuickPickEntries } from '../phelShowDoc';
+
+const corpus: PhelDoc[] = [
+    {
+        name: 'b-public',
+        ns: 'phel.misc',
+        qualifiedName: 'phel.misc/b-public',
+        kind: 'fn',
+        private: false,
+        signature: '(b-public x)',
+        doc: 'A public misc helper.\nMore detail on next line.',
+    },
+    {
+        name: 'a-public',
+        ns: 'phel.misc',
+        qualifiedName: 'phel.misc/a-public',
+        kind: 'macro',
+        private: false,
+        signature: '(a-public form)',
+    },
+    {
+        name: 'private-thing',
+        ns: 'phel.misc',
+        qualifiedName: 'phel.misc/private-thing',
+        kind: 'fn',
+        private: true,
+        signature: '(private-thing)',
+    },
+    {
+        name: 'assoc',
+        ns: 'phel.core',
+        qualifiedName: 'phel.core/assoc',
+        kind: 'fn',
+        private: false,
+        signature: '(assoc m k v)',
+        doc: 'Associates.',
+    },
+    {
+        name: 'map',
+        ns: 'phel.core',
+        qualifiedName: 'phel.core/map',
+        kind: 'fn',
+        private: false,
+        signature: '(map f & xs)',
+    },
+];
+
+describe('buildQuickPickEntries', function () {
+    it('excludes private symbols by default', function () {
+        const entries = buildQuickPickEntries(corpus);
+        assert.ok(!entries.some((e) => e.doc.private), 'no private entries should leak through');
+    });
+
+    it('includes private symbols when explicitly requested', function () {
+        const entries = buildQuickPickEntries(corpus, { includePrivate: true });
+        assert.ok(entries.some((e) => e.doc.qualifiedName === 'phel.misc/private-thing'));
+    });
+
+    it('sorts phel.core symbols ahead of every other namespace', function () {
+        const entries = buildQuickPickEntries(corpus);
+        const namespaces = entries.map((e) => e.doc.ns);
+        const firstNonCore = namespaces.findIndex((n) => n !== 'phel.core');
+        const lastCore = namespaces.lastIndexOf('phel.core');
+        assert.ok(lastCore < firstNonCore, 'all phel.core entries should come first');
+    });
+
+    it('sorts alphabetically within a namespace', function () {
+        const entries = buildQuickPickEntries(corpus);
+        const miscNames = entries.filter((e) => e.doc.ns === 'phel.misc').map((e) => e.doc.name);
+        assert.deepStrictEqual(miscNames, [...miscNames].sort());
+    });
+
+    it('puts the namespace and signature in the description', function () {
+        const entries = buildQuickPickEntries(corpus);
+        const map = entries.find((e) => e.doc.qualifiedName === 'phel.core/map');
+        assert.ok(map);
+        assert.strictEqual(map!.description, 'phel.core · (map f & xs)');
+    });
+
+    it('uses the first docstring line as the detail', function () {
+        const entries = buildQuickPickEntries(corpus);
+        const bPublic = entries.find((e) => e.doc.qualifiedName === 'phel.misc/b-public');
+        assert.ok(bPublic);
+        assert.strictEqual(bPublic!.detail, 'A public misc helper.');
+    });
+
+    it('falls back to the kind label when no docstring is available', function () {
+        const entries = buildQuickPickEntries(corpus);
+        const aPublic = entries.find((e) => e.doc.qualifiedName === 'phel.misc/a-public');
+        assert.ok(aPublic);
+        assert.strictEqual(aPublic!.detail, 'macro');
+    });
+
+    it('preserves the underlying doc on each entry', function () {
+        const entries = buildQuickPickEntries(corpus);
+        for (const e of entries) {
+            assert.strictEqual(typeof e.doc.qualifiedName, 'string');
+        }
+    });
+});


### PR DESCRIPTION
PR4 of the rolling roadmap. Reuses the docs DB (#27) and the markdown renderer (#28).

## What
- **\`Phel: Show Documentation\`** command. With no arg, prefers the symbol under the cursor (when an editor with language \`phel\` is active); if nothing resolves, falls back to a quick-pick over every public symbol.
- The selected doc is rendered with the same \`renderDocMarkdown\` used by the hover layer, written into a virtual markdown document, and shown via VS Code's \`markdown.showPreview\`.
- **\`src/phelShowDoc.ts\`** (pure): \`buildQuickPickEntries(docs)\` returns UI rows. \`phel.core\` symbols are listed first; remaining namespaces sort alphabetically; within a namespace, names are alphabetical. Description shows \`<ns> · <signature>\`; detail shows the first docstring line (or the kind label when no docstring exists).
- \`package.json\`: command registered in the palette.

## Tests
8 new tests in \`src/test/phelShowDoc.test.ts\`: private filter (default vs \`includePrivate: true\`), ordering (\`phel.core\` first), per-namespace alphabetical sort, description format, docstring-first-line vs kind-label fallback, doc reference preserved.

Total suite: **144 passing** (was 136).

## Editor behaviour
- Command palette -> \`Phel: Show Documentation\` -> if cursor is on a known symbol, opens its docs immediately; else quick-pick.
- Quick-pick is searchable across name, namespace, signature, and detail.
- Result opens as a Markdown preview tab.

## Test plan
- [x] \`npm run compile\` clean.
- [x] \`npm run format:check\` clean.
- [x] \`npm run lint\` clean.
- [x] \`npm test\` - 144 passing.