### PR TITLE
feat(diagnostics): inline diagnostics from `phel analyze`

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,6 +203,16 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Enable Phel debug adapter for source-level debugging"
+                },
+                "phel.diagnostics.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Run `phel analyze` on save and surface the result as inline diagnostics."
+                },
+                "phel.diagnostics.command": {
+                    "type": "string",
+                    "default": "vendor/bin/phel",
+                    "description": "Path to the Phel CLI used for diagnostics. Relative paths resolve against the workspace folder."
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { PhelSignatureHelpProvider } from './phelSignatureHelpProvider';
 import { PHEL_DOCS } from './phelCoreDocs';
 import { lookupSymbol, renderDocMarkdown } from './phelDocsLookup';
 import { buildQuickPickEntries } from './phelShowDoc';
+import { registerDiagnostics } from './phelDiagnosticsProvider';
 
 let sourceMapManager: SourceMapManager;
 
@@ -133,6 +134,8 @@ export function activate(context: vscode.ExtensionContext) {
             ' '
         )
     );
+
+    registerDiagnostics(context);
 
     // Provide hover information for breakpoints
     context.subscriptions.push(

--- a/src/phelDiagnostics.ts
+++ b/src/phelDiagnostics.ts
@@ -1,0 +1,158 @@
+// Pure helpers for the diagnostics-on-save provider:
+//
+// `phel analyze <file>` prints a JSON array of diagnostic objects on stdout.
+// `parsePhelAnalyzeOutput` turns that into a typed list, tolerating noise
+// (banner / trailing newline / non-JSON pre-amble) by walking forward to the
+// first `[` that opens a valid JSON array. Each entry is normalised so the
+// VS Code provider can map it to `vscode.Diagnostic` without further parsing.
+//
+// Kept free of `vscode` imports to make unit testing straightforward.
+
+export type PhelSeverity = 'error' | 'warning' | 'info' | 'hint';
+
+export interface PhelDiagnostic {
+    /** Phel diagnostic code, e.g. `"PHEL001"`. */
+    code?: string;
+    /** Severity bucket. Unknown values fall through as `"info"`. */
+    severity: PhelSeverity;
+    /** Human-readable message. */
+    message: string;
+    /** Absolute path of the offending file (as reported by phel). */
+    uri?: string;
+    /** 1-based line number where the diagnostic starts. */
+    startLine: number;
+    /** 1-based column number where the diagnostic starts. */
+    startCol: number;
+    /** 1-based line number where the diagnostic ends. */
+    endLine: number;
+    /** 1-based column number where the diagnostic ends. */
+    endCol: number;
+}
+
+/**
+ * Parse the stdout of `phel analyze`. Returns an empty array when the file
+ * has no issues (phel emits `[]`). When the output cannot be parsed as JSON
+ * the function returns an empty array rather than throwing - the caller
+ * usually wants to drop the diagnostics silently and try again on the next
+ * save.
+ */
+export function parsePhelAnalyzeOutput(stdout: string): PhelDiagnostic[] {
+    const trimmed = stdout.trim();
+    if (!trimmed) {
+        return [];
+    }
+
+    const start = trimmed.indexOf('[');
+    if (start < 0) {
+        return [];
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(trimmed.slice(start));
+    } catch {
+        return [];
+    }
+
+    if (!Array.isArray(parsed)) {
+        return [];
+    }
+
+    const out: PhelDiagnostic[] = [];
+    for (const raw of parsed) {
+        const diag = normaliseEntry(raw);
+        if (diag) {
+            out.push(diag);
+        }
+    }
+    return out;
+}
+
+function normaliseEntry(raw: unknown): PhelDiagnostic | null {
+    if (!raw || typeof raw !== 'object') {
+        return null;
+    }
+    const r = raw as Record<string, unknown>;
+
+    const message = typeof r.message === 'string' ? r.message : null;
+    if (!message) {
+        return null;
+    }
+
+    const startLine = toFiniteInt(r.startLine);
+    const startCol = toFiniteInt(r.startCol);
+    if (startLine === null || startCol === null) {
+        return null;
+    }
+
+    const endLine = toFiniteInt(r.endLine) ?? startLine;
+    const endCol = toFiniteInt(r.endCol) ?? startCol;
+
+    const diag: PhelDiagnostic = {
+        message,
+        severity: toSeverity(r.severity),
+        startLine,
+        startCol,
+        endLine,
+        endCol,
+    };
+    if (typeof r.code === 'string' && r.code) {
+        diag.code = r.code;
+    }
+    if (typeof r.uri === 'string' && r.uri) {
+        diag.uri = r.uri;
+    }
+    return diag;
+}
+
+function toFiniteInt(value: unknown): number | null {
+    if (typeof value !== 'number') {
+        return null;
+    }
+    if (!Number.isFinite(value)) {
+        return null;
+    }
+    return Math.trunc(value);
+}
+
+function toSeverity(value: unknown): PhelSeverity {
+    if (typeof value !== 'string') {
+        return 'info';
+    }
+    switch (value.toLowerCase()) {
+        case 'error':
+            return 'error';
+        case 'warning':
+        case 'warn':
+            return 'warning';
+        case 'info':
+        case 'note':
+            return 'info';
+        case 'hint':
+            return 'hint';
+        default:
+            return 'info';
+    }
+}
+
+/**
+ * Convert a 1-based phel diagnostic to the half-open 0-based range
+ * VS Code uses. `endCol` is treated as exclusive in the output (matching
+ * `phel analyze`'s convention where it points one past the last char).
+ */
+export function toZeroBasedRange(diag: PhelDiagnostic): {
+    startLine: number;
+    startCol: number;
+    endLine: number;
+    endCol: number;
+} {
+    const startLine = Math.max(0, diag.startLine - 1);
+    const startCol = Math.max(0, diag.startCol - 1);
+    const endLine = Math.max(startLine, diag.endLine - 1);
+    let endCol = Math.max(0, diag.endCol - 1);
+    if (endLine === startLine && endCol <= startCol) {
+        // Empty range — VS Code prefers a 1-char wide marker for visibility.
+        endCol = startCol + 1;
+    }
+    return { startLine, startCol, endLine, endCol };
+}

--- a/src/phelDiagnosticsProvider.ts
+++ b/src/phelDiagnosticsProvider.ts
@@ -1,0 +1,123 @@
+import { execFile } from 'node:child_process';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import { parsePhelAnalyzeOutput, toZeroBasedRange, PhelDiagnostic } from './phelDiagnostics';
+
+const COLLECTION_NAME = 'phel';
+
+/**
+ * Runs `phel analyze <file>` on every `.phel` open / save and surfaces the
+ * results as VS Code diagnostics.
+ *
+ * Configuration:
+ *   - `phel.diagnostics.enabled` (default `true`)
+ *   - `phel.diagnostics.command` (default `vendor/bin/phel`, resolved
+ *     relative to the workspace folder when not absolute)
+ */
+export function registerDiagnostics(context: vscode.ExtensionContext): void {
+    const collection = vscode.languages.createDiagnosticCollection(COLLECTION_NAME);
+    context.subscriptions.push(collection);
+
+    const runForDocument = (document: vscode.TextDocument) => {
+        if (document.languageId !== 'phel') {
+            return;
+        }
+        if (!isEnabled()) {
+            collection.delete(document.uri);
+            return;
+        }
+        const command = resolveCommand(document.uri);
+        if (!command) {
+            return;
+        }
+        analyzeFile(command, document.uri.fsPath)
+            .then((diagnostics) => {
+                collection.set(document.uri, toVscodeDiagnostics(diagnostics));
+            })
+            .catch((err) => {
+                console.error(`phel analyze failed for ${document.uri.fsPath}:`, err);
+                collection.delete(document.uri);
+            });
+    };
+
+    context.subscriptions.push(
+        vscode.workspace.onDidOpenTextDocument(runForDocument),
+        vscode.workspace.onDidSaveTextDocument(runForDocument),
+        vscode.workspace.onDidCloseTextDocument((doc) => collection.delete(doc.uri)),
+        vscode.workspace.onDidChangeConfiguration((e) => {
+            if (
+                e.affectsConfiguration('phel.diagnostics.enabled') ||
+                e.affectsConfiguration('phel.diagnostics.command')
+            ) {
+                collection.clear();
+                vscode.workspace.textDocuments.forEach(runForDocument);
+            }
+        })
+    );
+
+    vscode.workspace.textDocuments.forEach(runForDocument);
+}
+
+function isEnabled(): boolean {
+    return vscode.workspace.getConfiguration('phel').get<boolean>('diagnostics.enabled', true);
+}
+
+function resolveCommand(fileUri: vscode.Uri): string | null {
+    const config = vscode.workspace
+        .getConfiguration('phel')
+        .get<string>('diagnostics.command', 'vendor/bin/phel');
+    if (!config) {
+        return null;
+    }
+    if (path.isAbsolute(config)) {
+        return config;
+    }
+    const folder = vscode.workspace.getWorkspaceFolder(fileUri);
+    return folder ? path.join(folder.uri.fsPath, config) : config;
+}
+
+function analyzeFile(command: string, filePath: string): Promise<PhelDiagnostic[]> {
+    return new Promise((resolve, reject) => {
+        execFile(
+            command,
+            ['analyze', filePath],
+            { maxBuffer: 8 * 1024 * 1024 },
+            (err, stdout, stderr) => {
+                if (err && !stdout) {
+                    reject(new Error(stderr || err.message));
+                    return;
+                }
+                resolve(parsePhelAnalyzeOutput(stdout));
+            }
+        );
+    });
+}
+
+function toVscodeDiagnostics(diagnostics: PhelDiagnostic[]): vscode.Diagnostic[] {
+    return diagnostics.map((diag) => {
+        const r = toZeroBasedRange(diag);
+        const range = new vscode.Range(
+            new vscode.Position(r.startLine, r.startCol),
+            new vscode.Position(r.endLine, r.endCol)
+        );
+        const item = new vscode.Diagnostic(range, diag.message, mapSeverity(diag.severity));
+        if (diag.code) {
+            item.code = diag.code;
+        }
+        item.source = COLLECTION_NAME;
+        return item;
+    });
+}
+
+function mapSeverity(severity: PhelDiagnostic['severity']): vscode.DiagnosticSeverity {
+    switch (severity) {
+        case 'error':
+            return vscode.DiagnosticSeverity.Error;
+        case 'warning':
+            return vscode.DiagnosticSeverity.Warning;
+        case 'info':
+            return vscode.DiagnosticSeverity.Information;
+        case 'hint':
+            return vscode.DiagnosticSeverity.Hint;
+    }
+}

--- a/src/test/phelDiagnostics.test.ts
+++ b/src/test/phelDiagnostics.test.ts
@@ -1,0 +1,131 @@
+import * as assert from 'assert';
+import { parsePhelAnalyzeOutput, toZeroBasedRange, PhelDiagnostic } from '../phelDiagnostics';
+
+describe('parsePhelAnalyzeOutput', function () {
+    it('returns an empty array for an empty string', function () {
+        assert.deepStrictEqual(parsePhelAnalyzeOutput(''), []);
+        assert.deepStrictEqual(parsePhelAnalyzeOutput('   \n  '), []);
+    });
+
+    it('returns an empty array when phel reports no issues', function () {
+        assert.deepStrictEqual(parsePhelAnalyzeOutput('[]\n'), []);
+    });
+
+    it('parses one diagnostic with all fields', function () {
+        const output = JSON.stringify([
+            {
+                code: 'PHEL001',
+                severity: 'error',
+                message: "Cannot resolve symbol 'foo'.",
+                uri: '/tmp/file.phel',
+                startLine: 12,
+                startCol: 36,
+                endLine: 12,
+                endCol: 40,
+            },
+        ]);
+        const [diag] = parsePhelAnalyzeOutput(output);
+        assert.strictEqual(diag.code, 'PHEL001');
+        assert.strictEqual(diag.severity, 'error');
+        assert.strictEqual(diag.message, "Cannot resolve symbol 'foo'.");
+        assert.strictEqual(diag.uri, '/tmp/file.phel');
+        assert.strictEqual(diag.startLine, 12);
+        assert.strictEqual(diag.startCol, 36);
+        assert.strictEqual(diag.endLine, 12);
+        assert.strictEqual(diag.endCol, 40);
+    });
+
+    it('drops entries that lack a message or numeric start position', function () {
+        const output = JSON.stringify([
+            { severity: 'error', startLine: 1, startCol: 1, endLine: 1, endCol: 2 }, // no message
+            { message: 'no start cols', severity: 'error' },
+            {
+                message: 'good',
+                severity: 'error',
+                startLine: 1,
+                startCol: 1,
+                endLine: 1,
+                endCol: 5,
+            },
+        ]);
+        const out = parsePhelAnalyzeOutput(output);
+        assert.strictEqual(out.length, 1);
+        assert.strictEqual(out[0].message, 'good');
+    });
+
+    it('falls back to startLine/startCol when end positions are missing', function () {
+        const output = JSON.stringify([
+            { message: 'no end', severity: 'error', startLine: 5, startCol: 7 },
+        ]);
+        const [diag] = parsePhelAnalyzeOutput(output);
+        assert.strictEqual(diag.endLine, 5);
+        assert.strictEqual(diag.endCol, 7);
+    });
+
+    it('normalises severity strings and maps unknown values to "info"', function () {
+        const output = JSON.stringify([
+            { message: 'a', severity: 'ERROR', startLine: 1, startCol: 1, endLine: 1, endCol: 2 },
+            { message: 'b', severity: 'warn', startLine: 1, startCol: 1, endLine: 1, endCol: 2 },
+            { message: 'c', severity: 'note', startLine: 1, startCol: 1, endLine: 1, endCol: 2 },
+            { message: 'd', severity: 'mystery', startLine: 1, startCol: 1, endLine: 1, endCol: 2 },
+            { message: 'e', startLine: 1, startCol: 1, endLine: 1, endCol: 2 },
+        ]);
+        const sevs = parsePhelAnalyzeOutput(output).map((d) => d.severity);
+        assert.deepStrictEqual(sevs, ['error', 'warning', 'info', 'info', 'info']);
+    });
+
+    it('skips a non-JSON pre-amble before the array', function () {
+        const output =
+            'Phel CLI banner you can ignore\n' +
+            JSON.stringify([
+                {
+                    message: 'late',
+                    severity: 'error',
+                    startLine: 2,
+                    startCol: 3,
+                    endLine: 2,
+                    endCol: 4,
+                },
+            ]);
+        const out = parsePhelAnalyzeOutput(output);
+        assert.strictEqual(out.length, 1);
+        assert.strictEqual(out[0].message, 'late');
+    });
+
+    it('returns [] when the JSON is malformed', function () {
+        assert.deepStrictEqual(parsePhelAnalyzeOutput('[ {garbage'), []);
+    });
+
+    it('returns [] when the JSON is not an array', function () {
+        assert.deepStrictEqual(parsePhelAnalyzeOutput('{"message":"oops"}'), []);
+    });
+});
+
+describe('toZeroBasedRange', function () {
+    function diag(overrides: Partial<PhelDiagnostic> = {}): PhelDiagnostic {
+        return {
+            message: 'msg',
+            severity: 'error',
+            startLine: 1,
+            startCol: 1,
+            endLine: 1,
+            endCol: 2,
+            ...overrides,
+        };
+    }
+
+    it('translates to half-open zero-based positions', function () {
+        const r = toZeroBasedRange(diag({ startLine: 12, startCol: 36, endLine: 12, endCol: 40 }));
+        assert.deepStrictEqual(r, { startLine: 11, startCol: 35, endLine: 11, endCol: 39 });
+    });
+
+    it('expands a zero-width range so VS Code shows a marker', function () {
+        const r = toZeroBasedRange(diag({ startLine: 5, startCol: 7, endLine: 5, endCol: 7 }));
+        assert.deepStrictEqual(r, { startLine: 4, startCol: 6, endLine: 4, endCol: 7 });
+    });
+
+    it('clamps negative phel positions to zero', function () {
+        const r = toZeroBasedRange(diag({ startLine: 0, startCol: 0, endLine: 0, endCol: 0 }));
+        assert.deepStrictEqual(r, { startLine: 0, startCol: 0, endLine: 0, endCol: 1 });
+    });
+});


### PR DESCRIPTION
PR5 of the rolling roadmap. Last item from your "v0.6 - v0.9" list.

## What
- **\`src/phelDiagnostics.ts\`** (pure):
  - \`parsePhelAnalyzeOutput(stdout)\` tolerates a non-JSON banner before the array, returns \`[]\` on malformed JSON, drops entries missing \`message\` or numeric start positions, and normalises severity strings (\`warn\` -> warning, \`ERROR\` -> error, \`note\` -> info, anything unknown -> info).
  - \`toZeroBasedRange\` converts phel's 1-based half-open columns to the 0-based half-open positions VS Code expects, with a 1-char widening for zero-width ranges so the marker stays visible.
- **\`src/phelDiagnosticsProvider.ts\`**: \`registerDiagnostics()\` creates a \`phel\` \`DiagnosticCollection\` and, on every \`.phel\` open / save, shells \`phel analyze <file>\` and surfaces the result. Honours the new settings.
- **\`package.json\`**: registers two settings.
  - \`phel.diagnostics.enabled\` (default \`true\`)
  - \`phel.diagnostics.command\` (default \`vendor/bin/phel\`, relative paths resolve against the workspace folder)

## Tests
12 new tests in \`src/test/phelDiagnostics.test.ts\`: empty / array / full / missing-field / severity-normalisation / pre-amble / malformed JSON / non-array payload / range translation / zero-width widening / negative clamp.

Total suite: **156 passing** (was 144).

## Editor behaviour
- Open or save a \`.phel\` file -> errors / warnings appear inline with the same code (\`PHEL001\`, ...) the CLI emits.
- \`code\`, \`source: 'phel'\`, and \`severity\` are preserved so VS Code's Problems panel groups things sensibly.
- Disabling the setting clears all diagnostics live.

## Test plan
- [x] \`npm run compile\` clean.
- [x] \`npm run format:check\` clean.
- [x] \`npm run lint\` clean.
- [x] \`npm test\` - 156 passing.