### PR TITLE
feat(format): document formatter via `phel format`

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,6 +213,16 @@
                     "type": "string",
                     "default": "vendor/bin/phel",
                     "description": "Path to the Phel CLI used for diagnostics. Relative paths resolve against the workspace folder."
+                },
+                "phel.format.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Use `phel format` as the document formatter for .phel files."
+                },
+                "phel.format.command": {
+                    "type": "string",
+                    "default": "vendor/bin/phel",
+                    "description": "Path to the Phel CLI used for formatting. Relative paths resolve against the workspace folder."
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { PHEL_DOCS } from './phelCoreDocs';
 import { lookupSymbol, renderDocMarkdown } from './phelDocsLookup';
 import { buildQuickPickEntries } from './phelShowDoc';
 import { registerDiagnostics } from './phelDiagnosticsProvider';
+import { PhelFormatProvider } from './phelFormatProvider';
 
 let sourceMapManager: SourceMapManager;
 
@@ -136,6 +137,10 @@ export function activate(context: vscode.ExtensionContext) {
     );
 
     registerDiagnostics(context);
+
+    context.subscriptions.push(
+        vscode.languages.registerDocumentFormattingEditProvider('phel', new PhelFormatProvider())
+    );
 
     // Provide hover information for breakpoints
     context.subscriptions.push(

--- a/src/phelFormat.ts
+++ b/src/phelFormat.ts
@@ -1,0 +1,54 @@
+// Pure helpers for the format-on-save provider. The provider itself shells
+// `phel format` against a temp file (the CLI does not yet read from stdin),
+// so the only logic worth unit-testing here is the decision of whether to
+// emit an edit and the line/column conversion.
+
+export interface FormatRange {
+    /** 0-based line where the edit starts. */
+    startLine: number;
+    /** 0-based column where the edit starts. */
+    startCol: number;
+    /** 0-based line where the edit ends. */
+    endLine: number;
+    /** 0-based column where the edit ends. */
+    endCol: number;
+}
+
+export interface FormatEdit {
+    range: FormatRange;
+    newText: string;
+}
+
+/**
+ * Returns a single full-document replace edit when `formatted` differs from
+ * `original`, or an empty array when the two are identical.
+ *
+ * The range covers the whole document, expressed via the line/column of the
+ * last character: `{0:0 .. lastLine:lastCol}`. The provider passes that to
+ * `vscode.Range` / `vscode.TextEdit.replace`.
+ */
+export function buildFormatEdits(original: string, formatted: string): FormatEdit[] {
+    if (original === formatted) {
+        return [];
+    }
+    return [
+        {
+            range: rangeOfDocument(original),
+            newText: formatted,
+        },
+    ];
+}
+
+/**
+ * Compute a line/column range that spans the entire `text`. An empty
+ * document collapses to `{0:0 .. 0:0}`.
+ */
+export function rangeOfDocument(text: string): FormatRange {
+    if (text.length === 0) {
+        return { startLine: 0, startCol: 0, endLine: 0, endCol: 0 };
+    }
+    const lines = text.split('\n');
+    const endLine = lines.length - 1;
+    const endCol = lines[endLine].length;
+    return { startLine: 0, startCol: 0, endLine, endCol };
+}

--- a/src/phelFormatProvider.ts
+++ b/src/phelFormatProvider.ts
@@ -1,0 +1,86 @@
+import { execFile } from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import { buildFormatEdits } from './phelFormat';
+
+export class PhelFormatProvider implements vscode.DocumentFormattingEditProvider {
+    async provideDocumentFormattingEdits(
+        document: vscode.TextDocument,
+        _options: vscode.FormattingOptions,
+        token: vscode.CancellationToken
+    ): Promise<vscode.TextEdit[]> {
+        if (!isEnabled()) {
+            return [];
+        }
+        const command = resolveCommand(document.uri);
+        if (!command) {
+            return [];
+        }
+
+        const original = document.getText();
+        try {
+            const formatted = await formatViaCli(command, original);
+            if (token.isCancellationRequested) {
+                return [];
+            }
+            const edits = buildFormatEdits(original, formatted);
+            return edits.map(
+                (e) =>
+                    new vscode.TextEdit(
+                        new vscode.Range(
+                            new vscode.Position(e.range.startLine, e.range.startCol),
+                            new vscode.Position(e.range.endLine, e.range.endCol)
+                        ),
+                        e.newText
+                    )
+            );
+        } catch (err) {
+            console.error('phel format failed:', err);
+            return [];
+        }
+    }
+}
+
+function isEnabled(): boolean {
+    return vscode.workspace.getConfiguration('phel').get<boolean>('format.enabled', true);
+}
+
+function resolveCommand(fileUri: vscode.Uri): string | null {
+    const config = vscode.workspace
+        .getConfiguration('phel')
+        .get<string>('format.command', 'vendor/bin/phel');
+    if (!config) {
+        return null;
+    }
+    if (path.isAbsolute(config)) {
+        return config;
+    }
+    const folder = vscode.workspace.getWorkspaceFolder(fileUri);
+    return folder ? path.join(folder.uri.fsPath, config) : config;
+}
+
+/**
+ * `phel format` only edits files in place, so we round-trip through a temp
+ * file. The buffer is written, formatted, then read back. The temp file is
+ * always cleaned up.
+ */
+async function formatViaCli(command: string, source: string): Promise<string> {
+    const tmp = path.join(os.tmpdir(), `phel-fmt-${process.pid}-${Date.now()}.phel`);
+    await fs.writeFile(tmp, source, 'utf-8');
+    try {
+        await new Promise<void>((resolve, reject) => {
+            execFile(command, ['format', tmp], { maxBuffer: 8 * 1024 * 1024 }, (err) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            });
+        });
+        return await fs.readFile(tmp, 'utf-8');
+    } finally {
+        await fs.unlink(tmp).catch(() => undefined);
+    }
+}

--- a/src/test/phelFormat.test.ts
+++ b/src/test/phelFormat.test.ts
@@ -1,0 +1,68 @@
+import * as assert from 'assert';
+import { buildFormatEdits, rangeOfDocument } from '../phelFormat';
+
+describe('rangeOfDocument', function () {
+    it('collapses to 0:0..0:0 for an empty string', function () {
+        assert.deepStrictEqual(rangeOfDocument(''), {
+            startLine: 0,
+            startCol: 0,
+            endLine: 0,
+            endCol: 0,
+        });
+    });
+
+    it('reports the end of a single-line document', function () {
+        assert.deepStrictEqual(rangeOfDocument('hello'), {
+            startLine: 0,
+            startCol: 0,
+            endLine: 0,
+            endCol: 5,
+        });
+    });
+
+    it('reports the end of the last line in a multi-line document', function () {
+        const text = 'first line\nsecond longer line\nthird';
+        assert.deepStrictEqual(rangeOfDocument(text), {
+            startLine: 0,
+            startCol: 0,
+            endLine: 2,
+            endCol: 5,
+        });
+    });
+
+    it('treats a trailing newline as an empty final line', function () {
+        assert.deepStrictEqual(rangeOfDocument('x\n'), {
+            startLine: 0,
+            startCol: 0,
+            endLine: 1,
+            endCol: 0,
+        });
+    });
+});
+
+describe('buildFormatEdits', function () {
+    it('emits no edits when the formatter is a no-op', function () {
+        const same = '(defn id [x] x)\n';
+        assert.deepStrictEqual(buildFormatEdits(same, same), []);
+    });
+
+    it('emits a full-document replace edit when the text differs', function () {
+        const original = '(defn  id [x ] x)\n';
+        const formatted = '(defn id [x] x)\n';
+        const edits = buildFormatEdits(original, formatted);
+        assert.strictEqual(edits.length, 1);
+        assert.strictEqual(edits[0].newText, formatted);
+        assert.deepStrictEqual(edits[0].range, rangeOfDocument(original));
+    });
+
+    it('handles an empty original', function () {
+        const edits = buildFormatEdits('', 'now-non-empty');
+        assert.strictEqual(edits.length, 1);
+        assert.deepStrictEqual(edits[0].range, {
+            startLine: 0,
+            startCol: 0,
+            endLine: 0,
+            endCol: 0,
+        });
+    });
+});


### PR DESCRIPTION
PR6 / first item from the medium-priority list.

## What
- **\`src/phelFormat.ts\`** (pure): \`rangeOfDocument\` + \`buildFormatEdits\`. No-op formatting -> no edits. Anything else -> a single full-document replace.
- **\`src/phelFormatProvider.ts\`**: \`DocumentFormattingEditProvider\` that shells \`phel format\` on a temp file (the CLI doesn't read stdin yet), reads the result, and converts via \`buildFormatEdits\`. Always cleans up the temp file.
- **Settings**:
  - \`phel.format.enabled\` (default \`true\`)
  - \`phel.format.command\` (default \`vendor/bin/phel\`, relative paths resolve against the workspace folder)

## Tests
7 new tests covering empty / single-line / multi-line / trailing-newline range computation and edits emitted for no-op vs changed input.

Total suite: **163 passing** (was 156).

## Editor behaviour
- \`Format Document\` and \`editor.formatOnSave\` now use \`phel format\` for \`.phel\` buffers.
- Disabling the setting falls back to whatever default formatter VS Code picks (none, in practice).

## Test plan
- [x] \`npm run compile\` clean.
- [x] \`npm run format:check\` clean.
- [x] \`npm run lint\` clean.
- [x] \`npm test\` - 163 passing.