### PR TITLE
feat(codelens): inline 'Run test' lenses for deftest

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,6 +189,16 @@
                 "command": "phel.showDoc",
                 "title": "Phel: Show Documentation",
                 "category": "Phel"
+            },
+            {
+                "command": "phel.runTest",
+                "title": "Phel: Run Test",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.runTestsInFile",
+                "title": "Phel: Run All Tests in File",
+                "category": "Phel"
             }
         ],
         "configuration": {
@@ -223,6 +233,16 @@
                     "type": "string",
                     "default": "vendor/bin/phel",
                     "description": "Path to the Phel CLI used for formatting. Relative paths resolve against the workspace folder."
+                },
+                "phel.tests.codeLensEnabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Show inline CodeLens shortcuts for running individual `deftest` forms and all tests in the current file."
+                },
+                "phel.test.command": {
+                    "type": "string",
+                    "default": "vendor/bin/phel",
+                    "description": "Path to the Phel CLI used by the test CodeLens. Relative paths resolve against the workspace folder."
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import { lookupSymbol, renderDocMarkdown } from './phelDocsLookup';
 import { buildQuickPickEntries } from './phelShowDoc';
 import { registerDiagnostics } from './phelDiagnosticsProvider';
 import { PhelFormatProvider } from './phelFormatProvider';
+import { PhelTestCodeLensProvider } from './phelTestCodeLensProvider';
 
 let sourceMapManager: SourceMapManager;
 
@@ -142,6 +143,19 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.languages.registerDocumentFormattingEditProvider('phel', new PhelFormatProvider())
     );
 
+    context.subscriptions.push(
+        vscode.languages.registerCodeLensProvider('phel', new PhelTestCodeLensProvider())
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('phel.runTest', (uri?: vscode.Uri, testName?: string) => {
+            runPhelTests(uri, testName);
+        }),
+        vscode.commands.registerCommand('phel.runTestsInFile', (uri?: vscode.Uri) => {
+            runPhelTests(uri);
+        })
+    );
+
     // Provide hover information for breakpoints
     context.subscriptions.push(
         vscode.languages.registerHoverProvider('phel', {
@@ -212,6 +226,28 @@ function wordAtCursor(): string | undefined {
         /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/
     );
     return range ? editor.document.getText(range) : undefined;
+}
+
+function runPhelTests(uri?: vscode.Uri, testName?: string): void {
+    const target = uri ?? vscode.window.activeTextEditor?.document.uri;
+    if (!target) {
+        vscode.window.showWarningMessage('Open a .phel test file first.');
+        return;
+    }
+    const folder = vscode.workspace.getWorkspaceFolder(target);
+    const command = vscode.workspace
+        .getConfiguration('phel')
+        .get<string>('test.command', 'vendor/bin/phel');
+    const cwd = folder?.uri.fsPath ?? path.dirname(target.fsPath);
+    const filePath = path.relative(cwd, target.fsPath) || target.fsPath;
+    const args = ['test'];
+    if (testName) {
+        args.push('--filter', testName);
+    }
+    args.push(filePath);
+    const terminal = vscode.window.createTerminal({ name: 'Phel Tests', cwd });
+    terminal.show(true);
+    terminal.sendText(`${command} ${args.join(' ')}`);
 }
 
 async function pickSymbol(): Promise<string | undefined> {

--- a/src/phelTestCodeLensProvider.ts
+++ b/src/phelTestCodeLensProvider.ts
@@ -1,0 +1,59 @@
+import * as vscode from 'vscode';
+import { findDeftests } from './phelTestScanner';
+
+const ENABLED_KEY = 'tests.codeLensEnabled';
+
+export class PhelTestCodeLensProvider implements vscode.CodeLensProvider {
+    private readonly _onDidChange = new vscode.EventEmitter<void>();
+    readonly onDidChangeCodeLenses = this._onDidChange.event;
+
+    constructor() {
+        vscode.workspace.onDidChangeConfiguration((e) => {
+            if (e.affectsConfiguration(`phel.${ENABLED_KEY}`)) {
+                this._onDidChange.fire();
+            }
+        });
+    }
+
+    provideCodeLenses(document: vscode.TextDocument): vscode.ProviderResult<vscode.CodeLens[]> {
+        if (!isEnabled()) {
+            return [];
+        }
+
+        const refs = findDeftests(document.getText());
+        const lenses: vscode.CodeLens[] = [];
+
+        if (refs.length > 0) {
+            const fileLensRange = new vscode.Range(0, 0, 0, 0);
+            lenses.push(
+                new vscode.CodeLens(fileLensRange, {
+                    title: '$(play) Run all tests in file',
+                    command: 'phel.runTestsInFile',
+                    arguments: [document.uri],
+                })
+            );
+        }
+
+        for (const ref of refs) {
+            const range = new vscode.Range(
+                ref.line,
+                ref.nameCol,
+                ref.line,
+                ref.nameCol + ref.name.length
+            );
+            lenses.push(
+                new vscode.CodeLens(range, {
+                    title: '$(play) Run test',
+                    command: 'phel.runTest',
+                    arguments: [document.uri, ref.name],
+                })
+            );
+        }
+
+        return lenses;
+    }
+}
+
+function isEnabled(): boolean {
+    return vscode.workspace.getConfiguration('phel').get<boolean>(ENABLED_KEY, true);
+}

--- a/src/phelTestScanner.ts
+++ b/src/phelTestScanner.ts
@@ -1,0 +1,36 @@
+// Pure scanner that pulls `(deftest name ...)` declarations out of a Phel
+// source string. Top-level only (the form must start at the beginning of a
+// line, modulo leading whitespace) so we don't pick up false positives
+// inside `(comment ...)` blocks or strings.
+//
+// Each result reports the 0-based line and the 0-based column of the test
+// name, so the CodeLens can attach itself to the right token.
+
+export interface PhelTestRef {
+    /** Test name as it appears in source. */
+    name: string;
+    /** 0-based line of the `(deftest` form. */
+    line: number;
+    /** 0-based column where the test name starts. */
+    nameCol: number;
+}
+
+const DEFTEST_RE = /^[ \t]*\((deftest)\s+(?:\^:[^\s()[\]{}]+\s+)?([^\s()[\]{}]+)/gm;
+
+export function findDeftests(source: string): PhelTestRef[] {
+    const out: PhelTestRef[] = [];
+    DEFTEST_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = DEFTEST_RE.exec(source)) !== null) {
+        const fullMatch = match[0];
+        const name = match[2];
+        const matchStart = match.index;
+        const nameStart = matchStart + fullMatch.length - name.length;
+        const before = source.slice(0, nameStart);
+        const lastNewline = before.lastIndexOf('\n');
+        const line = (before.match(/\n/g) ?? []).length;
+        const nameCol = lastNewline < 0 ? nameStart : nameStart - lastNewline - 1;
+        out.push({ name, line, nameCol });
+    }
+    return out;
+}

--- a/src/test/phelTestScanner.test.ts
+++ b/src/test/phelTestScanner.test.ts
@@ -1,0 +1,57 @@
+import * as assert from 'assert';
+import { findDeftests } from '../phelTestScanner';
+
+describe('findDeftests', function () {
+    it('returns nothing when the file has no tests', function () {
+        assert.deepStrictEqual(findDeftests('(defn foo [] 1)\n'), []);
+    });
+
+    it('finds a single top-level deftest', function () {
+        const source = '(deftest my-test\n  (is true))\n';
+        const refs = findDeftests(source);
+        assert.deepStrictEqual(refs, [{ name: 'my-test', line: 0, nameCol: 9 }]);
+    });
+
+    it('finds multiple deftests in order', function () {
+        const source = ['(deftest a)', '', '(deftest b)', '', '(deftest c)'].join('\n');
+        const refs = findDeftests(source);
+        assert.deepStrictEqual(refs, [
+            { name: 'a', line: 0, nameCol: 9 },
+            { name: 'b', line: 2, nameCol: 9 },
+            { name: 'c', line: 4, nameCol: 9 },
+        ]);
+    });
+
+    it('skips metadata before the test name', function () {
+        const source = '(deftest ^:slow my-test\n  (is true))\n';
+        const refs = findDeftests(source);
+        assert.strictEqual(refs.length, 1);
+        assert.strictEqual(refs[0].name, 'my-test');
+        assert.strictEqual(refs[0].nameCol, 16);
+    });
+
+    it('reports the column relative to the line, not the file', function () {
+        const source = 'leading line\n  (deftest indented-test [] (is true))\n';
+        const [ref] = findDeftests(source);
+        assert.strictEqual(ref.line, 1);
+        assert.strictEqual(ref.nameCol, 11);
+    });
+
+    it('only matches forms starting at the line head', function () {
+        const source = "(println '(deftest fake-name))\n(deftest real)";
+        const names = findDeftests(source).map((r) => r.name);
+        assert.deepStrictEqual(names, ['real']);
+    });
+
+    it('tolerates leading tabs', function () {
+        const source = '\t(deftest tab-indent)\n';
+        assert.deepStrictEqual(findDeftests(source), [
+            { name: 'tab-indent', line: 0, nameCol: 10 },
+        ]);
+    });
+
+    it('handles names containing punctuation', function () {
+        const source = '(deftest a/b-c?-test)\n';
+        assert.strictEqual(findDeftests(source)[0].name, 'a/b-c?-test');
+    });
+});


### PR DESCRIPTION
PR7. Last item from the medium-priority list (we already shipped Hover, Diagnostics, Doc-lookup, Format).

## What
- **\`src/phelTestScanner.ts\`** (pure): \`findDeftests(text)\` returns each top-level \`(deftest <name>)\` with its 0-based line / column. Line-anchored so we don't hit \`(comment ...)\` blocks or quoted forms.
- **\`src/phelTestCodeLensProvider.ts\`**: emits two kinds of lenses:
  - **▶ Run all tests in file** at the top when the file contains any \`deftest\`.
  - **▶ Run test** next to each \`deftest\` name.
- **\`extension.ts\`**: \`phel.runTest\` shells \`phel test --filter <name> <file>\` in a dedicated \"Phel Tests\" terminal; \`phel.runTestsInFile\` does the whole-file run.
- **Settings**:
  - \`phel.tests.codeLensEnabled\` (default \`true\`)
  - \`phel.test.command\` (default \`vendor/bin/phel\`)

## Tests
8 new tests in \`src/test/phelTestScanner.test.ts\` covering empty / single / multiple deftests, metadata before name, indented forms, line-anchoring (rejects \`(println '(deftest fake))\`), tab indentation, punctuated names.

Total suite: **171 passing** (was 163).

## Editor behaviour
- Open a \`*_test.phel\` file -> CodeLens at top says \"▶ Run all tests in file\"; each \`(deftest ...)\` shows \"▶ Run test\".
- Click runs the test in a terminal so output is interactive (TestDox / progress all visible).

## Test plan
- [x] \`npm run compile\` clean.
- [x] \`npm run format:check\` clean.
- [x] \`npm run lint\` clean.
- [x] \`npm test\` - 171 passing.