### PR TITLE
docs(changelog): keep an [Unreleased] section between releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Change Log
 
+## [Unreleased]
+
+### Added
+
+- Symbol metadata DB (`src/phelCoreDocs.ts`): 1317 entries across 30 namespaces, regen via `npm run regen-docs`.
+- Hover docs: signature, doc, example, see-also, source link.
+- Completion items carry full Markdown documentation.
+- Signature help with active-param highlight.
+- `Phel: Show Documentation` command.
+- Diagnostics on save via `phel analyze`.
+- Format-on-save via `phel format`.
+- CodeLens on `deftest`: ▶ Run test / ▶ Run all tests in file.
+- GitHub Actions CI on Node 20 + 22.
+
+### Changed
+
+- `MACROS` / `CORE_FNS` derive from `PHEL_DOCS`.
+
+### Settings
+
+- `phel.diagnostics.enabled`, `phel.diagnostics.command`
+- `phel.format.enabled`, `phel.format.command`
+- `phel.tests.codeLensEnabled`, `phel.test.command`
+
 ## [0.5.1] - 2026-05-06
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Keep the subject under ~70 characters; put the *why* in the body when it isn't o
 
 - One concern per PR. Stack PRs if a feature naturally splits.
 - Link the source of truth when adding language features (e.g. point at the `phel-lang` file or commit that introduced the form).
-- Update `CHANGELOG.md` under an `## [Unreleased]` heading (or bump the version in a separate PR if the change ships immediately).
+- **Always** add an entry under the `## [Unreleased]` heading in `CHANGELOG.md`. Keep entries one line each. The release script promotes `## [Unreleased]` to `## [X.Y.Z] - DATE` and reinstates a fresh `## [Unreleased]` block, so the section is never empty between releases.
 - Make sure compile, lint, and tests pass.
 
 ## Releasing
@@ -66,7 +66,7 @@ That single command:
 
 1. Sanity-checks: on `main`, working tree clean, version not already tagged, local in sync with `origin/main`.
 2. Bumps `package.json` + `package-lock.json` to the requested version.
-3. Renames `## [Unreleased]` in `CHANGELOG.md` to `## [X.Y.Z] - YYYY-MM-DD` (no-op if you've already done it).
+3. Renames `## [Unreleased]` in `CHANGELOG.md` to `## [X.Y.Z] - YYYY-MM-DD`, then inserts a fresh empty `## [Unreleased]` heading above it (no-op if no Unreleased section exists).
 4. Runs the gate: `npm run compile`, `npm test`, `npm run tokenize`.
 5. Builds `phel-lang-X.Y.Z.vsix` via `vsce package`.
 6. Commits `chore(release): vX.Y.Z`, tags `vX.Y.Z`, pushes both.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -87,12 +87,22 @@ echo "==> releasing $TAG"
 npm version "$VERSION" --no-git-tag-version --allow-same-version >/dev/null
 echo "    package.json -> $VERSION"
 
-# 3. CHANGELOG: rewrite "## [Unreleased]" -> "## [X.Y.Z] - YYYY-MM-DD" if present.
+# 3. CHANGELOG: rewrite "## [Unreleased]" -> "## [X.Y.Z] - YYYY-MM-DD" and
+#    insert a fresh empty "## [Unreleased]" above it so the next contribution
+#    has a place to land.
 TODAY=$(date +%Y-%m-%d)
 if grep -q "^## \[Unreleased\]" CHANGELOG.md; then
     sed -i.bak -E "s/^## \[Unreleased\]/## [$VERSION] - $TODAY/" CHANGELOG.md
     rm CHANGELOG.md.bak
-    echo "    CHANGELOG.md: Unreleased -> [$VERSION] - $TODAY"
+    awk -v entry="## [$VERSION] - $TODAY" '
+        !inserted && $0 == entry {
+            print "## [Unreleased]"
+            print ""
+            inserted = 1
+        }
+        { print }
+    ' CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
+    echo "    CHANGELOG.md: Unreleased -> [$VERSION] - $TODAY (fresh Unreleased restored)"
 else
     echo "    CHANGELOG.md: no [Unreleased] heading; assuming entry already in place"
 fi


### PR DESCRIPTION
## Why
There is no signal today for "what is queued for the next release". Contributors and reviewers had to scan recent commits.

## Change
- **CHANGELOG.md** opens with a populated \`## [Unreleased]\` block listing every feature shipped on main since 0.5.1.
- **scripts/release.sh** now, in addition to renaming \`## [Unreleased]\` to \`## [X.Y.Z] - DATE\`, inserts a fresh empty \`## [Unreleased]\` heading above the new entry. Each release leaves the changelog ready to receive the next change.
- **CONTRIBUTING.md** explains the convention. Every PR appends to \`## [Unreleased]\`; releases promote that heading.

## Test plan
- [x] Awk insertion verified on a sample CHANGELOG: produces \`## [Unreleased]\` then \`## [VERSION] - DATE\` in order.
- [x] \`bash -n scripts/release.sh\` clean.
- [x] \`npm run format:check\`, \`npm test\` pass (171 tests).