### PR TITLE
feat(paredit): slurp / barf / raise / wrap commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Weekly scheduled workflow that regenerates the docs DB from phel-lang `main` and opens a PR.
 - Workspace indexer: parses every `.phel` in the workspace and surfaces user `defn`/`defmacro`/`def` forms in completion / hover / signature help.
 - Go-to-definition: jumps from a symbol to its workspace `defn`.
+- Paredit commands: slurp/barf forward and backward, raise, and wrap with `( )` / `[ ]` / `{ }`. Default keys for `.phel`: `ctrl+shift+]` / `ctrl+shift+[` (slurp/barf forward), `ctrl+shift+9` / `ctrl+shift+0` (slurp/barf backward), `ctrl+shift+r` (raise), `alt+w` (wrap).
 
 ### Changed
 
@@ -29,6 +30,7 @@
 - `phel.diagnostics.enabled`, `phel.diagnostics.command`
 - `phel.format.enabled`, `phel.format.command`
 - `phel.tests.codeLensEnabled`, `phel.test.command`
+- `phel.paredit.enabled`
 
 ## [0.5.1] - 2026-05-06
 

--- a/package.json
+++ b/package.json
@@ -199,6 +199,83 @@
                 "command": "phel.runTestsInFile",
                 "title": "Phel: Run All Tests in File",
                 "category": "Phel"
+            },
+            {
+                "command": "phel.paredit.slurpForward",
+                "title": "Phel: Slurp Forward",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.paredit.barfForward",
+                "title": "Phel: Barf Forward",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.paredit.slurpBackward",
+                "title": "Phel: Slurp Backward",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.paredit.barfBackward",
+                "title": "Phel: Barf Backward",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.paredit.raise",
+                "title": "Phel: Raise Form",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.paredit.wrapRound",
+                "title": "Phel: Wrap with ( )",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.paredit.wrapSquare",
+                "title": "Phel: Wrap with [ ]",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.paredit.wrapCurly",
+                "title": "Phel: Wrap with { }",
+                "category": "Phel"
+            }
+        ],
+        "keybindings": [
+            {
+                "command": "phel.paredit.slurpForward",
+                "key": "ctrl+shift+]",
+                "mac": "cmd+shift+]",
+                "when": "editorTextFocus && editorLangId == phel"
+            },
+            {
+                "command": "phel.paredit.barfForward",
+                "key": "ctrl+shift+[",
+                "mac": "cmd+shift+[",
+                "when": "editorTextFocus && editorLangId == phel"
+            },
+            {
+                "command": "phel.paredit.slurpBackward",
+                "key": "ctrl+shift+9",
+                "mac": "cmd+shift+9",
+                "when": "editorTextFocus && editorLangId == phel"
+            },
+            {
+                "command": "phel.paredit.barfBackward",
+                "key": "ctrl+shift+0",
+                "mac": "cmd+shift+0",
+                "when": "editorTextFocus && editorLangId == phel"
+            },
+            {
+                "command": "phel.paredit.raise",
+                "key": "ctrl+shift+r",
+                "mac": "cmd+shift+r",
+                "when": "editorTextFocus && editorLangId == phel"
+            },
+            {
+                "command": "phel.paredit.wrapRound",
+                "key": "alt+w",
+                "when": "editorTextFocus && editorLangId == phel"
             }
         ],
         "configuration": {
@@ -243,6 +320,11 @@
                     "type": "string",
                     "default": "vendor/bin/phel",
                     "description": "Path to the Phel CLI used by the test CodeLens. Relative paths resolve against the workspace folder."
+                },
+                "phel.paredit.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Register paredit-style structural editing commands (slurp / barf / raise / wrap)."
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import { PhelFormatProvider } from './phelFormatProvider';
 import { PhelTestCodeLensProvider } from './phelTestCodeLensProvider';
 import { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
 import { PhelDefinitionProvider } from './phelDefinitionProvider';
+import { registerPareditCommands } from './phelPareditProvider';
 
 let sourceMapManager: SourceMapManager;
 
@@ -180,6 +181,10 @@ export function activate(context: vscode.ExtensionContext) {
             runPhelTests(uri);
         })
     );
+
+    if (vscode.workspace.getConfiguration('phel').get<boolean>('paredit.enabled', true)) {
+        registerPareditCommands(context);
+    }
 
     // Provide hover information for breakpoints
     context.subscriptions.push(

--- a/src/phelParedit.ts
+++ b/src/phelParedit.ts
@@ -1,0 +1,565 @@
+// Pure structural-editing primitives for `.phel` source. No `vscode`
+// imports so the logic can be unit-tested without an editor host.
+//
+// The `parseAll` reader produces a tree of `Form` nodes spanning the input.
+// Edit operations return a `PareditEdit` describing a single textual replace
+// plus an optional new cursor position; the VS Code provider applies them.
+
+export type FormKind = 'list' | 'vector' | 'map' | 'set' | 'anon' | 'string' | 'char' | 'atom';
+
+export interface Form {
+    /** Offset of the first char of the form, including reader prefixes. */
+    start: number;
+    /** Offset just past the last char of the form (exclusive). */
+    end: number;
+    /** Offset of the opening bracket / first body char (after prefixes). */
+    bodyStart: number;
+    /** Offset just after the closing bracket, or `end` for atoms / strings. */
+    bodyEnd: number;
+    /** For container forms, offset just after the opener, else equal to `bodyStart`. */
+    innerStart: number;
+    /** For container forms, offset of the closing bracket, else equal to `bodyEnd`. */
+    innerEnd: number;
+    kind: FormKind;
+    children: Form[];
+}
+
+export interface PareditEdit {
+    replaceStart: number;
+    replaceEnd: number;
+    replacement: string;
+    cursor?: number;
+}
+
+const WHITESPACE = new Set([' ', '\t', '\n', '\r', ',']);
+const ATOM_TERMINATOR = new Set([
+    ' ',
+    '\t',
+    '\n',
+    '\r',
+    ',',
+    '(',
+    ')',
+    '[',
+    ']',
+    '{',
+    '}',
+    '"',
+    ';',
+]);
+const OPEN_TO_CLOSE: Record<string, string> = { '(': ')', '[': ']', '{': '}' };
+
+function skipTrivia(src: string, i: number, end: number): number {
+    while (i < end) {
+        const c = src[i];
+        if (WHITESPACE.has(c)) {
+            i++;
+            continue;
+        }
+        if (c === ';') {
+            while (i < end && src[i] !== '\n') {
+                i++;
+            }
+            continue;
+        }
+        if (c === '#' && src[i + 1] === '|') {
+            i += 2;
+            while (i < end - 1 && !(src[i] === '|' && src[i + 1] === '#')) {
+                i++;
+            }
+            if (i < end - 1) {
+                i += 2;
+            } else {
+                i = end;
+            }
+            continue;
+        }
+        if (c === '#' && src[i + 1] === '_') {
+            i += 2;
+            const next = readForm(src, i, end);
+            if (next) {
+                i = next.end;
+                continue;
+            }
+            return i;
+        }
+        return i;
+    }
+    return i;
+}
+
+function isReaderPrefix(src: string, i: number, end: number): number {
+    if (i >= end) {
+        return 0;
+    }
+    const c = src[i];
+    if (c === "'" || c === '`' || c === '@' || c === '^') {
+        return 1;
+    }
+    if (c === '~') {
+        return src[i + 1] === '@' ? 2 : 1;
+    }
+    if (c === '#') {
+        const n = src[i + 1];
+        if (n === "'") {
+            return 2;
+        }
+        if (n === '?' && src[i + 2] === '@') {
+            return 3;
+        }
+        if (n === '?') {
+            return 2;
+        }
+        // Tagged literal `#tag` (but not `#(`, `#{`, `#_`, `#|`).
+        if (n && /[A-Za-z]/.test(n)) {
+            let j = i + 1;
+            while (j < end && /[A-Za-z0-9_\-.]/.test(src[j])) {
+                j++;
+            }
+            return j - i;
+        }
+    }
+    return 0;
+}
+
+function readPrefixes(src: string, start: number, end: number): number {
+    let i = start;
+    while (i < end) {
+        const len = isReaderPrefix(src, i, end);
+        if (len === 0) {
+            break;
+        }
+        i += len;
+        // Reader prefixes attach to the very next form; allow whitespace between
+        // the prefix and the form (rare, but legal: `~\n  x`).
+        i = skipTrivia(src, i, end);
+    }
+    return i;
+}
+
+function readString(src: string, start: number, end: number): number {
+    let i = start + 1;
+    while (i < end) {
+        const c = src[i];
+        if (c === '\\') {
+            i += 2;
+            continue;
+        }
+        if (c === '"') {
+            return i + 1;
+        }
+        i++;
+    }
+    return end;
+}
+
+function readChar(src: string, start: number, end: number): number {
+    let i = start + 1;
+    while (i < end && !ATOM_TERMINATOR.has(src[i])) {
+        i++;
+    }
+    if (i === start + 1 && i < end) {
+        return i + 1;
+    }
+    return i;
+}
+
+function readAtomEnd(src: string, start: number, end: number): number {
+    let i = start;
+    while (i < end && !ATOM_TERMINATOR.has(src[i])) {
+        i++;
+    }
+    return i;
+}
+
+/**
+ * Read the next form at or after `start`. Returns null if there is no form
+ * before `end`. Trivia (whitespace, comments, `#_` discards) is skipped.
+ */
+export function readForm(src: string, start: number, end: number): Form | null {
+    const trivStart = skipTrivia(src, start, end);
+    const formStart = trivStart;
+    const bodyStart = readPrefixes(src, formStart, end);
+    if (bodyStart >= end) {
+        return null;
+    }
+    const c = src[bodyStart];
+    if (c === ')' || c === ']' || c === '}') {
+        return null;
+    }
+
+    const isHashContainer = c === '#' && (src[bodyStart + 1] === '(' || src[bodyStart + 1] === '{');
+    if (isHashContainer) {
+        const opener = src[bodyStart + 1];
+        const close = OPEN_TO_CLOSE[opener];
+        const innerStart = bodyStart + 2;
+        const children: Form[] = [];
+        let cursor = innerStart;
+        while (cursor < end) {
+            cursor = skipTrivia(src, cursor, end);
+            if (cursor >= end) {
+                break;
+            }
+            if (src[cursor] === close) {
+                break;
+            }
+            const child = readForm(src, cursor, end);
+            if (!child) {
+                break;
+            }
+            children.push(child);
+            cursor = child.end;
+        }
+        const innerEnd = cursor < end && src[cursor] === close ? cursor : cursor;
+        const bodyEnd = innerEnd < end && src[innerEnd] === close ? innerEnd + 1 : innerEnd;
+        return {
+            start: formStart,
+            end: bodyEnd,
+            bodyStart,
+            bodyEnd,
+            innerStart,
+            innerEnd,
+            kind: opener === '(' ? 'anon' : 'set',
+            children,
+        };
+    }
+
+    if (c === '(' || c === '[' || c === '{') {
+        const close = OPEN_TO_CLOSE[c];
+        const innerStart = bodyStart + 1;
+        const children: Form[] = [];
+        let cursor = innerStart;
+        while (cursor < end) {
+            cursor = skipTrivia(src, cursor, end);
+            if (cursor >= end) {
+                break;
+            }
+            if (src[cursor] === close) {
+                break;
+            }
+            const child = readForm(src, cursor, end);
+            if (!child) {
+                break;
+            }
+            children.push(child);
+            cursor = child.end;
+        }
+        const innerEnd = cursor;
+        const bodyEnd = innerEnd < end && src[innerEnd] === close ? innerEnd + 1 : innerEnd;
+        const kind: FormKind = c === '(' ? 'list' : c === '[' ? 'vector' : 'map';
+        return {
+            start: formStart,
+            end: bodyEnd,
+            bodyStart,
+            bodyEnd,
+            innerStart,
+            innerEnd,
+            kind,
+            children,
+        };
+    }
+
+    if (c === '"') {
+        const stringEnd = readString(src, bodyStart, end);
+        return {
+            start: formStart,
+            end: stringEnd,
+            bodyStart,
+            bodyEnd: stringEnd,
+            innerStart: bodyStart,
+            innerEnd: stringEnd,
+            kind: 'string',
+            children: [],
+        };
+    }
+
+    if (c === '\\') {
+        const charEnd = readChar(src, bodyStart, end);
+        return {
+            start: formStart,
+            end: charEnd,
+            bodyStart,
+            bodyEnd: charEnd,
+            innerStart: bodyStart,
+            innerEnd: charEnd,
+            kind: 'char',
+            children: [],
+        };
+    }
+
+    const atomEnd = readAtomEnd(src, bodyStart, end);
+    if (atomEnd === bodyStart) {
+        // Should not happen for well-formed input, but guard against infinite
+        // loops by advancing one character.
+        return {
+            start: formStart,
+            end: bodyStart + 1,
+            bodyStart,
+            bodyEnd: bodyStart + 1,
+            innerStart: bodyStart,
+            innerEnd: bodyStart + 1,
+            kind: 'atom',
+            children: [],
+        };
+    }
+    return {
+        start: formStart,
+        end: atomEnd,
+        bodyStart,
+        bodyEnd: atomEnd,
+        innerStart: bodyStart,
+        innerEnd: atomEnd,
+        kind: 'atom',
+        children: [],
+    };
+}
+
+/** Parse all top-level forms in `src`. */
+export function parseAll(src: string): Form[] {
+    const forms: Form[] = [];
+    let i = 0;
+    while (i < src.length) {
+        const f = readForm(src, i, src.length);
+        if (!f) {
+            const skipped = skipTrivia(src, i, src.length);
+            if (skipped <= i) {
+                break;
+            }
+            i = skipped;
+            continue;
+        }
+        forms.push(f);
+        i = f.end;
+    }
+    return forms;
+}
+
+/**
+ * Returns the path of forms enclosing `offset`, outermost first. Empty when
+ * the offset is outside every form.
+ */
+export function pathAt(forms: readonly Form[], offset: number): Form[] {
+    const path: Form[] = [];
+    let level: readonly Form[] = forms;
+    for (;;) {
+        const hit = level.find((f) => f.start <= offset && offset <= f.end);
+        if (!hit) {
+            break;
+        }
+        path.push(hit);
+        level = hit.children;
+    }
+    return path;
+}
+
+/** The smallest container (`list` | `vector` | `map` | `set` | `anon`) whose body strictly contains `offset`. */
+export function enclosingContainer(forms: readonly Form[], offset: number): Form | null {
+    const path = pathAt(forms, offset);
+    for (let i = path.length - 1; i >= 0; i--) {
+        const f = path[i];
+        if (isContainer(f) && f.innerStart <= offset && offset <= f.innerEnd) {
+            return f;
+        }
+    }
+    return null;
+}
+
+export function isContainer(f: Form): boolean {
+    return (
+        f.kind === 'list' ||
+        f.kind === 'vector' ||
+        f.kind === 'map' ||
+        f.kind === 'set' ||
+        f.kind === 'anon'
+    );
+}
+
+/** Form at offset (innermost). For containers prefers a child over the container itself. */
+export function formAt(forms: readonly Form[], offset: number): Form | null {
+    const path = pathAt(forms, offset);
+    return path[path.length - 1] ?? null;
+}
+
+function siblingsAndIndex(
+    forms: readonly Form[],
+    container: Form
+): { siblings: readonly Form[]; index: number } | null {
+    if (forms.includes(container)) {
+        return { siblings: forms, index: forms.indexOf(container) };
+    }
+    for (const f of forms) {
+        const found = siblingsAndIndex(f.children, container);
+        if (found) {
+            return found;
+        }
+    }
+    return null;
+}
+
+/**
+ * Slurp the next sibling form into the container that encloses `offset`.
+ * Moves the closing bracket of that container past the next sibling outside.
+ */
+export function slurpForward(src: string, offset: number): PareditEdit | null {
+    const forms = parseAll(src);
+    const container = enclosingContainer(forms, offset);
+    if (!container) {
+        return null;
+    }
+    const next = readForm(src, container.end, src.length);
+    if (!next) {
+        return null;
+    }
+    const close = src[container.innerEnd];
+    const between = src.slice(container.end, next.start);
+    const sep = between.length === 0 ? ' ' : '';
+    return {
+        replaceStart: container.innerEnd,
+        replaceEnd: next.end,
+        replacement: sep + src.slice(container.end, next.end) + close,
+        cursor: offset,
+    };
+}
+
+/**
+ * Barf the last child of the enclosing container outside.
+ * Moves the closing bracket back to before the last child.
+ */
+export function barfForward(src: string, offset: number): PareditEdit | null {
+    const forms = parseAll(src);
+    const container = enclosingContainer(forms, offset);
+    if (!container || container.children.length === 0) {
+        return null;
+    }
+    const last = container.children[container.children.length - 1];
+    const close = src[container.innerEnd];
+    // Need at least one whitespace between last and the new closer if there's a prev sibling.
+    let insertBefore = last.start;
+    // Trim trailing whitespace before `last` — keep the closer flush to last child end.
+    let trimEnd = last.start;
+    while (trimEnd > container.innerStart && WHITESPACE.has(src[trimEnd - 1])) {
+        trimEnd--;
+    }
+    if (trimEnd <= container.innerStart) {
+        // Only one child; just leave a single space inside.
+        insertBefore = last.start;
+    } else {
+        insertBefore = trimEnd;
+    }
+    const replacement = close + src.slice(insertBefore, container.innerEnd);
+    return {
+        replaceStart: insertBefore,
+        replaceEnd: container.innerEnd + 1,
+        replacement,
+        cursor: offset > container.innerEnd ? insertBefore : offset,
+    };
+}
+
+function findPrevSibling(container: Form, parents: readonly Form[]): Form | null {
+    const ctx = siblingsAndIndex(parents, container);
+    if (!ctx) {
+        return null;
+    }
+    return ctx.index > 0 ? ctx.siblings[ctx.index - 1] : null;
+}
+
+/**
+ * Slurp the previous sibling into the container.
+ * Moves the opening bracket back past the previous sibling.
+ */
+export function slurpBackward(src: string, offset: number): PareditEdit | null {
+    const forms = parseAll(src);
+    const container = enclosingContainer(forms, offset);
+    if (!container) {
+        return null;
+    }
+    const prev = findPrevSibling(container, forms);
+    if (!prev) {
+        return null;
+    }
+    const opener = src[container.bodyStart];
+    const between = src.slice(prev.end, container.bodyStart);
+    const sep = between.length === 0 ? ' ' : '';
+    return {
+        replaceStart: prev.start,
+        replaceEnd: container.bodyStart + 1,
+        replacement: opener + src.slice(prev.start, container.bodyStart) + sep,
+        cursor: offset,
+    };
+}
+
+/**
+ * Barf the first child of the enclosing container backwards (out the front).
+ */
+export function barfBackward(src: string, offset: number): PareditEdit | null {
+    const forms = parseAll(src);
+    const container = enclosingContainer(forms, offset);
+    if (!container || container.children.length === 0) {
+        return null;
+    }
+    const first = container.children[0];
+    const opener = src[container.bodyStart];
+    // Place new opener after `first`, dropping any leading whitespace between
+    // first and the next form.
+    let insertAt = first.end;
+    while (insertAt < container.innerEnd && WHITESPACE.has(src[insertAt])) {
+        insertAt++;
+    }
+    if (insertAt >= container.innerEnd) {
+        insertAt = first.end;
+    }
+    const replacement = src.slice(first.start, first.end) + ' ' + opener;
+    return {
+        replaceStart: container.bodyStart,
+        replaceEnd: insertAt,
+        replacement,
+        cursor: offset < container.bodyStart + 1 ? insertAt : offset,
+    };
+}
+
+/**
+ * Replace the enclosing container with the form at the cursor.
+ * `(foo (bar| baz))` -> `(bar baz)`.
+ */
+export function raise(src: string, offset: number): PareditEdit | null {
+    const forms = parseAll(src);
+    const path = pathAt(forms, offset);
+    if (path.length < 2) {
+        return null;
+    }
+    const target = path[path.length - 1];
+    const container = path[path.length - 2];
+    if (!isContainer(container)) {
+        return null;
+    }
+    return {
+        replaceStart: container.start,
+        replaceEnd: container.end,
+        replacement: src.slice(target.start, target.end),
+        cursor: container.start,
+    };
+}
+
+/**
+ * Wrap the form at `offset` (or empty range if no form there) with the given
+ * brackets. Cursor lands just after the open bracket.
+ */
+export function wrap(src: string, offset: number, open: '(' | '[' | '{'): PareditEdit {
+    const close = OPEN_TO_CLOSE[open];
+    const forms = parseAll(src);
+    const target = formAt(forms, offset);
+    if (!target) {
+        return {
+            replaceStart: offset,
+            replaceEnd: offset,
+            replacement: open + close,
+            cursor: offset + 1,
+        };
+    }
+    return {
+        replaceStart: target.start,
+        replaceEnd: target.end,
+        replacement: open + src.slice(target.start, target.end) + close,
+        cursor: target.start + 1,
+    };
+}

--- a/src/phelPareditProvider.ts
+++ b/src/phelPareditProvider.ts
@@ -1,0 +1,58 @@
+// Thin VS Code wrapper around `phelParedit`. Each command reads the active
+// editor's text + cursor, runs the corresponding pure operation, then applies
+// a single text edit and (optionally) repositions the cursor.
+
+import * as vscode from 'vscode';
+import {
+    barfBackward,
+    barfForward,
+    raise as raiseForm,
+    slurpBackward,
+    slurpForward,
+    wrap,
+    type PareditEdit,
+} from './phelParedit';
+
+type PareditOp = (src: string, offset: number) => PareditEdit | null;
+
+async function runOp(op: PareditOp): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'phel') {
+        return;
+    }
+    const doc = editor.document;
+    const pos = editor.selection.active;
+    const offset = doc.offsetAt(pos);
+    const edit = op(doc.getText(), offset);
+    if (!edit) {
+        return;
+    }
+    const range = new vscode.Range(
+        doc.positionAt(edit.replaceStart),
+        doc.positionAt(edit.replaceEnd)
+    );
+    await editor.edit((b) => b.replace(range, edit.replacement));
+    if (typeof edit.cursor === 'number') {
+        const newPos = editor.document.positionAt(edit.cursor);
+        editor.selection = new vscode.Selection(newPos, newPos);
+    }
+}
+
+export function registerPareditCommands(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand('phel.paredit.slurpForward', () => runOp(slurpForward)),
+        vscode.commands.registerCommand('phel.paredit.barfForward', () => runOp(barfForward)),
+        vscode.commands.registerCommand('phel.paredit.slurpBackward', () => runOp(slurpBackward)),
+        vscode.commands.registerCommand('phel.paredit.barfBackward', () => runOp(barfBackward)),
+        vscode.commands.registerCommand('phel.paredit.raise', () => runOp(raiseForm)),
+        vscode.commands.registerCommand('phel.paredit.wrapRound', () =>
+            runOp((src, off) => wrap(src, off, '('))
+        ),
+        vscode.commands.registerCommand('phel.paredit.wrapSquare', () =>
+            runOp((src, off) => wrap(src, off, '['))
+        ),
+        vscode.commands.registerCommand('phel.paredit.wrapCurly', () =>
+            runOp((src, off) => wrap(src, off, '{'))
+        )
+    );
+}

--- a/src/test/phelParedit.test.ts
+++ b/src/test/phelParedit.test.ts
@@ -1,0 +1,229 @@
+import * as assert from 'node:assert/strict';
+import {
+    barfBackward,
+    barfForward,
+    enclosingContainer,
+    formAt,
+    parseAll,
+    pathAt,
+    raise,
+    readForm,
+    slurpBackward,
+    slurpForward,
+    wrap,
+    type PareditEdit,
+} from '../phelParedit';
+
+function apply(src: string, edit: PareditEdit | null): string {
+    assert.ok(edit, 'expected edit, got null');
+    return src.slice(0, edit.replaceStart) + edit.replacement + src.slice(edit.replaceEnd);
+}
+
+describe('phelParedit.parseAll', () => {
+    it('parses top-level atoms', () => {
+        const forms = parseAll('a b c');
+        assert.deepEqual(
+            forms.map((f) => [f.start, f.end, f.kind]),
+            [
+                [0, 1, 'atom'],
+                [2, 3, 'atom'],
+                [4, 5, 'atom'],
+            ]
+        );
+    });
+
+    it('parses lists with children', () => {
+        const forms = parseAll('(a b)');
+        assert.equal(forms.length, 1);
+        assert.equal(forms[0].kind, 'list');
+        assert.equal(forms[0].children.length, 2);
+    });
+
+    it('parses vectors and maps', () => {
+        const forms = parseAll('[1 2] {:a 1}');
+        assert.equal(forms[0].kind, 'vector');
+        assert.equal(forms[1].kind, 'map');
+    });
+
+    it('parses anon-fn and set literals', () => {
+        const forms = parseAll('#(+ % 1) #{1 2}');
+        assert.equal(forms[0].kind, 'anon');
+        assert.equal(forms[1].kind, 'set');
+    });
+
+    it('treats a string as a single form', () => {
+        const forms = parseAll('"hello world"');
+        assert.equal(forms.length, 1);
+        assert.equal(forms[0].kind, 'string');
+    });
+
+    it('skips line comments', () => {
+        const forms = parseAll('; ignored\nfoo');
+        assert.equal(forms.length, 1);
+        assert.equal(forms[0].start, 10);
+    });
+
+    it('skips block comments', () => {
+        const forms = parseAll('#| ignored |# foo');
+        assert.equal(forms.length, 1);
+        assert.equal(forms[0].start, 14);
+    });
+
+    it('skips #_ discard form', () => {
+        const forms = parseAll('#_(a b) c');
+        assert.equal(forms.length, 1);
+        assert.equal(forms[0].start, 8);
+    });
+
+    it('attaches reader prefixes to the following form', () => {
+        const forms = parseAll("'foo");
+        assert.equal(forms.length, 1);
+        assert.equal(forms[0].start, 0);
+        assert.equal(forms[0].end, 4);
+        assert.equal(forms[0].kind, 'atom');
+    });
+
+    it('handles ~@ unquote-splice as a single prefix', () => {
+        const forms = parseAll('~@x');
+        assert.equal(forms.length, 1);
+        assert.equal(forms[0].start, 0);
+        assert.equal(forms[0].end, 3);
+    });
+});
+
+describe('phelParedit.pathAt / formAt / enclosingContainer', () => {
+    it('returns innermost form at offset', () => {
+        const src = '(foo (bar baz))';
+        const forms = parseAll(src);
+        const path = pathAt(forms, 7); // inside "bar"
+        assert.deepEqual(
+            path.map((f) => f.kind),
+            ['list', 'list', 'atom']
+        );
+    });
+
+    it('returns null for offset in whitespace at top level', () => {
+        const forms = parseAll(' x ');
+        assert.equal(formAt(forms, 0), null);
+    });
+
+    it('finds enclosing container', () => {
+        const src = '(a (b c))';
+        const forms = parseAll(src);
+        const c = enclosingContainer(forms, 5);
+        assert.ok(c);
+        assert.equal(c?.kind, 'list');
+        assert.equal(c?.start, 3);
+    });
+});
+
+describe('phelParedit.slurpForward', () => {
+    it('absorbs the next sibling', () => {
+        const src = '(a) b';
+        assert.equal(apply(src, slurpForward(src, 1)), '(a b)');
+    });
+
+    it('inserts a space when there is none between', () => {
+        const src = '(a)b';
+        assert.equal(apply(src, slurpForward(src, 1)), '(a b)');
+    });
+
+    it('absorbs into a vector', () => {
+        const src = '[a] b';
+        assert.equal(apply(src, slurpForward(src, 1)), '[a b]');
+    });
+
+    it('returns null when there is nothing to slurp', () => {
+        assert.equal(slurpForward('(a)', 1), null);
+    });
+
+    it('works on the inner list', () => {
+        const src = '(foo (bar) baz)';
+        assert.equal(apply(src, slurpForward(src, 6)), '(foo (bar baz))');
+    });
+});
+
+describe('phelParedit.barfForward', () => {
+    it('expels the last child', () => {
+        const src = '(a b c)';
+        assert.equal(apply(src, barfForward(src, 3)), '(a b) c');
+    });
+
+    it('works on a vector', () => {
+        const src = '[a b c]';
+        assert.equal(apply(src, barfForward(src, 3)), '[a b] c');
+    });
+
+    it('returns null on empty container', () => {
+        assert.equal(barfForward('()', 1), null);
+    });
+});
+
+describe('phelParedit.slurpBackward', () => {
+    it('absorbs the previous sibling', () => {
+        const src = 'a (b c)';
+        assert.equal(apply(src, slurpBackward(src, 4)), '(a b c)');
+    });
+
+    it('inserts a space when there is none between', () => {
+        const src = 'a(b c)';
+        assert.equal(apply(src, slurpBackward(src, 3)), '(a b c)');
+    });
+
+    it('returns null when there is no prev sibling', () => {
+        assert.equal(slurpBackward('(a b)', 1), null);
+    });
+});
+
+describe('phelParedit.barfBackward', () => {
+    it('expels the first child', () => {
+        const src = '(a b c)';
+        assert.equal(apply(src, barfBackward(src, 3)), 'a (b c)');
+    });
+
+    it('returns null on empty container', () => {
+        assert.equal(barfBackward('()', 1), null);
+    });
+});
+
+describe('phelParedit.raise', () => {
+    it('replaces the parent with the form at the cursor', () => {
+        const src = '(foo (bar baz))';
+        // cursor on "bar" (offset 7)
+        assert.equal(apply(src, raise(src, 7)), '(foo bar)');
+    });
+
+    it('returns null when there is no parent', () => {
+        assert.equal(raise('foo', 1), null);
+    });
+});
+
+describe('phelParedit.wrap', () => {
+    it('wraps an atom with parens', () => {
+        const src = 'foo';
+        assert.equal(apply(src, wrap(src, 1, '(')), '(foo)');
+    });
+
+    it('wraps a list with brackets', () => {
+        const src = '(a b)';
+        assert.equal(apply(src, wrap(src, 0, '[')), '[(a b)]');
+    });
+
+    it('inserts empty pair when not on a form', () => {
+        const src = '   ';
+        assert.equal(apply(src, wrap(src, 1, '(')), ' ()  ');
+    });
+});
+
+describe('phelParedit.readForm', () => {
+    it('returns null at end of input', () => {
+        assert.equal(readForm('   ', 0, 3), null);
+    });
+
+    it('reads through reader prefixes including # tag', () => {
+        const f = readForm('#inst "2026-01-01"', 0, 18);
+        assert.ok(f);
+        assert.equal(f?.start, 0);
+        assert.equal(f?.kind, 'string');
+    });
+});


### PR DESCRIPTION
## Summary

- Pure structural-editing primitives in `phelParedit.ts`: a small reader produces a `Form` tree, then ops compute a single `PareditEdit`.
- VS Code commands: `phel.paredit.{slurpForward,barfForward,slurpBackward,barfBackward,raise,wrapRound,wrapSquare,wrapCurly}`.
- Default keybindings (only when `editorLangId == phel`):
  - Slurp/Barf forward: `ctrl+shift+]` / `ctrl+shift+[` (cmd on mac)
  - Slurp/Barf backward: `ctrl+shift+9` / `ctrl+shift+0`
  - Raise: `ctrl+shift+r`
  - Wrap with `( )`: `alt+w`
- New setting `phel.paredit.enabled` (default true) to opt out.
- 33 unit tests covering parser, slurp, barf, raise, wrap.

## Test plan

- [ ] Cursor in `(a) b` -> slurp forward -> `(a b)`.
- [ ] Cursor in `(a b c)` -> barf forward -> `(a b) c`.
- [ ] Cursor in `a (b c)` -> slurp backward -> `(a b c)`.
- [ ] Cursor in `(a b c)` -> barf backward -> `a (b c)`.
- [ ] Cursor on `bar` in `(foo (bar baz))` -> raise -> `(foo bar)`.
- [ ] Cursor on `foo` -> wrap with `(` -> `(foo)` and cursor lands inside.
- [ ] Toggling `phel.paredit.enabled = false` skips registering the commands (verified at activate time).
- [ ] CI green (213 tests).