### PR TITLE
feat(repl): integrated phel repl + eval commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Workspace indexer: parses every `.phel` in the workspace and surfaces user `defn`/`defmacro`/`def` forms in completion / hover / signature help.
 - Go-to-definition: jumps from a symbol to its workspace `defn`.
 - Paredit commands: slurp/barf forward and backward, raise, and wrap with `( )` / `[ ]` / `{ }`. Default keys for `.phel`: `ctrl+shift+]` / `ctrl+shift+[` (slurp/barf forward), `ctrl+shift+9` / `ctrl+shift+0` (slurp/barf backward), `ctrl+shift+r` (raise), `alt+w` (wrap).
+- REPL integration: `Phel: Start REPL` opens a terminal running `phel repl`; `ctrl+enter` evals the form under the cursor, `ctrl+shift+enter` evals the selection. Commands also include eval next form and eval file.
 
 ### Changed
 
@@ -31,6 +32,7 @@
 - `phel.format.enabled`, `phel.format.command`
 - `phel.tests.codeLensEnabled`, `phel.test.command`
 - `phel.paredit.enabled`
+- `phel.repl.enabled`, `phel.repl.command`, `phel.repl.args`
 
 ## [0.5.1] - 2026-05-06
 

--- a/package.json
+++ b/package.json
@@ -239,6 +239,31 @@
                 "command": "phel.paredit.wrapCurly",
                 "title": "Phel: Wrap with { }",
                 "category": "Phel"
+            },
+            {
+                "command": "phel.repl.start",
+                "title": "Phel: Start REPL",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.repl.evalForm",
+                "title": "Phel: Eval Form Under Cursor",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.repl.evalSelection",
+                "title": "Phel: Eval Selection",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.repl.evalNextForm",
+                "title": "Phel: Eval Next Form",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.repl.evalFile",
+                "title": "Phel: Eval File",
+                "category": "Phel"
             }
         ],
         "keybindings": [
@@ -275,6 +300,18 @@
             {
                 "command": "phel.paredit.wrapRound",
                 "key": "alt+w",
+                "when": "editorTextFocus && editorLangId == phel"
+            },
+            {
+                "command": "phel.repl.evalForm",
+                "key": "ctrl+enter",
+                "mac": "cmd+enter",
+                "when": "editorTextFocus && editorLangId == phel"
+            },
+            {
+                "command": "phel.repl.evalSelection",
+                "key": "ctrl+shift+enter",
+                "mac": "cmd+shift+enter",
                 "when": "editorTextFocus && editorLangId == phel"
             }
         ],
@@ -325,6 +362,26 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Register paredit-style structural editing commands (slurp / barf / raise / wrap)."
+                },
+                "phel.repl.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Register Phel REPL commands (start, eval form / selection / next form / file)."
+                },
+                "phel.repl.command": {
+                    "type": "string",
+                    "default": "vendor/bin/phel",
+                    "description": "Path to the Phel CLI used to launch the REPL terminal. Relative paths resolve against the workspace folder."
+                },
+                "phel.repl.args": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "repl"
+                    ],
+                    "description": "Arguments passed to the Phel CLI when starting the REPL."
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import { PhelTestCodeLensProvider } from './phelTestCodeLensProvider';
 import { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
 import { PhelDefinitionProvider } from './phelDefinitionProvider';
 import { registerPareditCommands } from './phelPareditProvider';
+import { registerReplCommands } from './phelReplProvider';
 
 let sourceMapManager: SourceMapManager;
 
@@ -184,6 +185,10 @@ export function activate(context: vscode.ExtensionContext) {
 
     if (vscode.workspace.getConfiguration('phel').get<boolean>('paredit.enabled', true)) {
         registerPareditCommands(context);
+    }
+
+    if (vscode.workspace.getConfiguration('phel').get<boolean>('repl.enabled', true)) {
+        registerReplCommands(context);
     }
 
     // Provide hover information for breakpoints

--- a/src/phelRepl.ts
+++ b/src/phelRepl.ts
@@ -1,0 +1,47 @@
+// Pure helpers used by the REPL provider. No `vscode` imports so the cursor
+// math can be unit tested without an editor host.
+
+import { parseAll } from './phelParedit';
+
+export interface FormSpan {
+    start: number;
+    end: number;
+    text: string;
+}
+
+/**
+ * Top-level form whose span contains `offset`. Returns null if the cursor
+ * is between top-level forms (whitespace / comments).
+ */
+export function topLevelFormAt(src: string, offset: number): FormSpan | null {
+    const forms = parseAll(src);
+    for (const f of forms) {
+        if (f.start <= offset && offset <= f.end) {
+            return { start: f.start, end: f.end, text: src.slice(f.start, f.end) };
+        }
+    }
+    return null;
+}
+
+/**
+ * Top-level form whose span starts at or after `offset`. Used to step from
+ * one form to the next when evaluating successive forms in a buffer.
+ */
+export function nextTopLevelFormAfter(src: string, offset: number): FormSpan | null {
+    const forms = parseAll(src);
+    for (const f of forms) {
+        if (f.start >= offset) {
+            return { start: f.start, end: f.end, text: src.slice(f.start, f.end) };
+        }
+    }
+    return null;
+}
+
+/**
+ * Collapse a multiline form into a single line so it can be pasted into
+ * a line-oriented terminal REPL without intermediate continuation prompts.
+ * Preserves single spaces and trims the trailing newline.
+ */
+export function flattenForTerminal(text: string): string {
+    return text.replace(/\r?\n/g, ' ').replace(/\s+/g, ' ').trim();
+}

--- a/src/phelReplProvider.ts
+++ b/src/phelReplProvider.ts
@@ -1,0 +1,133 @@
+// REPL integration: spawns `phel repl` in an integrated terminal and lets
+// the user send the form under the cursor, the current selection, or the
+// whole file via commands / keybindings.
+//
+// One terminal per workspace folder is reused; closing the terminal makes
+// the next eval start a fresh one.
+
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import { flattenForTerminal, nextTopLevelFormAfter, topLevelFormAt } from './phelRepl';
+
+const REPL_TERMINAL_NAME = 'Phel REPL';
+
+interface ReplCommandConfig {
+    command: string;
+    args: readonly string[];
+    cwd: string;
+}
+
+function workspaceFolderForDoc(doc?: vscode.TextDocument): vscode.WorkspaceFolder | undefined {
+    if (doc && doc.uri.scheme === 'file') {
+        return vscode.workspace.getWorkspaceFolder(doc.uri) ?? undefined;
+    }
+    return vscode.workspace.workspaceFolders?.[0];
+}
+
+function resolveCommand(folder: vscode.WorkspaceFolder | undefined): ReplCommandConfig {
+    const config = vscode.workspace.getConfiguration('phel', folder);
+    const cmd = config.get<string>('repl.command', 'vendor/bin/phel');
+    const args = config.get<string[]>('repl.args', ['repl']);
+    const cwd = folder?.uri.fsPath ?? process.cwd();
+    const absolute = path.isAbsolute(cmd) ? cmd : path.join(cwd, cmd);
+    return { command: absolute, args, cwd };
+}
+
+function findTerminal(): vscode.Terminal | undefined {
+    return vscode.window.terminals.find((t) => t.name === REPL_TERMINAL_NAME);
+}
+
+function ensureTerminal(folder: vscode.WorkspaceFolder | undefined): vscode.Terminal {
+    const existing = findTerminal();
+    if (existing) {
+        existing.show(true);
+        return existing;
+    }
+    const cfg = resolveCommand(folder);
+    const term = vscode.window.createTerminal({
+        name: REPL_TERMINAL_NAME,
+        cwd: cfg.cwd,
+        shellPath: cfg.command,
+        shellArgs: [...cfg.args],
+    });
+    term.show(true);
+    return term;
+}
+
+function sendToRepl(text: string, folder: vscode.WorkspaceFolder | undefined): void {
+    const term = ensureTerminal(folder);
+    term.sendText(text, true);
+}
+
+async function evalForm(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'phel') {
+        return;
+    }
+    const doc = editor.document;
+    const offset = doc.offsetAt(editor.selection.active);
+    const form = topLevelFormAt(doc.getText(), offset);
+    if (!form) {
+        vscode.window.showWarningMessage('No Phel form under cursor.');
+        return;
+    }
+    sendToRepl(flattenForTerminal(form.text), workspaceFolderForDoc(doc));
+}
+
+async function evalSelection(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'phel') {
+        return;
+    }
+    const doc = editor.document;
+    const sel = editor.selection;
+    const text = sel.isEmpty ? doc.lineAt(sel.active.line).text : doc.getText(sel);
+    if (!text.trim()) {
+        return;
+    }
+    sendToRepl(flattenForTerminal(text), workspaceFolderForDoc(doc));
+}
+
+async function evalNextForm(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'phel') {
+        return;
+    }
+    const doc = editor.document;
+    const offset = doc.offsetAt(editor.selection.active);
+    const form = nextTopLevelFormAfter(doc.getText(), offset);
+    if (!form) {
+        return;
+    }
+    sendToRepl(flattenForTerminal(form.text), workspaceFolderForDoc(doc));
+    const newPos = doc.positionAt(form.end);
+    editor.selection = new vscode.Selection(newPos, newPos);
+    editor.revealRange(new vscode.Range(newPos, newPos));
+}
+
+async function evalFile(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'phel') {
+        return;
+    }
+    const text = editor.document.getText().trim();
+    if (!text) {
+        return;
+    }
+    sendToRepl(flattenForTerminal(text), workspaceFolderForDoc(editor.document));
+}
+
+function startRepl(): void {
+    const folder = workspaceFolderForDoc(vscode.window.activeTextEditor?.document);
+    ensureTerminal(folder);
+}
+
+export function registerReplCommands(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand('phel.repl.start', startRepl),
+        vscode.commands.registerCommand('phel.repl.evalForm', evalForm),
+        vscode.commands.registerCommand('phel.repl.evalSelection', evalSelection),
+        vscode.commands.registerCommand('phel.repl.evalNextForm', evalNextForm),
+        vscode.commands.registerCommand('phel.repl.evalFile', evalFile)
+    );
+}

--- a/src/test/phelRepl.test.ts
+++ b/src/test/phelRepl.test.ts
@@ -1,0 +1,55 @@
+import * as assert from 'node:assert/strict';
+import { flattenForTerminal, nextTopLevelFormAfter, topLevelFormAt } from '../phelRepl';
+
+describe('phelRepl.topLevelFormAt', () => {
+    it('returns the form spanning the cursor', () => {
+        const src = '(defn a [] 1)\n(defn b [] 2)';
+        const f = topLevelFormAt(src, 5);
+        assert.ok(f);
+        assert.equal(f?.text, '(defn a [] 1)');
+    });
+
+    it('returns the second form when the cursor is in it', () => {
+        const src = '(defn a [] 1)\n(defn b [] 2)';
+        const f = topLevelFormAt(src, 20);
+        assert.equal(f?.text, '(defn b [] 2)');
+    });
+
+    it('returns null between forms', () => {
+        const src = '(a)\n\n(b)';
+        const f = topLevelFormAt(src, 4);
+        assert.equal(f, null);
+    });
+
+    it('skips line comments', () => {
+        const src = '; comment\n(answer)';
+        assert.equal(topLevelFormAt(src, 12)?.text, '(answer)');
+    });
+});
+
+describe('phelRepl.nextTopLevelFormAfter', () => {
+    it('returns the next top-level form after offset', () => {
+        const src = '(a)\n(b)\n(c)';
+        const f = nextTopLevelFormAfter(src, 4);
+        assert.equal(f?.text, '(b)');
+    });
+
+    it('returns null past the last form', () => {
+        const src = '(a)';
+        assert.equal(nextTopLevelFormAfter(src, 10), null);
+    });
+});
+
+describe('phelRepl.flattenForTerminal', () => {
+    it('collapses newlines to single spaces', () => {
+        assert.equal(flattenForTerminal('(defn a\n  []\n  1)'), '(defn a [] 1)');
+    });
+
+    it('preserves single-line input unchanged', () => {
+        assert.equal(flattenForTerminal('(+ 1 2)'), '(+ 1 2)');
+    });
+
+    it('trims trailing whitespace', () => {
+        assert.equal(flattenForTerminal('(+ 1 2)\n'), '(+ 1 2)');
+    });
+});


### PR DESCRIPTION
## Summary

- `Phel: Start REPL` opens an integrated terminal running the configured Phel CLI (`phel.repl.command` + `phel.repl.args`, default `vendor/bin/phel repl`).
- Eval commands send to that terminal:
  - `phel.repl.evalForm` (`ctrl+enter`) — top-level form under cursor.
  - `phel.repl.evalSelection` (`ctrl+shift+enter`) — selection or current line.
  - `phel.repl.evalNextForm` — next top-level form, advances cursor.
  - `phel.repl.evalFile` — whole file.
- Multi-line forms are flattened to a single line so the terminal REPL doesn't see continuation prompts.
- Setting `phel.repl.enabled = false` skips registering the commands.

Form-finding logic lives in `phelRepl.ts` with unit tests; the provider is a thin VS Code wrapper.

## Test plan

- [ ] Open a `.phel` file, run `Phel: Start REPL`, terminal opens with `phel repl`.
- [ ] Cursor inside `(defn foo [] 1)`, press `ctrl+enter`, the form is sent and evaluated.
- [ ] Select `(+ 1 2)`, press `ctrl+shift+enter`, sent.
- [ ] `Phel: Eval Next Form` advances cursor past the form just sent.
- [ ] `Phel: Eval File` sends the whole buffer.
- [ ] CI green (222 tests).