### PR TITLE
feat(refactor): references + symbols + rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 - Go-to-definition: jumps from a symbol to its workspace `defn`.
 - Paredit commands: slurp/barf forward and backward, raise, and wrap with `( )` / `[ ]` / `{ }`. Default keys for `.phel`: `ctrl+shift+]` / `ctrl+shift+[` (slurp/barf forward), `ctrl+shift+9` / `ctrl+shift+0` (slurp/barf backward), `ctrl+shift+r` (raise), `alt+w` (wrap).
 - REPL integration: `Phel: Start REPL` opens a terminal running `phel repl`; `ctrl+enter` evals the form under the cursor, `ctrl+shift+enter` evals the selection. Commands also include eval next form and eval file.
+- Find-all-references (`shift+F12`) across every indexed `.phel` file.
+- Document outline + Go to Symbol in Workspace (`cmd+T`).
+- Rename refactor (`F2`): renames the symbol in every workspace file; rejects invalid names.
 
 ### Changed
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,9 @@ import { PhelFormatProvider } from './phelFormatProvider';
 import { PhelTestCodeLensProvider } from './phelTestCodeLensProvider';
 import { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
 import { PhelDefinitionProvider } from './phelDefinitionProvider';
+import { PhelReferenceProvider } from './phelReferenceProvider';
+import { PhelRenameProvider } from './phelRenameProvider';
+import { PhelDocumentSymbolProvider, PhelWorkspaceSymbolProvider } from './phelSymbolProviders';
 import { registerPareditCommands } from './phelPareditProvider';
 import { registerReplCommands } from './phelReplProvider';
 
@@ -152,6 +155,27 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.languages.registerDefinitionProvider(
             'phel',
             new PhelDefinitionProvider(workspaceIndexer)
+        )
+    );
+
+    context.subscriptions.push(
+        vscode.languages.registerReferenceProvider(
+            'phel',
+            new PhelReferenceProvider(workspaceIndexer)
+        )
+    );
+
+    context.subscriptions.push(
+        vscode.languages.registerRenameProvider('phel', new PhelRenameProvider(workspaceIndexer))
+    );
+
+    context.subscriptions.push(
+        vscode.languages.registerDocumentSymbolProvider('phel', new PhelDocumentSymbolProvider())
+    );
+
+    context.subscriptions.push(
+        vscode.languages.registerWorkspaceSymbolProvider(
+            new PhelWorkspaceSymbolProvider(workspaceIndexer)
         )
     );
 

--- a/src/phelReferenceProvider.ts
+++ b/src/phelReferenceProvider.ts
@@ -1,0 +1,88 @@
+// Find-all-references for `.phel` symbols. Walks every indexed file plus
+// the active document, looking for occurrences of the symbol under the
+// cursor (skipping strings / comments / char literals).
+
+import * as fs from 'node:fs/promises';
+import * as vscode from 'vscode';
+import { findOccurrences } from './phelReferences';
+import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
+
+const SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;
+
+export class PhelReferenceProvider implements vscode.ReferenceProvider {
+    constructor(private readonly indexer: PhelWorkspaceIndexer) {}
+
+    async provideReferences(
+        document: vscode.TextDocument,
+        position: vscode.Position
+    ): Promise<vscode.Location[]> {
+        const range = document.getWordRangeAtPosition(position, SYMBOL_RE);
+        if (!range) {
+            return [];
+        }
+        const word = document.getText(range);
+        return findReferenceLocations(word, document, this.indexer);
+    }
+}
+
+export async function findReferenceLocations(
+    name: string,
+    activeDoc: vscode.TextDocument,
+    indexer: PhelWorkspaceIndexer
+): Promise<vscode.Location[]> {
+    const out: vscode.Location[] = [];
+    const seen = new Set<string>();
+
+    addOccurrencesFromDoc(name, activeDoc, out);
+    seen.add(activeDoc.uri.fsPath);
+
+    const indexedFiles = new Set<string>(indexer.index.allDocs().map((d) => d.sourceFile));
+    for (const file of indexedFiles) {
+        if (seen.has(file)) {
+            continue;
+        }
+        seen.add(file);
+        const opened = vscode.workspace.textDocuments.find((d) => d.uri.fsPath === file);
+        if (opened) {
+            addOccurrencesFromDoc(name, opened, out);
+            continue;
+        }
+        try {
+            const text = await fs.readFile(file, 'utf-8');
+            addOccurrencesFromText(name, vscode.Uri.file(file), text, out);
+        } catch {
+            // File disappeared between indexing and the request.
+        }
+    }
+    return out;
+}
+
+function addOccurrencesFromDoc(
+    name: string,
+    doc: vscode.TextDocument,
+    out: vscode.Location[]
+): void {
+    addOccurrencesFromText(name, doc.uri, doc.getText(), out, doc);
+}
+
+function addOccurrencesFromText(
+    name: string,
+    uri: vscode.Uri,
+    text: string,
+    out: vscode.Location[],
+    doc?: vscode.TextDocument
+): void {
+    for (const occ of findOccurrences(text, name)) {
+        const start = doc ? doc.positionAt(occ.start) : positionAt(text, occ.start);
+        const end = doc ? doc.positionAt(occ.end) : positionAt(text, occ.end);
+        out.push(new vscode.Location(uri, new vscode.Range(start, end)));
+    }
+}
+
+function positionAt(text: string, offset: number): vscode.Position {
+    const before = text.slice(0, offset);
+    const lastNewline = before.lastIndexOf('\n');
+    const line = (before.match(/\n/g) ?? []).length;
+    const character = lastNewline < 0 ? offset : offset - lastNewline - 1;
+    return new vscode.Position(line, character);
+}

--- a/src/phelReferences.ts
+++ b/src/phelReferences.ts
@@ -1,0 +1,146 @@
+// Pure occurrence scanner. Walks `src` and returns every position where
+// `name` appears as a symbol token (i.e. surrounded by non-symbol delimiters
+// and not inside a string, character literal, or comment).
+//
+// Used by the references provider, the rename provider, and (potentially)
+// future refactorings. No `vscode` imports so the logic is unit-testable.
+
+const SYMBOL_TERMINATOR = new Set([
+    ' ',
+    '\t',
+    '\n',
+    '\r',
+    ',',
+    '(',
+    ')',
+    '[',
+    ']',
+    '{',
+    '}',
+    '"',
+    ';',
+    "'",
+    '`',
+    '@',
+    '~',
+    '^',
+]);
+
+export interface Occurrence {
+    start: number;
+    end: number;
+}
+
+/**
+ * Find every occurrence of `name` as a standalone symbol token in `src`.
+ * Skips strings (`"..."`), char literals (`\c`), line comments (`;...`),
+ * block comments (`#| ... |#`), and `#_`-discarded forms.
+ */
+export function findOccurrences(src: string, name: string): Occurrence[] {
+    if (!name) {
+        return [];
+    }
+    const out: Occurrence[] = [];
+    const len = src.length;
+    let i = 0;
+    while (i < len) {
+        const c = src[i];
+        if (c === '"') {
+            i = skipString(src, i, len);
+            continue;
+        }
+        if (c === ';') {
+            while (i < len && src[i] !== '\n') {
+                i++;
+            }
+            continue;
+        }
+        if (c === '#' && src[i + 1] === '|') {
+            i = skipBlockComment(src, i, len);
+            continue;
+        }
+        if (c === '\\') {
+            i = skipChar(src, i, len);
+            continue;
+        }
+        if (matchesAt(src, i, name)) {
+            const end = i + name.length;
+            const before = i === 0 ? '' : src[i - 1];
+            const after = end >= len ? '' : src[end];
+            if (isBoundary(before) && isBoundary(after)) {
+                out.push({ start: i, end });
+                i = end;
+                continue;
+            }
+        }
+        i++;
+    }
+    return out;
+}
+
+function skipString(src: string, start: number, len: number): number {
+    let i = start + 1;
+    while (i < len) {
+        const c = src[i];
+        if (c === '\\') {
+            i += 2;
+            continue;
+        }
+        if (c === '"') {
+            return i + 1;
+        }
+        i++;
+    }
+    return len;
+}
+
+function skipBlockComment(src: string, start: number, len: number): number {
+    let i = start + 2;
+    while (i < len - 1) {
+        if (src[i] === '|' && src[i + 1] === '#') {
+            return i + 2;
+        }
+        i++;
+    }
+    return len;
+}
+
+function skipChar(src: string, start: number, len: number): number {
+    let i = start + 1;
+    while (i < len && !SYMBOL_TERMINATOR.has(src[i])) {
+        i++;
+    }
+    return i === start + 1 && i < len ? i + 1 : i;
+}
+
+function matchesAt(src: string, i: number, name: string): boolean {
+    for (let k = 0; k < name.length; k++) {
+        if (src[i + k] !== name[k]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function isBoundary(c: string): boolean {
+    if (c === '') {
+        return true;
+    }
+    return SYMBOL_TERMINATOR.has(c);
+}
+
+/**
+ * Validate that `name` is a legal Phel symbol token (no whitespace, no
+ * delimiter chars). Used by the rename provider before applying edits.
+ */
+export function isValidSymbolName(name: string): boolean {
+    if (!name) {
+        return false;
+    }
+    for (const c of name) {
+        if (SYMBOL_TERMINATOR.has(c)) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/src/phelRenameProvider.ts
+++ b/src/phelRenameProvider.ts
@@ -1,0 +1,53 @@
+// Workspace-wide rename for Phel symbols. Reuses the find-references
+// scanner so every standalone occurrence (excluding strings and comments)
+// is rewritten consistently.
+//
+// `prepareRename` rejects names that aren't valid Phel symbol tokens to
+// avoid producing broken source.
+
+import * as vscode from 'vscode';
+import { findReferenceLocations } from './phelReferenceProvider';
+import { isValidSymbolName } from './phelReferences';
+import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
+
+const SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;
+
+export class PhelRenameProvider implements vscode.RenameProvider {
+    constructor(private readonly indexer: PhelWorkspaceIndexer) {}
+
+    prepareRename(
+        document: vscode.TextDocument,
+        position: vscode.Position
+    ): vscode.ProviderResult<vscode.Range | { range: vscode.Range; placeholder: string }> {
+        const range = document.getWordRangeAtPosition(position, SYMBOL_RE);
+        if (!range) {
+            throw new Error('No symbol at cursor.');
+        }
+        return { range, placeholder: document.getText(range) };
+    }
+
+    async provideRenameEdits(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        newName: string
+    ): Promise<vscode.WorkspaceEdit | undefined> {
+        if (!isValidSymbolName(newName)) {
+            throw new Error(`'${newName}' is not a valid Phel symbol name.`);
+        }
+        const range = document.getWordRangeAtPosition(position, SYMBOL_RE);
+        if (!range) {
+            return undefined;
+        }
+        const oldName = document.getText(range);
+        if (oldName === newName) {
+            return undefined;
+        }
+
+        const locations = await findReferenceLocations(oldName, document, this.indexer);
+        const edit = new vscode.WorkspaceEdit();
+        for (const loc of locations) {
+            edit.replace(loc.uri, loc.range, newName);
+        }
+        return edit;
+    }
+}

--- a/src/phelSymbolProviders.ts
+++ b/src/phelSymbolProviders.ts
@@ -1,0 +1,93 @@
+// Surface user-defined Phel forms in:
+//   * the editor outline (DocumentSymbolProvider)
+//   * the "Go to Symbol in Workspace" picker (WorkspaceSymbolProvider)
+//
+// Both providers reuse the parsed `PhelDoc`s already maintained by the
+// workspace indexer. Document symbols re-parse the active buffer so unsaved
+// edits show up; workspace symbols read from the persistent index.
+
+import * as vscode from 'vscode';
+import { parsePhelFile } from './phelDocs';
+import type { PhelDoc, PhelDocKind } from './phelDocs';
+import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
+
+const NAMESPACE_RE = /\((?:ns|in-ns)\s+([A-Za-z][\w.-]*)/;
+
+function symbolKindFor(kind: PhelDocKind): vscode.SymbolKind {
+    switch (kind) {
+        case 'fn':
+            return vscode.SymbolKind.Function;
+        case 'macro':
+            return vscode.SymbolKind.Method;
+        case 'def':
+        default:
+            return vscode.SymbolKind.Variable;
+    }
+}
+
+function detailFor(doc: PhelDoc): string {
+    if (doc.signature) {
+        return doc.signature;
+    }
+    return doc.private ? 'private' : '';
+}
+
+function detectNamespace(text: string, fallback: string): string {
+    const match = text.match(NAMESPACE_RE);
+    return match ? match[1] : fallback;
+}
+
+export class PhelDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
+    provideDocumentSymbols(
+        document: vscode.TextDocument
+    ): vscode.ProviderResult<vscode.DocumentSymbol[]> {
+        const text = document.getText();
+        const ns = detectNamespace(text, document.uri.fsPath);
+        const docs = parsePhelFile(text, ns);
+        return docs.map((d) => buildDocumentSymbol(d, document));
+    }
+}
+
+function buildDocumentSymbol(doc: PhelDoc, document: vscode.TextDocument): vscode.DocumentSymbol {
+    const line = doc.line ?? 0;
+    const column = doc.column ?? 0;
+    const start = new vscode.Position(line, column);
+    const end =
+        line < document.lineCount
+            ? document.lineAt(Math.min(line, document.lineCount - 1)).range.end
+            : start;
+    const range = new vscode.Range(start, end);
+    return new vscode.DocumentSymbol(
+        doc.name,
+        detailFor(doc),
+        symbolKindFor(doc.kind),
+        range,
+        new vscode.Range(start, start.translate(0, doc.name.length))
+    );
+}
+
+export class PhelWorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider {
+    constructor(private readonly indexer: PhelWorkspaceIndexer) {}
+
+    provideWorkspaceSymbols(query: string): vscode.ProviderResult<vscode.SymbolInformation[]> {
+        const lower = query.toLowerCase();
+        const out: vscode.SymbolInformation[] = [];
+        for (const doc of this.indexer.index.allDocs()) {
+            if (!doc.name.toLowerCase().includes(lower)) {
+                continue;
+            }
+            const line = doc.line ?? 0;
+            const column = doc.column ?? 0;
+            const pos = new vscode.Position(line, column);
+            out.push(
+                new vscode.SymbolInformation(
+                    doc.name,
+                    symbolKindFor(doc.kind),
+                    doc.ns,
+                    new vscode.Location(vscode.Uri.file(doc.sourceFile), pos)
+                )
+            );
+        }
+        return out;
+    }
+}

--- a/src/test/phelReferences.test.ts
+++ b/src/test/phelReferences.test.ts
@@ -1,0 +1,70 @@
+import * as assert from 'node:assert/strict';
+import { findOccurrences, isValidSymbolName } from '../phelReferences';
+
+function offsets(occ: ReturnType<typeof findOccurrences>): number[] {
+    return occ.map((o) => o.start);
+}
+
+describe('phelReferences.findOccurrences', () => {
+    it('finds standalone occurrences', () => {
+        const src = '(foo bar foo)';
+        assert.deepEqual(offsets(findOccurrences(src, 'foo')), [1, 9]);
+    });
+
+    it('does not match substrings', () => {
+        const src = '(foobar foo-bar foo)';
+        assert.deepEqual(offsets(findOccurrences(src, 'foo')), [16]);
+    });
+
+    it('skips strings', () => {
+        const src = '(foo "foo" foo)';
+        assert.deepEqual(offsets(findOccurrences(src, 'foo')), [1, 11]);
+    });
+
+    it('skips line comments', () => {
+        const src = '(foo)\n; foo here\n(foo)';
+        assert.deepEqual(offsets(findOccurrences(src, 'foo')), [1, 18]);
+    });
+
+    it('skips block comments', () => {
+        const src = '(foo) #| foo |# (foo)';
+        assert.deepEqual(offsets(findOccurrences(src, 'foo')), [1, 17]);
+    });
+
+    it('skips char literals', () => {
+        const src = '(foo \\f foo)';
+        assert.deepEqual(offsets(findOccurrences(src, 'foo')), [1, 8]);
+    });
+
+    it('matches at end of file', () => {
+        const src = '(let [x foo])\nfoo';
+        assert.deepEqual(offsets(findOccurrences(src, 'foo')), [8, 14]);
+    });
+
+    it('matches symbols with special chars', () => {
+        const src = '(my-fn? a) (my-fn? b)';
+        assert.deepEqual(offsets(findOccurrences(src, 'my-fn?')), [1, 12]);
+    });
+
+    it('returns empty for empty name', () => {
+        assert.deepEqual(findOccurrences('foo', ''), []);
+    });
+});
+
+describe('phelReferences.isValidSymbolName', () => {
+    it('accepts plain symbols', () => {
+        assert.equal(isValidSymbolName('foo'), true);
+        assert.equal(isValidSymbolName('my-fn?'), true);
+        assert.equal(isValidSymbolName('+'), true);
+    });
+
+    it('rejects empty names', () => {
+        assert.equal(isValidSymbolName(''), false);
+    });
+
+    it('rejects names with delimiters', () => {
+        assert.equal(isValidSymbolName('foo bar'), false);
+        assert.equal(isValidSymbolName('foo)'), false);
+        assert.equal(isValidSymbolName('"foo"'), false);
+    });
+});


### PR DESCRIPTION
## Summary

- Find-all-references (`shift+F12`) walks every indexed `.phel` file plus the active buffer.
- Document outline / breadcrumbs via `DocumentSymbolProvider`.
- `Go to Symbol in Workspace` (`cmd+T`) via `WorkspaceSymbolProvider` reading the existing index.
- Rename refactor (`F2`): `prepareRename` validates the target, `provideRenameEdits` returns a `WorkspaceEdit` covering every occurrence (skipping strings / comments / char literals).
- Pure scanner in `phelReferences.ts` with 12 unit tests.

## Test plan

- [ ] Place cursor on a `defn` name, `shift+F12` lists every call site.
- [ ] Outline view shows defs from the current buffer.
- [ ] `cmd+T foo` filters to `foo` defs across the workspace.
- [ ] `F2` renames a symbol everywhere; rename to `bad name` is rejected.
- [ ] Strings / comments are not edited.
- [ ] CI green (234 tests).