### PR TITLE
feat(selection): expand/shrink by sexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Find-all-references (`shift+F12`) across every indexed `.phel` file.
 - Document outline + Go to Symbol in Workspace (`cmd+T`).
 - Rename refactor (`F2`): renames the symbol in every workspace file; rejects invalid names.
+- Selection expand/shrink by sexp: `ctrl+shift+space` grows the selection to the enclosing form, `ctrl+shift+alt+space` undoes the last grow.
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -264,6 +264,16 @@
                 "command": "phel.repl.evalFile",
                 "title": "Phel: Eval File",
                 "category": "Phel"
+            },
+            {
+                "command": "phel.selection.expand",
+                "title": "Phel: Expand Selection",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.selection.shrink",
+                "title": "Phel: Shrink Selection",
+                "category": "Phel"
             }
         ],
         "keybindings": [
@@ -312,6 +322,18 @@
                 "command": "phel.repl.evalSelection",
                 "key": "ctrl+shift+enter",
                 "mac": "cmd+shift+enter",
+                "when": "editorTextFocus && editorLangId == phel"
+            },
+            {
+                "command": "phel.selection.expand",
+                "key": "ctrl+shift+space",
+                "mac": "cmd+shift+space",
+                "when": "editorTextFocus && editorLangId == phel"
+            },
+            {
+                "command": "phel.selection.shrink",
+                "key": "ctrl+shift+alt+space",
+                "mac": "cmd+shift+alt+space",
                 "when": "editorTextFocus && editorLangId == phel"
             }
         ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import { PhelRenameProvider } from './phelRenameProvider';
 import { PhelDocumentSymbolProvider, PhelWorkspaceSymbolProvider } from './phelSymbolProviders';
 import { registerPareditCommands } from './phelPareditProvider';
 import { registerReplCommands } from './phelReplProvider';
+import { registerSelectionCommands } from './phelSelectionProvider';
 
 let sourceMapManager: SourceMapManager;
 
@@ -214,6 +215,8 @@ export function activate(context: vscode.ExtensionContext) {
     if (vscode.workspace.getConfiguration('phel').get<boolean>('repl.enabled', true)) {
         registerReplCommands(context);
     }
+
+    registerSelectionCommands(context);
 
     // Provide hover information for breakpoints
     context.subscriptions.push(

--- a/src/phelSelection.ts
+++ b/src/phelSelection.ts
@@ -1,0 +1,31 @@
+// Pure helper for selection-expansion. Given a source string and the current
+// selection [start, end], returns the next-larger form span. The provider
+// keeps a per-document stack and pops it for shrink.
+
+import { parseAll, pathAt, type Form } from './phelParedit';
+
+export interface Span {
+    start: number;
+    end: number;
+}
+
+export function expandSelection(src: string, start: number, end: number): Span | null {
+    const forms = parseAll(src);
+    const mid = Math.floor((start + end) / 2);
+    const path = pathAt(forms, mid);
+    const fromPath = pickEnclosing(path, start, end);
+    if (fromPath) {
+        return fromPath;
+    }
+    return pickEnclosing(forms, start, end);
+}
+
+function pickEnclosing(forms: readonly Form[], start: number, end: number): Span | null {
+    for (let i = forms.length - 1; i >= 0; i--) {
+        const f = forms[i];
+        if (f.start <= start && end <= f.end && (f.start < start || f.end > end)) {
+            return { start: f.start, end: f.end };
+        }
+    }
+    return null;
+}

--- a/src/phelSelectionProvider.ts
+++ b/src/phelSelectionProvider.ts
@@ -1,0 +1,90 @@
+// Per-editor expand/shrink commands. Maintains a stack of selections so
+// "shrink" undoes the most recent expansion.
+//
+// The stack is keyed by `TextEditor` (each editor instance is identity-stable
+// for the lifetime of the document). If the user changes the selection
+// outside of these commands, the stack is reset so we never restore a stale
+// span.
+
+import * as vscode from 'vscode';
+import { expandSelection } from './phelSelection';
+
+interface ExpansionEntry {
+    start: number;
+    end: number;
+}
+
+const stacks = new WeakMap<vscode.TextEditor, ExpansionEntry[]>();
+let mutating = false;
+
+function snapshot(editor: vscode.TextEditor): ExpansionEntry {
+    const sel = editor.selection;
+    return {
+        start: editor.document.offsetAt(sel.start),
+        end: editor.document.offsetAt(sel.end),
+    };
+}
+
+function selectRange(editor: vscode.TextEditor, span: ExpansionEntry): void {
+    const start = editor.document.positionAt(span.start);
+    const end = editor.document.positionAt(span.end);
+    mutating = true;
+    editor.selection = new vscode.Selection(start, end);
+    editor.revealRange(new vscode.Range(start, end));
+    mutating = false;
+}
+
+function topMatchesCurrent(editor: vscode.TextEditor): boolean {
+    const stack = stacks.get(editor);
+    if (!stack || stack.length === 0) {
+        return false;
+    }
+    const top = stack[stack.length - 1];
+    const current = snapshot(editor);
+    return top.start === current.start && top.end === current.end;
+}
+
+export function expand(): void {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'phel') {
+        return;
+    }
+    const current = snapshot(editor);
+    const next = expandSelection(editor.document.getText(), current.start, current.end);
+    if (!next) {
+        return;
+    }
+    let stack = stacks.get(editor);
+    if (!stack || !topMatchesCurrent(editor)) {
+        stack = [current];
+        stacks.set(editor, stack);
+    }
+    stack.push(next);
+    selectRange(editor, next);
+}
+
+export function shrink(): void {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'phel') {
+        return;
+    }
+    const stack = stacks.get(editor);
+    if (!stack || stack.length < 2 || !topMatchesCurrent(editor)) {
+        return;
+    }
+    stack.pop();
+    selectRange(editor, stack[stack.length - 1]);
+}
+
+export function registerSelectionCommands(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand('phel.selection.expand', expand),
+        vscode.commands.registerCommand('phel.selection.shrink', shrink),
+        vscode.window.onDidChangeTextEditorSelection((e) => {
+            if (mutating) {
+                return;
+            }
+            stacks.delete(e.textEditor);
+        })
+    );
+}

--- a/src/test/phelSelection.test.ts
+++ b/src/test/phelSelection.test.ts
@@ -1,0 +1,42 @@
+import * as assert from 'node:assert/strict';
+import { expandSelection } from '../phelSelection';
+
+describe('phelSelection.expandSelection', () => {
+    it('expands an empty cursor to the innermost form', () => {
+        const src = '(foo bar)';
+        // cursor in "bar"
+        const r = expandSelection(src, 6, 6);
+        assert.deepEqual(r, { start: 5, end: 8 });
+    });
+
+    it('expands an atom to its enclosing list', () => {
+        const src = '(foo bar)';
+        const r = expandSelection(src, 5, 8);
+        assert.deepEqual(r, { start: 0, end: 9 });
+    });
+
+    it('expands again to outer list', () => {
+        const src = '(foo (bar baz))';
+        // selection on `bar` (6..9)
+        let r = expandSelection(src, 6, 9);
+        assert.deepEqual(r, { start: 5, end: 14 });
+        r = expandSelection(src, 5, 14);
+        assert.deepEqual(r, { start: 0, end: 15 });
+    });
+
+    it('returns null when there is no larger form', () => {
+        const src = '(a)';
+        const r = expandSelection(src, 0, 3);
+        assert.equal(r, null);
+    });
+
+    it('returns null on empty input', () => {
+        assert.equal(expandSelection('', 0, 0), null);
+    });
+
+    it('expands cursor inside whitespace to the surrounding form', () => {
+        const src = '(foo   bar)';
+        const r = expandSelection(src, 5, 5);
+        assert.deepEqual(r, { start: 0, end: 11 });
+    });
+});


### PR DESCRIPTION
## Summary

- `phel.selection.expand` (`ctrl+shift+space`) grows the current selection to the next-larger Phel form.
- `phel.selection.shrink` (`ctrl+shift+alt+space`) reverts the most recent expansion.
- Expand logic is pure (`phelSelection.ts`) and reuses the paredit reader; provider keeps a per-editor stack and resets it when the user moves the caret manually.

## Test plan

- [ ] Cursor on `bar` in `(foo bar)` → expand selects `bar`, again → `(foo bar)`.
- [ ] `ctrl+shift+alt+space` shrinks back step-by-step.
- [ ] Manually clicking elsewhere resets the stack.
- [ ] CI green (240 tests).