### PR TITLE
feat(completion): auto-add :require for cross-ns workspace symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Document outline + Go to Symbol in Workspace (`cmd+T`).
 - Rename refactor (`F2`): renames the symbol in every workspace file; rejects invalid names.
 - Selection expand/shrink by sexp: `ctrl+shift+space` grows the selection to the enclosing form, `ctrl+shift+alt+space` undoes the last grow.
+- Auto-import: completing a workspace symbol from another namespace also inserts the matching `:require` entry into the current file's `(ns ...)` form (`:refer [name]`). Skipped for `phel.core` and same-ns symbols.
 
 ### Changed
 

--- a/src/phelCompletionProvider.ts
+++ b/src/phelCompletionProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { PHEL_DOCS } from './phelCoreDocs';
 import { CORE_FNS, MACROS, SPECIAL_FORMS } from './phelCoreSymbols';
 import { lookupSymbol, renderDocMarkdown } from './phelDocsLookup';
+import { buildRequireEdit, parseNsForm, type NsForm } from './phelNsAnalyzer';
 import { combineDocs } from './phelWorkspaceIndex';
 import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
 
@@ -11,6 +12,10 @@ interface ItemSpec {
     label: string;
     kind: vscode.CompletionItemKind;
     detail: string;
+    /** Namespace this symbol lives in. Used for auto-import. */
+    ns?: string;
+    /** Whether this symbol is a workspace doc (vs a core fn / built-in). */
+    workspace?: boolean;
 }
 
 function buildBaseSpecs(): ItemSpec[] {
@@ -60,6 +65,8 @@ function workspaceSpecs(indexer?: PhelWorkspaceIndexer): ItemSpec[] {
                     ? vscode.CompletionItemKind.Keyword
                     : vscode.CompletionItemKind.Function,
             detail: `${doc.ns} (workspace)`,
+            ns: doc.ns,
+            workspace: true,
         });
     }
     return specs;
@@ -68,7 +75,9 @@ function workspaceSpecs(indexer?: PhelWorkspaceIndexer): ItemSpec[] {
 function buildItem(
     spec: ItemSpec,
     range: vscode.Range | undefined,
-    docs: readonly import('./phelDocs').PhelDoc[]
+    docs: readonly import('./phelDocs').PhelDoc[],
+    document: vscode.TextDocument,
+    nsForm: NsForm | null
 ): vscode.CompletionItem {
     const item = new vscode.CompletionItem(spec.label, spec.kind);
     item.detail = spec.detail;
@@ -82,7 +91,28 @@ function buildItem(
     if (range) {
         item.range = range;
     }
+    if (spec.workspace && spec.ns && nsForm && shouldAutoImport(spec.ns, nsForm)) {
+        const edit = buildRequireEdit(nsForm, spec.ns, spec.label);
+        if (edit) {
+            const pos = document.positionAt(edit.insertAt);
+            item.additionalTextEdits = [vscode.TextEdit.insert(pos, edit.text)];
+            item.detail = `${spec.detail} (auto-add :require)`;
+        }
+    }
     return item;
+}
+
+function shouldAutoImport(targetNs: string, nsForm: NsForm): boolean {
+    if (!targetNs) {
+        return false;
+    }
+    if (targetNs === nsForm.name) {
+        return false;
+    }
+    if (targetNs === 'phel.core') {
+        return false;
+    }
+    return true;
 }
 
 export class PhelCompletionProvider implements vscode.CompletionItemProvider {
@@ -99,6 +129,7 @@ export class PhelCompletionProvider implements vscode.CompletionItemProvider {
             ? combineDocs(this.indexer.index.allDocs(), PHEL_DOCS)
             : [...PHEL_DOCS];
         const specs = [...this.baseSpecs, ...workspaceSpecs(this.indexer)];
-        return specs.map((spec) => buildItem(spec, range, merged));
+        const nsForm = parseNsForm(document.getText());
+        return specs.map((spec) => buildItem(spec, range, merged, document, nsForm));
     }
 }

--- a/src/phelNsAnalyzer.ts
+++ b/src/phelNsAnalyzer.ts
@@ -1,0 +1,196 @@
+// Pure analysis of the `(ns ...)` form at the top of a Phel file. The
+// completion provider uses this to decide whether a chosen workspace symbol
+// needs a new `:require` entry, and to build the text edit that adds it.
+//
+// Only the shapes Phel actually emits are handled:
+//
+//   (ns my.app)
+//   (ns my.app
+//     (:require [other.ns :refer [a b] :as o]))
+
+import { parseAll, type Form } from './phelParedit';
+
+export interface RequireEntry {
+    /** Span of the `[other.ns ...]` vector. */
+    start: number;
+    end: number;
+    ns: string;
+    /** Span of the `[a b ...]` `:refer` vector, if any. */
+    referVector?: { start: number; end: number };
+    /** Names listed in `:refer [...]`. Empty when there is no `:refer`. */
+    refer: string[];
+    /** Alias from `:as`, if present. */
+    as?: string;
+}
+
+export interface RequireClause {
+    /** Span of the `(:require ...)` list. */
+    start: number;
+    end: number;
+    entries: RequireEntry[];
+}
+
+export interface NsForm {
+    /** Span of the entire `(ns ...)` list. */
+    start: number;
+    end: number;
+    /** Position just before the closing `)` of the ns form (for inserts). */
+    closeOffset: number;
+    name: string;
+    requireClause: RequireClause | null;
+}
+
+export function parseNsForm(src: string): NsForm | null {
+    const forms = parseAll(src);
+    for (const form of forms) {
+        if (form.kind !== 'list' || form.children.length === 0) {
+            continue;
+        }
+        const head = form.children[0];
+        if (head.kind !== 'atom') {
+            continue;
+        }
+        if (atomText(src, head) !== 'ns') {
+            continue;
+        }
+        const nameChild = form.children[1];
+        if (!nameChild || nameChild.kind !== 'atom') {
+            return null;
+        }
+        const name = atomText(src, nameChild);
+        const requireClause = findRequireClause(src, form);
+        return {
+            start: form.start,
+            end: form.end,
+            closeOffset: form.innerEnd,
+            name,
+            requireClause,
+        };
+    }
+    return null;
+}
+
+function atomText(src: string, atom: Form): string {
+    return src.slice(atom.start, atom.end);
+}
+
+function findRequireClause(src: string, ns: Form): RequireClause | null {
+    for (const child of ns.children) {
+        if (child.kind !== 'list' || child.children.length === 0) {
+            continue;
+        }
+        const head = child.children[0];
+        if (head.kind !== 'atom') {
+            continue;
+        }
+        if (atomText(src, head) !== ':require') {
+            continue;
+        }
+        return {
+            start: child.start,
+            end: child.end,
+            entries: child.children.slice(1).map((entry) => parseRequireEntry(src, entry)),
+        };
+    }
+    return null;
+}
+
+function parseRequireEntry(src: string, entry: Form): RequireEntry {
+    if (entry.kind === 'atom') {
+        return {
+            start: entry.start,
+            end: entry.end,
+            ns: atomText(src, entry),
+            refer: [],
+        };
+    }
+    if (entry.kind !== 'vector' || entry.children.length === 0) {
+        return {
+            start: entry.start,
+            end: entry.end,
+            ns: '',
+            refer: [],
+        };
+    }
+    const nsAtom = entry.children[0];
+    const ns = nsAtom.kind === 'atom' ? atomText(src, nsAtom) : '';
+    let refer: string[] = [];
+    let referVector: { start: number; end: number } | undefined;
+    let as: string | undefined;
+    for (let i = 1; i < entry.children.length; i++) {
+        const kw = entry.children[i];
+        if (kw.kind !== 'atom') {
+            continue;
+        }
+        const text = atomText(src, kw);
+        const next = entry.children[i + 1];
+        if (text === ':refer' && next?.kind === 'vector') {
+            refer = next.children.filter((c) => c.kind === 'atom').map((c) => atomText(src, c));
+            referVector = { start: next.start, end: next.end };
+            i++;
+        } else if (text === ':as' && next?.kind === 'atom') {
+            as = atomText(src, next);
+            i++;
+        }
+    }
+    return { start: entry.start, end: entry.end, ns, refer, referVector, as };
+}
+
+export interface RequireEdit {
+    /** Offset where the new text should be inserted. */
+    insertAt: number;
+    text: string;
+}
+
+/**
+ * Compute the edit needed so `targetNs/name` is reachable as the bare token
+ * `name` from the file whose ns form is `nsForm`. Returns null when no edit
+ * is necessary (already imported, or no `(ns ...)` form to amend).
+ */
+export function buildRequireEdit(
+    nsForm: NsForm | null,
+    targetNs: string,
+    name: string
+): RequireEdit | null {
+    if (!nsForm) {
+        return null;
+    }
+    if (!targetNs || !name) {
+        return null;
+    }
+    if (nsForm.name === targetNs) {
+        return null;
+    }
+
+    if (!nsForm.requireClause) {
+        return {
+            insertAt: nsForm.closeOffset,
+            text: `\n  (:require [${targetNs} :refer [${name}]])`,
+        };
+    }
+
+    const existing = nsForm.requireClause.entries.find((e) => e.ns === targetNs);
+    if (!existing) {
+        return {
+            insertAt: nsForm.requireClause.end - 1,
+            text: `\n            [${targetNs} :refer [${name}]]`,
+        };
+    }
+
+    if (existing.refer.includes(name)) {
+        return null;
+    }
+
+    if (existing.referVector) {
+        const referText = existing.refer.length === 0 ? name : ` ${name}`;
+        return {
+            insertAt: existing.referVector.end - 1,
+            text: referText,
+        };
+    }
+
+    return {
+        insertAt: existing.end - 1,
+        text: ` :refer [${name}]`,
+    };
+}

--- a/src/test/phelNsAnalyzer.test.ts
+++ b/src/test/phelNsAnalyzer.test.ts
@@ -1,0 +1,81 @@
+import * as assert from 'node:assert/strict';
+import { buildRequireEdit, parseNsForm } from '../phelNsAnalyzer';
+
+function applyEdit(src: string, edit: ReturnType<typeof buildRequireEdit>): string {
+    if (!edit) {
+        return src;
+    }
+    return src.slice(0, edit.insertAt) + edit.text + src.slice(edit.insertAt);
+}
+
+describe('phelNsAnalyzer.parseNsForm', () => {
+    it('parses a bare (ns name) form', () => {
+        const ns = parseNsForm('(ns my.app)');
+        assert.equal(ns?.name, 'my.app');
+        assert.equal(ns?.requireClause, null);
+    });
+
+    it('parses a require clause with :refer and :as', () => {
+        const src = '(ns my.app\n  (:require [other.ns :refer [a b] :as o]))';
+        const ns = parseNsForm(src);
+        assert.ok(ns);
+        assert.equal(ns?.requireClause?.entries.length, 1);
+        const entry = ns?.requireClause?.entries[0];
+        assert.equal(entry?.ns, 'other.ns');
+        assert.deepEqual(entry?.refer, ['a', 'b']);
+        assert.equal(entry?.as, 'o');
+    });
+
+    it('returns null when there is no ns form', () => {
+        assert.equal(parseNsForm('(defn foo [])'), null);
+    });
+});
+
+describe('phelNsAnalyzer.buildRequireEdit', () => {
+    it('returns null for the same namespace', () => {
+        const ns = parseNsForm('(ns my.app)');
+        assert.equal(buildRequireEdit(ns, 'my.app', 'foo'), null);
+    });
+
+    it('inserts a fresh require clause when none exists', () => {
+        const src = '(ns my.app)';
+        const ns = parseNsForm(src);
+        const edit = buildRequireEdit(ns, 'other.ns', 'foo');
+        const result = applyEdit(src, edit);
+        assert.equal(result, '(ns my.app\n  (:require [other.ns :refer [foo]]))');
+    });
+
+    it('appends a new entry when require exists but ns missing', () => {
+        const src = '(ns my.app\n  (:require [a.b :refer [x]]))';
+        const ns = parseNsForm(src);
+        const edit = buildRequireEdit(ns, 'other.ns', 'foo');
+        const result = applyEdit(src, edit);
+        assert.match(result, /\[other\.ns :refer \[foo\]\]/);
+    });
+
+    it('extends an existing :refer vector', () => {
+        const src = '(ns my.app\n  (:require [other.ns :refer [a]]))';
+        const ns = parseNsForm(src);
+        const edit = buildRequireEdit(ns, 'other.ns', 'b');
+        const result = applyEdit(src, edit);
+        assert.equal(result, '(ns my.app\n  (:require [other.ns :refer [a b]]))');
+    });
+
+    it('adds :refer when entry has only :as', () => {
+        const src = '(ns my.app\n  (:require [other.ns :as o]))';
+        const ns = parseNsForm(src);
+        const edit = buildRequireEdit(ns, 'other.ns', 'foo');
+        const result = applyEdit(src, edit);
+        assert.equal(result, '(ns my.app\n  (:require [other.ns :as o :refer [foo]]))');
+    });
+
+    it('returns null when the symbol is already referred', () => {
+        const src = '(ns my.app\n  (:require [other.ns :refer [foo]]))';
+        const ns = parseNsForm(src);
+        assert.equal(buildRequireEdit(ns, 'other.ns', 'foo'), null);
+    });
+
+    it('returns null when there is no ns form', () => {
+        assert.equal(buildRequireEdit(null, 'other.ns', 'foo'), null);
+    });
+});


### PR DESCRIPTION
## Summary

- Completing a workspace symbol from another namespace also inserts the matching `(:require [target.ns :refer [name]])` clause via `additionalTextEdits`.
- Handles four shapes: no `(ns ...)` at all (skip), `ns` without `:require` (insert clause), `:require` without that ns (append entry), entry without `:refer` (add `:refer [name]`), entry with `:refer` (extend the vector).
- Skipped for `phel.core` (auto-loaded) and same-ns symbols.
- Pure analyzer (`phelNsAnalyzer.ts`) with 10 unit tests.

## Test plan

- [ ] Type a symbol from a different file, accept the completion, the `(ns ...)` form gains the `:require` entry.
- [ ] Existing `:require` with the same ns extends the `:refer` vector.
- [ ] `phel.core` completions don't add a require.
- [ ] CI green (250 tests).