### PR TITLE
feat(completion): call-site snippet from signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Rename refactor (`F2`): renames the symbol in every workspace file; rejects invalid names.
 - Selection expand/shrink by sexp: `ctrl+shift+space` grows the selection to the enclosing form, `ctrl+shift+alt+space` undoes the last grow.
 - Auto-import: completing a workspace symbol from another namespace also inserts the matching `:require` entry into the current file's `(ns ...)` form (`:refer [name]`). Skipped for `phel.core` and same-ns symbols.
+- Call snippets: accepting a function completion in callee position (just after `(`) inserts a `name ${1:arg1} ${2:arg2}` skeleton with tab stops, derived from the function's signature.
 
 ### Changed
 

--- a/src/phelCallSnippet.ts
+++ b/src/phelCallSnippet.ts
@@ -1,0 +1,33 @@
+// Build a `${1:arg}`-style snippet from a PhelDoc's first arity signature.
+// The completion provider attaches the result to `item.insertText` only when
+// the cursor sits in callee position (right after `(`).
+
+import { parseSignatureParams } from './phelSignatureHelp';
+
+export function buildCallSnippet(name: string, signature?: string): string | null {
+    if (!signature) {
+        return null;
+    }
+    const params = parseSignatureParams(signature);
+    if (params.length === 0) {
+        return null;
+    }
+    const tabs = params.map((p, i) => `\${${i + 1}:${p.replace(/[{}\\$]/g, '')}}`);
+    return `${name} ${tabs.join(' ')}`;
+}
+
+/**
+ * True when the character immediately before `offset` is an opening `(`,
+ * meaning the user is starting a function call. Whitespace between `(` and
+ * the cursor disqualifies (the user has moved past the callee slot).
+ */
+export function isCalleePosition(linePrefix: string): boolean {
+    let i = linePrefix.length - 1;
+    while (i >= 0 && /[A-Za-z0-9_!?*+<>=/\-.':$&%]/.test(linePrefix[i])) {
+        i--;
+    }
+    if (i < 0) {
+        return false;
+    }
+    return linePrefix[i] === '(';
+}

--- a/src/phelCompletionProvider.ts
+++ b/src/phelCompletionProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { PHEL_DOCS } from './phelCoreDocs';
 import { CORE_FNS, MACROS, SPECIAL_FORMS } from './phelCoreSymbols';
+import { buildCallSnippet, isCalleePosition } from './phelCallSnippet';
 import { lookupSymbol, renderDocMarkdown } from './phelDocsLookup';
 import { buildRequireEdit, parseNsForm, type NsForm } from './phelNsAnalyzer';
 import { combineDocs } from './phelWorkspaceIndex';
@@ -77,7 +78,8 @@ function buildItem(
     range: vscode.Range | undefined,
     docs: readonly import('./phelDocs').PhelDoc[],
     document: vscode.TextDocument,
-    nsForm: NsForm | null
+    nsForm: NsForm | null,
+    callee: boolean
 ): vscode.CompletionItem {
     const item = new vscode.CompletionItem(spec.label, spec.kind);
     item.detail = spec.detail;
@@ -87,6 +89,12 @@ function buildItem(
         md.isTrusted = false;
         md.supportHtml = false;
         item.documentation = md;
+        if (callee) {
+            const snippet = buildCallSnippet(spec.label, doc.signature);
+            if (snippet) {
+                item.insertText = new vscode.SnippetString(snippet);
+            }
+        }
     }
     if (range) {
         item.range = range;
@@ -130,6 +138,8 @@ export class PhelCompletionProvider implements vscode.CompletionItemProvider {
             : [...PHEL_DOCS];
         const specs = [...this.baseSpecs, ...workspaceSpecs(this.indexer)];
         const nsForm = parseNsForm(document.getText());
-        return specs.map((spec) => buildItem(spec, range, merged, document, nsForm));
+        const linePrefix = document.lineAt(position.line).text.slice(0, position.character);
+        const callee = isCalleePosition(linePrefix);
+        return specs.map((spec) => buildItem(spec, range, merged, document, nsForm, callee));
     }
 }

--- a/src/test/phelCallSnippet.test.ts
+++ b/src/test/phelCallSnippet.test.ts
@@ -1,0 +1,40 @@
+import * as assert from 'node:assert/strict';
+import { buildCallSnippet, isCalleePosition } from '../phelCallSnippet';
+
+describe('phelCallSnippet.buildCallSnippet', () => {
+    it('returns null when no signature is provided', () => {
+        assert.equal(buildCallSnippet('foo'), null);
+    });
+
+    it('returns null for a zero-arg signature', () => {
+        assert.equal(buildCallSnippet('foo', '(foo)'), null);
+    });
+
+    it('builds tabstops for each parameter', () => {
+        const snippet = buildCallSnippet('assoc', '(assoc m k v)');
+        assert.equal(snippet, 'assoc ${1:m} ${2:k} ${3:v}');
+    });
+
+    it('handles rest parameters', () => {
+        const snippet = buildCallSnippet('+', '(+ x & xs)');
+        assert.equal(snippet, '+ ${1:x} ${2:& xs}');
+    });
+});
+
+describe('phelCallSnippet.isCalleePosition', () => {
+    it('detects the cursor right after `(`', () => {
+        assert.equal(isCalleePosition('(ass'), true);
+    });
+
+    it('rejects when there is whitespace after `(`', () => {
+        assert.equal(isCalleePosition('( ass'), false);
+    });
+
+    it('rejects at the start of a line', () => {
+        assert.equal(isCalleePosition(''), false);
+    });
+
+    it('rejects in argument position', () => {
+        assert.equal(isCalleePosition('(foo bar'), false);
+    });
+});


### PR DESCRIPTION
## Summary

- When the user accepts a function completion in callee position (right after `(`), the completion now inserts a snippet skeleton derived from the function's first arity, e.g. `assoc ${1:m} ${2:k} ${3:v}`.
- Outside callee position, completions still insert the bare name.
- Pure helper (`phelCallSnippet.ts`) with eight unit tests.

## Test plan

- [ ] Type `(asso`, accept `assoc`, body becomes `(assoc m k v)` with cursor on `m`.
- [ ] Type `asso` outside any list, accept, body is `assoc` only.
- [ ] CI green (258 tests).