### PR TITLE
feat(repl): in-ns follow + history file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 - Selection expand/shrink by sexp: `ctrl+shift+space` grows the selection to the enclosing form, `ctrl+shift+alt+space` undoes the last grow.
 - Auto-import: completing a workspace symbol from another namespace also inserts the matching `:require` entry into the current file's `(ns ...)` form (`:refer [name]`). Skipped for `phel.core` and same-ns symbols.
 - Call snippets: accepting a function completion in callee position (just after `(`) inserts a `name ${1:arg1} ${2:arg2}` skeleton with tab stops, derived from the function's signature.
+- REPL `(in-ns ...)` follow: evaluating from a different file automatically switches the REPL into that file's namespace first.
+- REPL history: every form sent to the REPL is appended to `.vscode/phel-repl-history.phel` (toggle via `phel.repl.history.enabled`).
+- New command `Phel: Switch REPL to Current Namespace`.
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -266,6 +266,11 @@
                 "category": "Phel"
             },
             {
+                "command": "phel.repl.switchNs",
+                "title": "Phel: Switch REPL to Current Namespace",
+                "category": "Phel"
+            },
+            {
                 "command": "phel.selection.expand",
                 "title": "Phel: Expand Selection",
                 "category": "Phel"
@@ -404,6 +409,11 @@
                         "repl"
                     ],
                     "description": "Arguments passed to the Phel CLI when starting the REPL."
+                },
+                "phel.repl.history.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Append every form sent to the REPL to `.vscode/phel-repl-history.phel` in the workspace."
                 }
             }
         }

--- a/src/phelReplProvider.ts
+++ b/src/phelReplProvider.ts
@@ -3,13 +3,23 @@
 // whole file via commands / keybindings.
 //
 // One terminal per workspace folder is reused; closing the terminal makes
-// the next eval start a fresh one.
+// the next eval start a fresh one. The provider also tracks which Phel
+// namespace each terminal is currently in and emits `(in-ns ...)` before
+// evaluating a form from a different namespace, so cross-file evals don't
+// silently land in the previous file's `ns`.
+//
+// Every form sent to the REPL is appended to `.vscode/phel-repl-history.phel`
+// in the corresponding workspace folder when `phel.repl.history.enabled` is
+// true (the default).
 
 import * as path from 'node:path';
 import * as vscode from 'vscode';
+import { parseNsForm } from './phelNsAnalyzer';
 import { flattenForTerminal, nextTopLevelFormAfter, topLevelFormAt } from './phelRepl';
 
 const REPL_TERMINAL_NAME = 'Phel REPL';
+const HISTORY_FILE = '.vscode/phel-repl-history.phel';
+const terminalNs = new WeakMap<vscode.Terminal, string>();
 
 interface ReplCommandConfig {
     command: string;
@@ -54,9 +64,71 @@ function ensureTerminal(folder: vscode.WorkspaceFolder | undefined): vscode.Term
     return term;
 }
 
-function sendToRepl(text: string, folder: vscode.WorkspaceFolder | undefined): void {
+function detectDocumentNs(doc: vscode.TextDocument): string | null {
+    const ns = parseNsForm(doc.getText());
+    return ns?.name ?? null;
+}
+
+function maybeSwitchNs(term: vscode.Terminal, doc: vscode.TextDocument | undefined): void {
+    if (!doc) {
+        return;
+    }
+    const ns = detectDocumentNs(doc);
+    if (!ns) {
+        return;
+    }
+    if (terminalNs.get(term) === ns) {
+        return;
+    }
+    term.sendText(`(in-ns '${ns})`, true);
+    terminalNs.set(term, ns);
+}
+
+async function appendHistory(
+    folder: vscode.WorkspaceFolder | undefined,
+    text: string
+): Promise<void> {
+    if (!folder) {
+        return;
+    }
+    const enabled = vscode.workspace
+        .getConfiguration('phel', folder)
+        .get<boolean>('repl.history.enabled', true);
+    if (!enabled) {
+        return;
+    }
+    const uri = vscode.Uri.joinPath(folder.uri, HISTORY_FILE);
+    const stamp = new Date().toISOString();
+    const entry = `;; ${stamp}\n${text}\n\n`;
+    try {
+        const existing = await vscode.workspace.fs.readFile(uri);
+        const merged = Buffer.concat([Buffer.from(existing), Buffer.from(entry, 'utf-8')]);
+        await vscode.workspace.fs.writeFile(uri, merged);
+    } catch {
+        try {
+            await vscode.workspace.fs.writeFile(uri, Buffer.from(entry, 'utf-8'));
+        } catch {
+            // Couldn't create the history file (read-only workspace, etc); skip.
+        }
+    }
+}
+
+interface SendOptions {
+    /** Document the form was extracted from; used for `(in-ns ...)` sync. */
+    doc?: vscode.TextDocument;
+}
+
+function sendToRepl(
+    text: string,
+    folder: vscode.WorkspaceFolder | undefined,
+    options: SendOptions = {}
+): void {
     const term = ensureTerminal(folder);
+    if (options.doc) {
+        maybeSwitchNs(term, options.doc);
+    }
     term.sendText(text, true);
+    void appendHistory(folder, text);
 }
 
 async function evalForm(): Promise<void> {
@@ -71,7 +143,7 @@ async function evalForm(): Promise<void> {
         vscode.window.showWarningMessage('No Phel form under cursor.');
         return;
     }
-    sendToRepl(flattenForTerminal(form.text), workspaceFolderForDoc(doc));
+    sendToRepl(flattenForTerminal(form.text), workspaceFolderForDoc(doc), { doc });
 }
 
 async function evalSelection(): Promise<void> {
@@ -85,7 +157,7 @@ async function evalSelection(): Promise<void> {
     if (!text.trim()) {
         return;
     }
-    sendToRepl(flattenForTerminal(text), workspaceFolderForDoc(doc));
+    sendToRepl(flattenForTerminal(text), workspaceFolderForDoc(doc), { doc });
 }
 
 async function evalNextForm(): Promise<void> {
@@ -99,7 +171,7 @@ async function evalNextForm(): Promise<void> {
     if (!form) {
         return;
     }
-    sendToRepl(flattenForTerminal(form.text), workspaceFolderForDoc(doc));
+    sendToRepl(flattenForTerminal(form.text), workspaceFolderForDoc(doc), { doc });
     const newPos = doc.positionAt(form.end);
     editor.selection = new vscode.Selection(newPos, newPos);
     editor.revealRange(new vscode.Range(newPos, newPos));
@@ -114,7 +186,25 @@ async function evalFile(): Promise<void> {
     if (!text) {
         return;
     }
-    sendToRepl(flattenForTerminal(text), workspaceFolderForDoc(editor.document));
+    sendToRepl(flattenForTerminal(text), workspaceFolderForDoc(editor.document), {
+        doc: editor.document,
+    });
+}
+
+async function switchNs(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'phel') {
+        return;
+    }
+    const ns = detectDocumentNs(editor.document);
+    if (!ns) {
+        vscode.window.showWarningMessage('No (ns ...) form in this file.');
+        return;
+    }
+    const folder = workspaceFolderForDoc(editor.document);
+    const term = ensureTerminal(folder);
+    term.sendText(`(in-ns '${ns})`, true);
+    terminalNs.set(term, ns);
 }
 
 function startRepl(): void {
@@ -128,6 +218,10 @@ export function registerReplCommands(context: vscode.ExtensionContext): void {
         vscode.commands.registerCommand('phel.repl.evalForm', evalForm),
         vscode.commands.registerCommand('phel.repl.evalSelection', evalSelection),
         vscode.commands.registerCommand('phel.repl.evalNextForm', evalNextForm),
-        vscode.commands.registerCommand('phel.repl.evalFile', evalFile)
+        vscode.commands.registerCommand('phel.repl.evalFile', evalFile),
+        vscode.commands.registerCommand('phel.repl.switchNs', switchNs),
+        vscode.window.onDidCloseTerminal((t) => {
+            terminalNs.delete(t);
+        })
     );
 }


### PR DESCRIPTION
## Summary

- Per-terminal namespace tracking: the provider sends `(in-ns 'that.ns)` before evaluating a form from a different file, so cross-file evals don't silently land in the previous namespace.
- Every form sent to the REPL is appended to `.vscode/phel-repl-history.phel` in the workspace (timestamped). Toggle via `phel.repl.history.enabled`.
- New command `Phel: Switch REPL to Current Namespace` to switch manually.
- Terminal close listener clears the cached ns so the next REPL session starts fresh.

## Test plan

- [ ] Eval a form in `src/a.phel`, then jump to `src/b.phel` and eval — REPL receives `(in-ns 'b.ns)` first.
- [ ] History file is created on first eval and appended on subsequent evals.
- [ ] `phel.repl.history.enabled = false` skips writing the file.
- [ ] CI green (258 tests).