### PR TITLE
feat(status): Phel project detection + namespace status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - REPL `(in-ns ...)` follow: evaluating from a different file automatically switches the REPL into that file's namespace first.
 - REPL history: every form sent to the REPL is appended to `.vscode/phel-repl-history.phel` (toggle via `phel.repl.history.enabled`).
 - New command `Phel: Switch REPL to Current Namespace`.
+- Status bar: shows the current Phel namespace when editing a `.phel` file, or a `Phel` badge when the workspace has `phel-lang/phel` in its `composer.json`. Click it to start the REPL.
 
 ### Changed
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import { PhelDocumentSymbolProvider, PhelWorkspaceSymbolProvider } from './phelS
 import { registerPareditCommands } from './phelPareditProvider';
 import { registerReplCommands } from './phelReplProvider';
 import { registerSelectionCommands } from './phelSelectionProvider';
+import { PhelStatusBar } from './phelStatusBar';
 
 let sourceMapManager: SourceMapManager;
 
@@ -217,6 +218,8 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     registerSelectionCommands(context);
+
+    void new PhelStatusBar().start(context);
 
     // Provide hover information for breakpoints
     context.subscriptions.push(

--- a/src/phelProject.ts
+++ b/src/phelProject.ts
@@ -1,0 +1,34 @@
+// Pure project-detection helpers. Given the contents of a `composer.json`,
+// determine whether the workspace folder is a Phel project (i.e. the
+// `phel-lang/phel` package appears in `require` or `require-dev`).
+
+export interface PhelProjectInfo {
+    isPhelProject: boolean;
+    /** Phel package version constraint declared in composer.json, if any. */
+    version?: string;
+    /** Whether the dependency is dev-only. */
+    dev?: boolean;
+}
+
+interface ComposerJson {
+    require?: Record<string, string>;
+    'require-dev'?: Record<string, string>;
+}
+
+const PACKAGE_NAME = 'phel-lang/phel';
+
+export function analyzeComposerJson(text: string): PhelProjectInfo {
+    let data: ComposerJson;
+    try {
+        data = JSON.parse(text) as ComposerJson;
+    } catch {
+        return { isPhelProject: false };
+    }
+    if (data.require && data.require[PACKAGE_NAME]) {
+        return { isPhelProject: true, version: data.require[PACKAGE_NAME] };
+    }
+    if (data['require-dev'] && data['require-dev'][PACKAGE_NAME]) {
+        return { isPhelProject: true, version: data['require-dev'][PACKAGE_NAME], dev: true };
+    }
+    return { isPhelProject: false };
+}

--- a/src/phelStatusBar.ts
+++ b/src/phelStatusBar.ts
@@ -1,0 +1,93 @@
+// Status-bar item that shows the current Phel namespace (when editing a
+// `.phel` file) and a "Phel" indicator otherwise. Clicking it runs
+// `phel.repl.start` so the REPL is one click away.
+//
+// Project detection scans each workspace folder's `composer.json` once at
+// activation and updates if the file changes; we don't need to be live for
+// every keystroke.
+
+import * as vscode from 'vscode';
+import { parseNsForm } from './phelNsAnalyzer';
+import { analyzeComposerJson, type PhelProjectInfo } from './phelProject';
+
+const COMPOSER_PATH = 'composer.json';
+
+export class PhelStatusBar implements vscode.Disposable {
+    private readonly item: vscode.StatusBarItem;
+    private readonly disposables: vscode.Disposable[] = [];
+    private readonly projects = new Map<string, PhelProjectInfo>();
+
+    constructor() {
+        this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
+        this.item.command = 'phel.repl.start';
+        this.disposables.push(this.item);
+    }
+
+    async start(context: vscode.ExtensionContext): Promise<void> {
+        context.subscriptions.push(this);
+        await this.refreshProjects();
+        this.disposables.push(
+            vscode.window.onDidChangeActiveTextEditor(() => this.update()),
+            vscode.workspace.onDidChangeTextDocument((e) => {
+                if (e.document === vscode.window.activeTextEditor?.document) {
+                    this.update();
+                }
+            }),
+            vscode.workspace.onDidChangeWorkspaceFolders(() => this.refreshProjects()),
+            vscode.workspace.onDidSaveTextDocument((doc) => {
+                if (doc.uri.path.endsWith(`/${COMPOSER_PATH}`)) {
+                    void this.refreshProjects();
+                }
+            })
+        );
+        this.update();
+    }
+
+    private async refreshProjects(): Promise<void> {
+        this.projects.clear();
+        for (const folder of vscode.workspace.workspaceFolders ?? []) {
+            const uri = vscode.Uri.joinPath(folder.uri, COMPOSER_PATH);
+            try {
+                const bytes = await vscode.workspace.fs.readFile(uri);
+                const info = analyzeComposerJson(Buffer.from(bytes).toString('utf-8'));
+                if (info.isPhelProject) {
+                    this.projects.set(folder.uri.fsPath, info);
+                }
+            } catch {
+                // No composer.json — not a Phel project, leave map clean.
+            }
+        }
+        this.update();
+    }
+
+    private update(): void {
+        const editor = vscode.window.activeTextEditor;
+        if (editor?.document.languageId === 'phel') {
+            const ns = parseNsForm(editor.document.getText());
+            this.item.text = ns ? `$(symbol-namespace) ${ns.name}` : `$(symbol-namespace) Phel`;
+            this.item.tooltip = ns
+                ? `Phel namespace: ${ns.name}\nClick to start the REPL.`
+                : 'Phel file (no ns form). Click to start the REPL.';
+            this.item.show();
+            return;
+        }
+        if (this.projects.size > 0) {
+            const versions = [...this.projects.values()]
+                .map((p) => p.version ?? '')
+                .filter(Boolean);
+            this.item.text = '$(symbol-namespace) Phel';
+            this.item.tooltip = versions.length
+                ? `Phel project (${versions.join(', ')}). Click to start the REPL.`
+                : 'Phel project. Click to start the REPL.';
+            this.item.show();
+            return;
+        }
+        this.item.hide();
+    }
+
+    dispose(): void {
+        for (const d of this.disposables) {
+            d.dispose();
+        }
+    }
+}

--- a/src/test/phelProject.test.ts
+++ b/src/test/phelProject.test.ts
@@ -1,0 +1,29 @@
+import * as assert from 'node:assert/strict';
+import { analyzeComposerJson } from '../phelProject';
+
+describe('phelProject.analyzeComposerJson', () => {
+    it('detects phel-lang/phel in require', () => {
+        const json = JSON.stringify({ require: { 'phel-lang/phel': '^0.18' } });
+        const info = analyzeComposerJson(json);
+        assert.equal(info.isPhelProject, true);
+        assert.equal(info.version, '^0.18');
+        assert.equal(info.dev, undefined);
+    });
+
+    it('detects phel-lang/phel in require-dev', () => {
+        const json = JSON.stringify({ 'require-dev': { 'phel-lang/phel': 'dev-main' } });
+        const info = analyzeComposerJson(json);
+        assert.equal(info.isPhelProject, true);
+        assert.equal(info.version, 'dev-main');
+        assert.equal(info.dev, true);
+    });
+
+    it('returns false for unrelated packages', () => {
+        const json = JSON.stringify({ require: { 'symfony/console': '*' } });
+        assert.equal(analyzeComposerJson(json).isPhelProject, false);
+    });
+
+    it('returns false for invalid JSON', () => {
+        assert.equal(analyzeComposerJson('{ broken').isPhelProject, false);
+    });
+});


### PR DESCRIPTION
## Summary

- Pure project analyzer reads `composer.json` and reports whether `phel-lang/phel` is in `require` or `require-dev`.
- Status bar item:
  - In a `.phel` file: shows `$(symbol-namespace) <ns>` from the file's `(ns ...)` form.
  - In any other file when the workspace has `phel-lang/phel`: shows `$(symbol-namespace) Phel`.
  - Hidden otherwise.
- Clicking the status bar runs `phel.repl.start`.
- Refresh on `composer.json` save and on workspace-folder change.

## Test plan

- [ ] Open a `.phel` file with `(ns my.app)` → status bar shows `my.app`.
- [ ] Open a non-Phel file in a workspace whose `composer.json` requires `phel-lang/phel` → status bar shows `Phel`.
- [ ] Edit `composer.json` to remove the dep, save → badge disappears.
- [ ] CI green (262 tests).