### PR TITLE
ci: enforce non-empty [Unreleased] section on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
       - run: npm run compile
       - run: npm run lint
       - run: npm test
+      - run: npm run check:changelog
+        if: github.event_name == 'pull_request'
       - run: npm run tokenize
       - run: npm run bundle:prod
       - name: vsce package (sanity)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - New command `Phel: Switch REPL to Current Namespace`.
 - Status bar: shows the current Phel namespace when editing a `.phel` file, or a `Phel` badge when the workspace has `phel-lang/phel` in its `composer.json`. Click it to start the REPL.
 - Build: ship a single bundled `dist/extension.js` via esbuild for faster activation and a smaller vsix.
+- CI: PRs must keep at least one bullet in `## [Unreleased]` (`scripts/check-changelog.cjs`).
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -432,6 +432,7 @@
         "format:check": "prettier --check \"src/**/*.ts\"",
         "pretest": "npm run compile && npm run lint",
         "test": "mocha out/test/**/*.test.js",
+        "check:changelog": "node scripts/check-changelog.cjs",
         "tokenize": "node scripts/tokenize-sample.mjs",
         "regen-docs": "npm run compile && node scripts/regen-core-docs.cjs",
         "package": "vsce package",

--- a/scripts/check-changelog.cjs
+++ b/scripts/check-changelog.cjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+//
+// Fail CI when the `## [Unreleased]` section in CHANGELOG.md exists but has
+// no bullets, or when it's missing entirely. Releases bump the Unreleased
+// header to a version, so we leave that case alone — `release.sh` is
+// responsible for re-creating an empty Unreleased on the next iteration.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const file = path.resolve(__dirname, '..', 'CHANGELOG.md');
+const text = fs.readFileSync(file, 'utf-8');
+const lines = text.split(/\r?\n/);
+
+let inUnreleased = false;
+let bullets = 0;
+let foundUnreleased = false;
+
+for (const line of lines) {
+    if (/^##\s+\[Unreleased\]/i.test(line)) {
+        inUnreleased = true;
+        foundUnreleased = true;
+        continue;
+    }
+    if (inUnreleased) {
+        if (/^##\s/.test(line)) break;
+        if (/^\s*-\s+\S/.test(line)) bullets++;
+    }
+}
+
+if (!foundUnreleased) {
+    console.error(
+        'CHANGELOG.md is missing a `## [Unreleased]` section. Add one (even empty) so future PRs have somewhere to land notes.'
+    );
+    process.exit(1);
+}
+
+if (bullets === 0) {
+    console.error(
+        'CHANGELOG.md `[Unreleased]` section has no bullets. Add a one-line entry under the appropriate heading (Added / Changed / Fixed / Settings).'
+    );
+    process.exit(1);
+}
+
+console.log(`CHANGELOG.md [Unreleased] OK (${bullets} bullet${bullets === 1 ? '' : 's'}).`);


### PR DESCRIPTION
## Summary

- New `scripts/check-changelog.cjs`: walks CHANGELOG.md, finds the `## [Unreleased]` section, fails if it's missing or has no bullets.
- Wired into the CI job for `pull_request` events only — `main` pushes don't gate on it (release.sh empties the section between cuts).

The marketplace icon (`icon` field + PNG) needs an actual image file and will land in a follow-up. Banner colour is already configured.

## Test plan

- [ ] Run `npm run check:changelog` locally → passes.
- [ ] Open a PR that doesn't touch CHANGELOG → CI fails with the helpful message.
- [ ] CI green on this PR.