### PR TITLE
feat(testing): TestController integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Status bar: shows the current Phel namespace when editing a `.phel` file, or a `Phel` badge when the workspace has `phel-lang/phel` in its `composer.json`. Click it to start the REPL.
 - Build: ship a single bundled `dist/extension.js` via esbuild for faster activation and a smaller vsix.
 - CI: PRs must keep at least one bullet in `## [Unreleased]` (`scripts/check-changelog.cjs`).
+- Test Explorer: every `deftest` shows up in VS Code's testing panel; running an item shells `phel test --filter` and reports pass/fail by exit code.
 
 ### Changed
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import { registerPareditCommands } from './phelPareditProvider';
 import { registerReplCommands } from './phelReplProvider';
 import { registerSelectionCommands } from './phelSelectionProvider';
 import { PhelStatusBar } from './phelStatusBar';
+import { PhelTestController } from './phelTestController';
 
 let sourceMapManager: SourceMapManager;
 
@@ -220,6 +221,8 @@ export function activate(context: vscode.ExtensionContext) {
     registerSelectionCommands(context);
 
     void new PhelStatusBar().start(context);
+
+    context.subscriptions.push(new PhelTestController());
 
     // Provide hover information for breakpoints
     context.subscriptions.push(

--- a/src/phelTestController.ts
+++ b/src/phelTestController.ts
@@ -1,0 +1,190 @@
+// VS Code Test Explorer integration for Phel.
+//
+// Each `.phel` file with at least one `deftest` becomes a TestItem; each
+// `deftest` becomes a child item. Running an item shells out to `phel test
+// --filter` and reports pass / fail based on the exit code. We don't parse
+// the textual output yet — when the Phel CLI gains structured (JSON / TAP)
+// output we can attach per-assertion messages.
+
+import { spawn } from 'node:child_process';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import * as vscode from 'vscode';
+import { findDeftests } from './phelTestScanner';
+
+interface ResolvedCommand {
+    command: string;
+    args: string[];
+    cwd: string;
+}
+
+function resolveTestCommand(folder: vscode.WorkspaceFolder): ResolvedCommand {
+    const config = vscode.workspace.getConfiguration('phel', folder);
+    const cmd = config.get<string>('test.command', 'vendor/bin/phel');
+    const cwd = folder.uri.fsPath;
+    const command = path.isAbsolute(cmd) ? cmd : path.join(cwd, cmd);
+    return { command, args: ['test'], cwd };
+}
+
+async function readFile(uri: vscode.Uri): Promise<string | null> {
+    try {
+        return await fs.readFile(uri.fsPath, 'utf-8');
+    } catch {
+        return null;
+    }
+}
+
+function attachItems(
+    controller: vscode.TestController,
+    file: vscode.Uri,
+    text: string
+): vscode.TestItem | null {
+    const tests = findDeftests(text);
+    if (tests.length === 0) {
+        controller.items.delete(file.toString());
+        return null;
+    }
+    const fileItem =
+        controller.items.get(file.toString()) ??
+        controller.createTestItem(file.toString(), path.basename(file.fsPath), file);
+    fileItem.children.replace(
+        tests.map((t) => {
+            const id = `${file.toString()}::${t.name}`;
+            const item = controller.createTestItem(id, t.name, file);
+            item.range = new vscode.Range(t.line, t.nameCol, t.line, t.nameCol + t.name.length);
+            return item;
+        })
+    );
+    controller.items.add(fileItem);
+    return fileItem;
+}
+
+async function loadAllTests(controller: vscode.TestController): Promise<void> {
+    const uris = await vscode.workspace.findFiles('**/*.phel', '**/node_modules/**');
+    for (const uri of uris) {
+        const text = await readFile(uri);
+        if (text === null) {
+            continue;
+        }
+        attachItems(controller, uri, text);
+    }
+}
+
+interface TestRunOutcome {
+    code: number;
+    output: string;
+}
+
+function runPhelTest(folder: vscode.WorkspaceFolder, filter: string): Promise<TestRunOutcome> {
+    return new Promise((resolve) => {
+        const cmd = resolveTestCommand(folder);
+        const proc = spawn(cmd.command, [...cmd.args, '--filter', filter], { cwd: cmd.cwd });
+        let output = '';
+        proc.stdout?.on('data', (d) => {
+            output += d.toString();
+        });
+        proc.stderr?.on('data', (d) => {
+            output += d.toString();
+        });
+        proc.on('close', (code) => resolve({ code: code ?? 1, output }));
+        proc.on('error', (err) => resolve({ code: 1, output: err.message }));
+    });
+}
+
+function expandQueue(
+    queue: readonly vscode.TestItem[],
+    request: vscode.TestRunRequest
+): vscode.TestItem[] {
+    const flat: vscode.TestItem[] = [];
+    const visit = (item: vscode.TestItem): void => {
+        if (request.exclude?.includes(item)) {
+            return;
+        }
+        if (item.children.size === 0) {
+            flat.push(item);
+            return;
+        }
+        item.children.forEach(visit);
+    };
+    for (const item of queue) {
+        visit(item);
+    }
+    return flat;
+}
+
+function filterFor(item: vscode.TestItem): string {
+    const sep = item.id.indexOf('::');
+    if (sep < 0) {
+        return '.*';
+    }
+    return `^${escapeRegex(item.id.slice(sep + 2))}$`;
+}
+
+function escapeRegex(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export class PhelTestController implements vscode.Disposable {
+    private readonly controller: vscode.TestController;
+    private readonly disposables: vscode.Disposable[] = [];
+
+    constructor() {
+        this.controller = vscode.tests.createTestController('phel-tests', 'Phel');
+        this.disposables.push(this.controller);
+        this.controller.resolveHandler = async () => {
+            await loadAllTests(this.controller);
+        };
+        this.controller.createRunProfile(
+            'Run',
+            vscode.TestRunProfileKind.Run,
+            (request, token) => this.run(request, token),
+            true
+        );
+        this.disposables.push(
+            vscode.workspace.onDidSaveTextDocument(async (doc) => {
+                if (doc.languageId !== 'phel') {
+                    return;
+                }
+                attachItems(this.controller, doc.uri, doc.getText());
+            })
+        );
+    }
+
+    private async run(
+        request: vscode.TestRunRequest,
+        token: vscode.CancellationToken
+    ): Promise<void> {
+        const queue: vscode.TestItem[] = [];
+        if (request.include) {
+            queue.push(...request.include);
+        } else {
+            this.controller.items.forEach((it) => queue.push(it));
+        }
+        const items = expandQueue(queue, request);
+        const run = this.controller.createTestRun(request);
+        for (const item of items) {
+            if (token.isCancellationRequested) {
+                break;
+            }
+            const folder = item.uri ? vscode.workspace.getWorkspaceFolder(item.uri) : undefined;
+            if (!folder) {
+                run.skipped(item);
+                continue;
+            }
+            run.started(item);
+            const outcome = await runPhelTest(folder, filterFor(item));
+            if (outcome.code === 0) {
+                run.passed(item);
+            } else {
+                run.failed(item, new vscode.TestMessage(outcome.output || `exit ${outcome.code}`));
+            }
+        }
+        run.end();
+    }
+
+    dispose(): void {
+        for (const d of this.disposables) {
+            d.dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `vscode.tests.createTestController('phel-tests')` driver that lists every `deftest` in the workspace as a TestItem under its `.phel` file.
- Run handler shells `phel test --filter ^name$` per item and reports pass / fail based on exit code; full output is attached on failure.
- Saving a `.phel` file refreshes its TestItems.
- Cancelling the run stops queueing further tests.

Per-assertion messages will be wired up later when the Phel CLI gains structured output (JSON / TAP). The existing CodeLens shortcuts continue to work.

## Test plan

- [ ] Open Testing view → tree shows `.phel` files and their `deftest` names.
- [ ] Click `Run` on a single test → CLI runs, panel marks it green or red.
- [ ] A failing test shows the captured stdout/stderr on click.
- [ ] Adding a new `deftest` and saving updates the tree.
- [ ] CI green (262 tests).