### PR TITLE
feat(highlight): enclosing-form decoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Build: ship a single bundled `dist/extension.js` via esbuild for faster activation and a smaller vsix.
 - CI: PRs must keep at least one bullet in `## [Unreleased]` (`scripts/check-changelog.cjs`).
 - Test Explorer: every `deftest` shows up in VS Code's testing panel; running an item shells `phel test --filter` and reports pass/fail by exit code.
+- Enclosing-form highlight: subtle background tint on the form containing the cursor in `.phel` files. Toggle via `phel.formHighlight.enabled`.
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -414,6 +414,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Append every form sent to the REPL to `.vscode/phel-repl-history.phel` in the workspace."
+                },
+                "phel.formHighlight.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Highlight the form enclosing the cursor with a subtle background tint."
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import { PhelDocumentSymbolProvider, PhelWorkspaceSymbolProvider } from './phelS
 import { registerPareditCommands } from './phelPareditProvider';
 import { registerReplCommands } from './phelReplProvider';
 import { registerSelectionCommands } from './phelSelectionProvider';
+import { PhelFormHighlight } from './phelFormHighlight';
 import { PhelStatusBar } from './phelStatusBar';
 import { PhelTestController } from './phelTestController';
 
@@ -223,6 +224,7 @@ export function activate(context: vscode.ExtensionContext) {
     void new PhelStatusBar().start(context);
 
     context.subscriptions.push(new PhelTestController());
+    context.subscriptions.push(new PhelFormHighlight());
 
     // Provide hover information for breakpoints
     context.subscriptions.push(

--- a/src/phelFormHighlight.ts
+++ b/src/phelFormHighlight.ts
@@ -1,0 +1,87 @@
+// Subtle background highlight for the form enclosing the cursor in the
+// active `.phel` editor. Reuses the paredit reader to find the smallest
+// enclosing container; falls back to the innermost form when the cursor
+// sits on an atom inside a top-level expression.
+//
+// The decoration is debounced so rapid cursor movement doesn't churn.
+
+import * as vscode from 'vscode';
+import { enclosingContainer, parseAll, pathAt } from './phelParedit';
+
+const DEBOUNCE_MS = 50;
+const SETTING = 'phel.formHighlight.enabled';
+
+export class PhelFormHighlight implements vscode.Disposable {
+    private readonly decoration = vscode.window.createTextEditorDecorationType({
+        backgroundColor: new vscode.ThemeColor('editor.selectionHighlightBackground'),
+        isWholeLine: false,
+    });
+    private readonly disposables: vscode.Disposable[] = [];
+    private timer: NodeJS.Timeout | undefined;
+
+    constructor() {
+        this.disposables.push(
+            this.decoration,
+            vscode.window.onDidChangeTextEditorSelection((e) => this.schedule(e.textEditor)),
+            vscode.window.onDidChangeActiveTextEditor((editor) => {
+                if (editor) {
+                    this.schedule(editor);
+                }
+            }),
+            vscode.workspace.onDidChangeTextDocument((e) => {
+                if (e.document === vscode.window.activeTextEditor?.document) {
+                    this.schedule(vscode.window.activeTextEditor);
+                }
+            }),
+            vscode.workspace.onDidChangeConfiguration((e) => {
+                if (e.affectsConfiguration(SETTING) && vscode.window.activeTextEditor) {
+                    this.schedule(vscode.window.activeTextEditor);
+                }
+            })
+        );
+        if (vscode.window.activeTextEditor) {
+            this.schedule(vscode.window.activeTextEditor);
+        }
+    }
+
+    private schedule(editor: vscode.TextEditor): void {
+        if (this.timer) {
+            clearTimeout(this.timer);
+        }
+        this.timer = setTimeout(() => this.apply(editor), DEBOUNCE_MS);
+    }
+
+    private apply(editor: vscode.TextEditor): void {
+        if (editor.document.languageId !== 'phel') {
+            editor.setDecorations(this.decoration, []);
+            return;
+        }
+        const enabled = vscode.workspace.getConfiguration().get<boolean>(SETTING, true);
+        if (!enabled) {
+            editor.setDecorations(this.decoration, []);
+            return;
+        }
+        const text = editor.document.getText();
+        const offset = editor.document.offsetAt(editor.selection.active);
+        const forms = parseAll(text);
+        const target = enclosingContainer(forms, offset) ?? pathAt(forms, offset).slice(-1)[0];
+        if (!target) {
+            editor.setDecorations(this.decoration, []);
+            return;
+        }
+        const range = new vscode.Range(
+            editor.document.positionAt(target.start),
+            editor.document.positionAt(target.end)
+        );
+        editor.setDecorations(this.decoration, [{ range }]);
+    }
+
+    dispose(): void {
+        if (this.timer) {
+            clearTimeout(this.timer);
+        }
+        for (const d of this.disposables) {
+            d.dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Subtle background tint on the form containing the cursor (uses the editor's `editor.selectionHighlightBackground` theme color so it adapts to light/dark themes).
- Debounced 50 ms so rapid cursor movement doesn't churn.
- Reuses the paredit reader to find the smallest enclosing container; falls back to the innermost atom when there's no enclosing form.
- Toggle via `phel.formHighlight.enabled` (default true).

## Test plan

- [ ] Move the cursor between forms in a `.phel` file → highlight follows.
- [ ] `phel.formHighlight.enabled = false` clears the highlight.
- [ ] Switching to a non-`.phel` file clears the highlight.
- [ ] CI green (262 tests).