### PR TITLE
docs: cover REPL, paredit, refactoring in README + new doc pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - CI: PRs must keep at least one bullet in `## [Unreleased]` (`scripts/check-changelog.cjs`).
 - Test Explorer: every `deftest` shows up in VS Code's testing panel; running an item shells `phel test --filter` and reports pass/fail by exit code.
 - Enclosing-form highlight: subtle background tint on the form containing the cursor in `.phel` files. Toggle via `phel.formHighlight.enabled`.
+- README rewritten to cover REPL, paredit, refactoring, test explorer, diagnostics, and formatting alongside the original highlighting/completion/snippets/debug story. Added `docs/repl-and-paredit.md` and `docs/refactoring.md`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,18 @@ VS Code support for [Phel](https://phel-lang.org/) - a functional Lisp that comp
 
 ## Why this extension
 
-Writing Phel without editor support means colourless code, no completion for the 400+ symbols in `phel.core`, and dropping back to PHP-level debugging. This extension fixes all three.
+Writing Phel without editor support means colourless code, no completion for the 400+ symbols in `phel.core`, and dropping back to PHP-level debugging. This extension covers the full IDE flow.
 
-- **Highlighting** - full coverage of forms, macros, reader macros, tagged literals (`#inst`, `#regex`, `#php`, …) and reader conditionals (`#?(...)`).
-- **Completion** for every public symbol in `phel.core` (47 special forms, ~70 macros, 394 functions).
-- **Snippets** for everyday scaffolding - `defn`, `let`, `cond`, `try`, `deftest`, `->`, …
+- **Highlighting** - forms, macros, reader macros, tagged literals (`#inst`, `#regex`, `#php`, …) and reader conditionals (`#?(...)`).
+- **Completion** for every public symbol in `phel.core` plus user `defn`/`defmacro`/`def` from anywhere in the workspace. Accepting a function in callee position fills in signature tabstops; cross-namespace symbols also auto-add the matching `:require`.
+- **Hover & signature help** - markdown docstring, examples, and per-arity parameter highlight.
+- **Go to / Find / Rename** - `F12` go-to-definition, `shift+F12` find-all-references, `F2` workspace rename, `cmd+T` go-to-symbol-in-workspace.
+- **Diagnostics on save** via `phel analyze`; **format on save** via `phel format`.
+- **REPL integration** - `Phel: Start REPL` opens an integrated terminal; `ctrl+enter` evals the form under the cursor in the file's namespace; history is appended to `.vscode/phel-repl-history.phel`.
+- **Test Explorer + CodeLens** - every `deftest` shows up in the testing panel; inline `▶ Run test` lenses run a single deftest.
+- **Paredit** - slurp/barf/raise/wrap commands; `cmd+shift+space` expands the selection by sexp.
 - **Native debug adapter** - set breakpoints in `.phel` files; the adapter translates between Phel and the compiled PHP via Xdebug.
+- **Snippets** for everyday scaffolding - `defn`, `let`, `cond`, `try`, `deftest`, `->`, …
 
 ## Install
 
@@ -31,8 +37,9 @@ Requires VS Code **1.75+**. Other paths (`.vsix` from GitHub releases, build fro
 
 1. **Open any `.phel` file** - highlighting kicks in automatically.
 2. **Try completion** - start typing `re-` or `swap` and accept a suggestion.
-3. **Expand a snippet** - type `defn` <kbd>Tab</kbd> and tab through the placeholders.
-4. **Set a breakpoint** in `.phel`, add a launch config (see [docs/debugging.md](docs/debugging.md)), press <kbd>F5</kbd>.
+3. **Run the REPL** - `cmd+shift+P` → `Phel: Start REPL`, then `ctrl+enter` over a form to eval it.
+4. **Find & rename** - place the cursor on a symbol, press <kbd>F2</kbd> to rename it across the workspace, <kbd>shift+F12</kbd> to list every usage.
+5. **Set a breakpoint** in `.phel`, add a launch config (see [docs/debugging.md](docs/debugging.md)), press <kbd>F5</kbd>.
 
 ## Documentation
 
@@ -41,6 +48,8 @@ Requires VS Code **1.75+**. Other paths (`.vsix` from GitHub releases, build fro
 | Installation paths | [docs/installation.md](docs/installation.md) |
 | Syntax highlighting reference | [docs/syntax.md](docs/syntax.md) |
 | Completion & snippets | [docs/completion.md](docs/completion.md) |
+| REPL & paredit | [docs/repl-and-paredit.md](docs/repl-and-paredit.md) |
+| Refactoring (rename / refs / symbols) | [docs/refactoring.md](docs/refactoring.md) |
 | Debugging with Xdebug | [docs/debugging.md](docs/debugging.md) |
 | Tracing with `tap>` | [docs/taps.md](docs/taps.md) |
 | Settings reference | [docs/settings.md](docs/settings.md) |

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -1,0 +1,34 @@
+# Refactoring
+
+## Go to Definition (`F12`)
+
+Place the cursor on a symbol and press <kbd>F12</kbd>. The extension first checks the workspace index for a `defn` / `defmacro` / `def`, then falls back to the bundled core docs.
+
+## Find All References (`shift+F12`)
+
+Lists every standalone occurrence of the symbol across every indexed `.phel` file plus the active buffer. Strings, character literals, line comments, and block comments are skipped, so you don't get false positives in docstrings.
+
+## Rename Symbol (`F2`)
+
+Rewrites every occurrence of the symbol in the workspace via a single `WorkspaceEdit`. The new name is validated as a legal Phel symbol token before any edit is applied.
+
+Same skipping rules as Find References - you can rename `foo` without touching the literal `"foo"` inside a string.
+
+## Document Outline & Breadcrumbs
+
+Every public form (`defn`, `defmacro`, `def`) shows up in the editor outline (`cmd+shift+O`) with its first arity signature as the detail.
+
+## Go to Symbol in Workspace (`cmd+T`)
+
+Type to filter the union of every `defn`/`defmacro`/`def` from every workspace file. Results show the namespace as the container so you can disambiguate between same-named symbols in different namespaces.
+
+## Auto-import on completion
+
+When you accept a completion for a workspace symbol whose namespace isn't already required by the current file, the extension also inserts (or extends) a matching `:require` entry in the file's `(ns ...)` form:
+
+- No `:require` clause yet → adds `(:require [target.ns :refer [name]])`.
+- `:require` exists, target ns missing → appends `[target.ns :refer [name]]`.
+- Target ns required without `:refer` → adds `:refer [name]` to the entry.
+- Target ns required with `:refer` → extends the existing vector.
+
+`phel.core` and same-namespace symbols are skipped (no edit needed).

--- a/docs/repl-and-paredit.md
+++ b/docs/repl-and-paredit.md
@@ -1,0 +1,56 @@
+# REPL & Paredit
+
+## Integrated REPL
+
+`Phel: Start REPL` opens an integrated terminal running the configured Phel CLI (defaults to `vendor/bin/phel repl`). The terminal is reused across evaluations.
+
+| Command | Default key | What it does |
+|---|---|---|
+| `Phel: Eval Form Under Cursor` | `ctrl+enter` (`cmd+enter` on macOS) | Sends the top-level form containing the cursor. Multi-line forms are flattened to a single line. |
+| `Phel: Eval Selection` | `ctrl+shift+enter` (`cmd+shift+enter`) | Sends the selection, or the current line if the selection is empty. |
+| `Phel: Eval Next Form` | _unbound_ | Sends the next top-level form and advances the cursor. |
+| `Phel: Eval File` | _unbound_ | Sends the entire buffer. |
+| `Phel: Switch REPL to Current Namespace` | _unbound_ | Sends `(in-ns 'this.ns)` for the active file. |
+
+### Namespace tracking
+
+Each REPL terminal remembers which namespace it last switched into. When you eval from a different file, the extension first sends `(in-ns 'that.ns)` so cross-file evals don't silently land in the previous namespace.
+
+### History
+
+Every form sent to the REPL is appended to `.vscode/phel-repl-history.phel` in the workspace, with a UTC timestamp comment above each entry. Toggle via `phel.repl.history.enabled`.
+
+### Settings
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `phel.repl.enabled` | `true` | Register REPL commands |
+| `phel.repl.command` | `vendor/bin/phel` | CLI path (relative to the workspace folder) |
+| `phel.repl.args` | `["repl"]` | Args passed to the CLI |
+| `phel.repl.history.enabled` | `true` | Append sent forms to the history file |
+
+## Paredit
+
+Structural editing for Phel forms. All commands are scoped to `editorLangId == phel`.
+
+| Command | Default key |
+|---|---|
+| Slurp forward | `ctrl+shift+]` (`cmd+shift+]`) |
+| Barf forward | `ctrl+shift+[` (`cmd+shift+[`) |
+| Slurp backward | `ctrl+shift+9` (`cmd+shift+9`) |
+| Barf backward | `ctrl+shift+0` (`cmd+shift+0`) |
+| Raise form | `ctrl+shift+r` (`cmd+shift+r`) |
+| Wrap with `( )` | `alt+w` |
+| Wrap with `[ ]` / `{ }` | _unbound_ (commands `phel.paredit.wrapSquare`, `phel.paredit.wrapCurly`) |
+| Expand selection | `ctrl+shift+space` (`cmd+shift+space`) |
+| Shrink selection | `ctrl+shift+alt+space` (`cmd+shift+alt+space`) |
+
+### Examples
+
+```text
+(a) b              ; cursor in (a), slurp-forward → (a b)
+(a b c)            ; cursor inside, barf-forward  → (a b) c
+a (b c)            ; cursor in (b c), slurp-back  → (a b c)
+(foo (bar baz))    ; cursor on bar, raise         → (foo bar)
+foo                ; cursor on foo, wrap-round    → (foo)
+```


### PR DESCRIPTION
## Summary

The README still listed only highlighting / completion / snippets / debug. Updated the 'Why this extension' bullets and 'First steps' to cover everything that has shipped in 0.5.x: REPL, refactoring (refs / rename / symbols), test explorer, diagnostics, format-on-save, paredit, and namespace-aware auto-import.

Added `docs/repl-and-paredit.md` and `docs/refactoring.md` so the README can stay short while the details remain searchable.

## Test plan

- [ ] `npm run check:changelog` passes.
- [ ] CI green.