### PR TITLE
feat(debug): inline values during Phel debug sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - README rewritten to cover REPL, paredit, refactoring, test explorer, diagnostics, and formatting alongside the original highlighting/completion/snippets/debug story. Added `docs/repl-and-paredit.md` and `docs/refactoring.md`.
 - Marketplace icon: 256x256 PNG generated from the official `phel-lang/phel-lang/logo_readme.svg`.
 - README tour: code-first walkthrough of completion + auto-import, hover, REPL, paredit, refactoring, and the test explorer at the top of the README.
+- Inline debug values: while a Phel debug session is paused, plain symbol tokens in the visible range get inline value annotations. Unresolved names (e.g. macros that didn't survive compilation) drop silently.
 
 ### Changed
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import { registerPareditCommands } from './phelPareditProvider';
 import { registerReplCommands } from './phelReplProvider';
 import { registerSelectionCommands } from './phelSelectionProvider';
 import { PhelFormHighlight } from './phelFormHighlight';
+import { PhelInlineValuesProvider } from './phelInlineValuesProvider';
 import { PhelStatusBar } from './phelStatusBar';
 import { PhelTestController } from './phelTestController';
 
@@ -225,6 +226,10 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(new PhelTestController());
     context.subscriptions.push(new PhelFormHighlight());
+
+    context.subscriptions.push(
+        vscode.languages.registerInlineValuesProvider('phel', new PhelInlineValuesProvider())
+    );
 
     // Provide hover information for breakpoints
     context.subscriptions.push(

--- a/src/phelInlineValues.ts
+++ b/src/phelInlineValues.ts
@@ -1,0 +1,135 @@
+// Pure helper: extract candidate variable names from a Phel source range.
+// Each occurrence becomes a separate InlineValue entry so the same name on
+// multiple lines is annotated independently. Strings, comments, char
+// literals, and reader keyword tokens (`:foo`) are skipped.
+
+const KEYWORD_PREFIXES = new Set([':']);
+const SYMBOL_BODY = /[A-Za-z0-9_!?*+<>=/\-.':$&%]/;
+const SYMBOL_TERMINATOR = new Set([
+    ' ',
+    '\t',
+    '\n',
+    '\r',
+    ',',
+    '(',
+    ')',
+    '[',
+    ']',
+    '{',
+    '}',
+    '"',
+    ';',
+    "'",
+    '`',
+    '@',
+    '~',
+    '^',
+]);
+
+export interface InlineNameOccurrence {
+    /** 0-based line. */
+    line: number;
+    /** 0-based column where the name starts. */
+    column: number;
+    /** Bare symbol token. */
+    name: string;
+}
+
+export function findInlineCandidates(
+    source: string,
+    fromLine: number,
+    toLine: number
+): InlineNameOccurrence[] {
+    const lines = source.split(/\r?\n/);
+    const out: InlineNameOccurrence[] = [];
+    const start = Math.max(0, fromLine);
+    const end = Math.min(lines.length - 1, toLine);
+    for (let line = start; line <= end; line++) {
+        scanLine(lines[line], line, out);
+    }
+    return out;
+}
+
+function scanLine(text: string, line: number, out: InlineNameOccurrence[]): void {
+    let i = 0;
+    let inString = false;
+    while (i < text.length) {
+        const c = text[i];
+        if (inString) {
+            if (c === '\\') {
+                i += 2;
+                continue;
+            }
+            if (c === '"') {
+                inString = false;
+            }
+            i++;
+            continue;
+        }
+        if (c === ';') {
+            return;
+        }
+        if (c === '"') {
+            inString = true;
+            i++;
+            continue;
+        }
+        if (c === '\\') {
+            i += 2;
+            continue;
+        }
+        if (KEYWORD_PREFIXES.has(c)) {
+            i++;
+            while (
+                i < text.length &&
+                SYMBOL_BODY.test(text[i]) &&
+                !SYMBOL_TERMINATOR.has(text[i])
+            ) {
+                i++;
+            }
+            continue;
+        }
+        if (isReaderPrefix(c)) {
+            i++;
+            continue;
+        }
+        if (!SYMBOL_BODY.test(c) || SYMBOL_TERMINATOR.has(c)) {
+            i++;
+            continue;
+        }
+        const start = i;
+        while (i < text.length && SYMBOL_BODY.test(text[i]) && !SYMBOL_TERMINATOR.has(text[i])) {
+            i++;
+        }
+        const name = text.slice(start, i);
+        if (isCandidate(name)) {
+            out.push({ line, column: start, name });
+        }
+    }
+}
+
+function isReaderPrefix(c: string): boolean {
+    return c === "'" || c === '`' || c === '~' || c === '@' || c === '^' || c === '#';
+}
+
+function isCandidate(name: string): boolean {
+    if (!name) {
+        return false;
+    }
+    if (name.startsWith(':')) {
+        return false;
+    }
+    if (/^[0-9]/.test(name)) {
+        return false;
+    }
+    if (name === 'true' || name === 'false' || name === 'nil') {
+        return false;
+    }
+    if (name.includes('/')) {
+        return false;
+    } // namespace-qualified
+    if (!/^[A-Za-z_]/.test(name)) {
+        return false;
+    } // reject `+`, `-`, `*` etc.
+    return true;
+}

--- a/src/phelInlineValuesProvider.ts
+++ b/src/phelInlineValuesProvider.ts
@@ -1,0 +1,37 @@
+// Inline-values during Phel debug sessions.
+//
+// VS Code calls `provideInlineValues` for the visible range above the
+// stopped line. We extract candidate symbol names with `findInlineCandidates`
+// and return one `InlineValueVariableLookup` per occurrence; VS Code asks
+// the active debug session to look each one up. Names not present in the
+// current scope are silently dropped, so this fails gracefully when the
+// Phel-to-PHP name doesn't match a live variable.
+//
+// Surfaces real values for plain locals (the common case after `let`/`for`)
+// and stays out of the way when the binding doesn't survive compilation.
+
+import * as vscode from 'vscode';
+import { findInlineCandidates } from './phelInlineValues';
+
+export class PhelInlineValuesProvider implements vscode.InlineValuesProvider {
+    provideInlineValues(
+        document: vscode.TextDocument,
+        viewport: vscode.Range,
+        context: vscode.InlineValueContext
+    ): vscode.ProviderResult<vscode.InlineValue[]> {
+        const fromLine = viewport.start.line;
+        const toLine = Math.min(context.stoppedLocation.end.line, viewport.end.line);
+        if (toLine < fromLine) {
+            return [];
+        }
+        const occurrences = findInlineCandidates(document.getText(), fromLine, toLine);
+        return occurrences.map(
+            (o) =>
+                new vscode.InlineValueVariableLookup(
+                    new vscode.Range(o.line, o.column, o.line, o.column + o.name.length),
+                    o.name,
+                    false
+                )
+        );
+    }
+}

--- a/src/test/phelInlineValues.test.ts
+++ b/src/test/phelInlineValues.test.ts
@@ -1,0 +1,47 @@
+import * as assert from 'node:assert/strict';
+import { findInlineCandidates } from '../phelInlineValues';
+
+function names(occ: ReturnType<typeof findInlineCandidates>): string[] {
+    return occ.map((o) => o.name);
+}
+
+describe('phelInlineValues.findInlineCandidates', () => {
+    it('extracts plain symbols', () => {
+        const src = '(let [x 1 y 2] (+ x y))';
+        assert.deepEqual(names(findInlineCandidates(src, 0, 0)), ['let', 'x', 'y', 'x', 'y']);
+    });
+
+    it('skips keywords', () => {
+        const src = '(assoc m :a 1)';
+        assert.deepEqual(names(findInlineCandidates(src, 0, 0)), ['assoc', 'm']);
+    });
+
+    it('skips strings and comments', () => {
+        const src = '(println "x" foo) ; bar';
+        assert.deepEqual(names(findInlineCandidates(src, 0, 0)), ['println', 'foo']);
+    });
+
+    it('skips operator-like names', () => {
+        const src = '(+ a b)';
+        assert.deepEqual(names(findInlineCandidates(src, 0, 0)), ['a', 'b']);
+    });
+
+    it('skips ns-qualified symbols', () => {
+        const src = '(my.ns/foo a)';
+        assert.deepEqual(names(findInlineCandidates(src, 0, 0)), ['a']);
+    });
+
+    it('respects line range', () => {
+        const src = 'x\ny\nz';
+        assert.deepEqual(names(findInlineCandidates(src, 1, 1)), ['y']);
+    });
+
+    it('returns line/column positions', () => {
+        const src = '(println foo)';
+        const occ = findInlineCandidates(src, 0, 0);
+        const foo = occ.find((o) => o.name === 'foo');
+        assert.ok(foo);
+        assert.equal(foo?.line, 0);
+        assert.equal(foo?.column, 9);
+    });
+});


### PR DESCRIPTION
## Summary

- Register `InlineValuesProvider` for `phel`. While a Phel debug session is paused, plain symbol tokens in the visible range get inline value annotations.
- Resolution is delegated to the active debug adapter via `InlineValueVariableLookup`; names not in the current scope are silently dropped, so we don't render `?` for macros / arguments that didn't survive Phel→PHP compilation.
- Pure scanner (`phelInlineValues.ts`) skips strings, comments, char literals, keywords, numbers, ns-qualified names, and operator-only identifiers. Seven unit tests.

## Test plan

- [ ] Set a breakpoint, hit it. Plain `let`/`for` bindings render their value next to the symbol.
- [ ] Names not in scope render nothing (no `?` clutter).
- [ ] Disabling debug mode hides all values immediately.
- [ ] CI green (269 tests).