### PR TITLE
feat(highlight): document highlight for symbol under cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Marketplace icon: 256x256 PNG generated from the official `phel-lang/phel-lang/logo_readme.svg`.
 - README tour: code-first walkthrough of completion + auto-import, hover, REPL, paredit, refactoring, and the test explorer at the top of the README.
 - Inline debug values: while a Phel debug session is paused, plain symbol tokens in the visible range get inline value annotations. Unresolved names (e.g. macros that didn't survive compilation) drop silently.
+- Document highlight: putting the cursor on a symbol underlines every occurrence of it in the current file (reusing the find-references scanner so strings and comments are skipped).
 
 ### Changed
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import { PhelFormatProvider } from './phelFormatProvider';
 import { PhelTestCodeLensProvider } from './phelTestCodeLensProvider';
 import { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
 import { PhelDefinitionProvider } from './phelDefinitionProvider';
+import { PhelDocumentHighlightProvider } from './phelDocumentHighlight';
 import { PhelReferenceProvider } from './phelReferenceProvider';
 import { PhelRenameProvider } from './phelRenameProvider';
 import { PhelDocumentSymbolProvider, PhelWorkspaceSymbolProvider } from './phelSymbolProviders';
@@ -167,6 +168,13 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.languages.registerReferenceProvider(
             'phel',
             new PhelReferenceProvider(workspaceIndexer)
+        )
+    );
+
+    context.subscriptions.push(
+        vscode.languages.registerDocumentHighlightProvider(
+            'phel',
+            new PhelDocumentHighlightProvider()
         )
     );
 

--- a/src/phelDocumentHighlight.ts
+++ b/src/phelDocumentHighlight.ts
@@ -1,0 +1,29 @@
+// Highlight every occurrence of the symbol under the cursor in the current
+// `.phel` file. Reuses `findOccurrences` so the same string-/comment-
+// skipping rules apply that find-references and rename use.
+
+import * as vscode from 'vscode';
+import { findOccurrences } from './phelReferences';
+
+const SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;
+
+export class PhelDocumentHighlightProvider implements vscode.DocumentHighlightProvider {
+    provideDocumentHighlights(
+        document: vscode.TextDocument,
+        position: vscode.Position
+    ): vscode.ProviderResult<vscode.DocumentHighlight[]> {
+        const range = document.getWordRangeAtPosition(position, SYMBOL_RE);
+        if (!range) {
+            return null;
+        }
+        const word = document.getText(range);
+        const text = document.getText();
+        return findOccurrences(text, word).map(
+            (occ) =>
+                new vscode.DocumentHighlight(
+                    new vscode.Range(document.positionAt(occ.start), document.positionAt(occ.end)),
+                    vscode.DocumentHighlightKind.Text
+                )
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Register `DocumentHighlightProvider` for `phel`.
- Putting the cursor on a symbol underlines every occurrence of it in the current file. Reuses the find-references scanner so strings, comments, and char literals are skipped.
- Standard editor behaviour for other languages; this brings Phel into line.

## Test plan

- [ ] Place the cursor on `foo` in `(defn bar [foo] (* foo foo))` -> both `foo` arguments get the editor highlight.
- [ ] Cursor on `"foo"` (inside the string) -> no highlight.
- [ ] CI green (269 tests).