### PR TITLE
fix(readme): use vsmarketplacebadges.dev for marketplace badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - README tour: code-first walkthrough of completion + auto-import, hover, REPL, paredit, refactoring, and the test explorer at the top of the README.
 - Inline debug values: while a Phel debug session is paused, plain symbol tokens in the visible range get inline value annotations. Unresolved names (e.g. macros that didn't survive compilation) drop silently.
 - Document highlight: putting the cursor on a symbol underlines every occurrence of it in the current file (reusing the find-references scanner so strings and comments are skipped).
+- README + package.json: switch Marketplace / Installs badges from the retired shields.io endpoint to `vsmarketplacebadges.dev` so the badges render real values.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 # Phel Lang for VS Code
 
 [![CI](https://github.com/phel-lang/phel-vs-code-extension/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/phel-lang/phel-vs-code-extension/actions/workflows/ci.yml)
-[![Marketplace](https://img.shields.io/visual-studio-marketplace/v/Phel-Lang.phel-lang?label=marketplace)](https://marketplace.visualstudio.com/items?itemName=Phel-Lang.phel-lang)
-[![Installs](https://img.shields.io/visual-studio-marketplace/i/Phel-Lang.phel-lang)](https://marketplace.visualstudio.com/items?itemName=Phel-Lang.phel-lang)
+[![Marketplace](https://vsmarketplacebadges.dev/version-short/Phel-Lang.phel-lang.svg)](https://marketplace.visualstudio.com/items?itemName=Phel-Lang.phel-lang)
+[![Installs](https://vsmarketplacebadges.dev/installs-short/Phel-Lang.phel-lang.svg)](https://marketplace.visualstudio.com/items?itemName=Phel-Lang.phel-lang)
 [![Release](https://img.shields.io/github/v/release/phel-lang/phel-vs-code-extension?label=release)](https://github.com/phel-lang/phel-vs-code-extension/releases)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     },
     "badges": [
         {
-            "url": "https://img.shields.io/visual-studio-marketplace/v/Phel-Lang.phel-lang?label=marketplace",
+            "url": "https://vsmarketplacebadges.dev/version-short/Phel-Lang.phel-lang.svg",
             "href": "https://marketplace.visualstudio.com/items?itemName=Phel-Lang.phel-lang",
             "description": "Marketplace version"
         },


### PR DESCRIPTION
## Summary

`img.shields.io/visual-studio-marketplace/...` is retired and now returns a gray *retired badge* placeholder (verified via API). Switch to `vsmarketplacebadges.dev` which still serves real values:

- Version: `https://vsmarketplacebadges.dev/version-short/Phel-Lang.phel-lang.svg`
- Installs: `https://vsmarketplacebadges.dev/installs-short/Phel-Lang.phel-lang.svg`

Updated in both `README.md` and the `badges` array in `package.json` so the marketplace listing matches.

## Test plan

- [ ] GitHub README renders both badges with real numbers.
- [ ] Marketplace listing badges aren't gray.
- [ ] CI green.