### PR TITLE
ci: workflow_dispatch release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+
+# Manual release: bump version, package the vsix, push the tag, create the
+# GitHub Release, and publish to the VS Code Marketplace.
+#
+# One-time setup:
+#   * Repo secret `VSCE_PAT` with a Marketplace personal access token that
+#     can publish under the `Phel-Lang` publisher.
+#   * Default `GITHUB_TOKEN` is enough for `gh release create` and pushes
+#     because the `contents: write` permission is granted below.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Semver version to cut (e.g. 0.6.0)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run: skip git push and Marketplace publish'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # release.sh checks current branch is `main`; ensure we're on main
+          # rather than a detached HEAD from `actions/checkout`.
+          git checkout -B main "$(git rev-parse HEAD)"
+
+      - run: npm ci
+
+      - name: Run release script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          if [[ -z "${VSCE_PAT}" && "${{ inputs.dry_run }}" != "true" ]]; then
+            echo "VSCE_PAT secret is missing. Add it in repo Settings > Secrets, or rerun with dry_run=true." >&2
+            exit 1
+          fi
+          flags=""
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            flags="--no-push --no-publish"
+          fi
+          ./scripts/release.sh "${{ inputs.version }}" $flags
+
+      - name: Upload vsix artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: phel-lang-${{ inputs.version }}.vsix
+          path: phel-lang-${{ inputs.version }}.vsix
+          if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Inline debug values: while a Phel debug session is paused, plain symbol tokens in the visible range get inline value annotations. Unresolved names (e.g. macros that didn't survive compilation) drop silently.
 - Document highlight: putting the cursor on a symbol underlines every occurrence of it in the current file (reusing the find-references scanner so strings and comments are skipped).
 - README + package.json: switch Marketplace / Installs badges from the retired shields.io endpoint to `vsmarketplacebadges.dev` so the badges render real values.
+- Release: new `Release` GitHub Actions workflow with manual `workflow_dispatch` trigger. Runs `scripts/release.sh` end-to-end (bump, tag, GH release, vsix attach, marketplace publish via `VSCE_PAT` secret). Local `npm run release -- X.Y.Z` still works.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,34 +55,42 @@ Keep the subject under ~70 characters; put the *why* in the body when it isn't o
 
 ## Releasing
 
-The end-to-end flow is automated by `scripts/release.sh` (also exposed as `npm run release`):
+Cut a release entirely from GitHub Actions: no local install, no manual marketplace upload.
+
+### One-click release (recommended)
+
+1. Make sure CHANGELOG `## [Unreleased]` is up to date on `main`.
+2. Open <https://github.com/phel-lang/phel-vs-code-extension/actions/workflows/release.yml> and click **Run workflow**.
+3. Fill in:
+   - `version`: e.g. `0.6.0`
+   - `dry_run`: leave unchecked for a real release; check it to package + push nothing.
+4. The workflow:
+   - bumps `package.json` + `package-lock.json`,
+   - rewrites `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` and re-creates an empty `Unreleased`,
+   - runs the gate (compile, lint, test, tokenize, bundle),
+   - packages the vsix,
+   - commits / tags / pushes,
+   - creates the GitHub Release with the vsix attached and the CHANGELOG section as the body,
+   - publishes to the VS Code Marketplace via `vsce publish`.
+
+### Local release
+
+Same flow, run from a clean `main` checkout:
 
 ```bash
-# from a clean main branch:
 npm run release -- 0.6.0
 ```
 
-That single command:
-
-1. Sanity-checks: on `main`, working tree clean, version not already tagged, local in sync with `origin/main`.
-2. Bumps `package.json` + `package-lock.json` to the requested version.
-3. Renames `## [Unreleased]` in `CHANGELOG.md` to `## [X.Y.Z] - YYYY-MM-DD`, then inserts a fresh empty `## [Unreleased]` heading above it (no-op if no Unreleased section exists).
-4. Runs the gate: `npm run compile`, `npm test`, `npm run tokenize`.
-5. Builds `phel-lang-X.Y.Z.vsix` via `vsce package`.
-6. Commits `chore(release): vX.Y.Z`, tags `vX.Y.Z`, pushes both.
-7. Creates a GitHub Release with the `.vsix` attached, using the matching CHANGELOG section as the body.
-8. Publishes to the VS Code Marketplace via `vsce publish`.
-
 Useful flags:
 
-- `--no-publish` - everything except the Marketplace upload (use when you want to drag-and-drop the `.vsix` via the publisher web UI instead).
-- `--no-push` - dry run: bumps versions and builds the `.vsix` locally, but does not push, tag remotely, create a release, or publish.
+- `--no-publish` - everything except the Marketplace upload.
+- `--no-push` - bumps versions and builds the `.vsix` locally, but does not push, tag remotely, create a release, or publish.
 
-If the script fails partway through, fix the cause and re-run; it's safe to re-run from the same point because each step checks for existing artefacts.
+If the script fails partway through, fix the cause and re-run; each step checks for existing artefacts.
 
 ### Marketplace setup (one-time)
 
-The extension's `publisher` field is `Phel-Lang`. To publish you need a Personal Access Token (PAT) tied to that account:
+The extension's `publisher` field is `Phel-Lang`. To publish you need a Personal Access Token (PAT) tied to that account.
 
 1. Go to <https://dev.azure.com>, sign in with the same account that owns the [`Phel-Lang` publisher](https://marketplace.visualstudio.com/manage/publishers/Phel-Lang).
 2. **User settings → Personal Access Tokens → New Token**:
@@ -90,13 +98,14 @@ The extension's `publisher` field is `Phel-Lang`. To publish you need a Personal
    - Expiration: pick what you're comfortable with (max 1 year)
    - Scopes → **Custom defined** → check **Marketplace > Manage**
 3. Copy the token (shown once).
-4. Cache it locally:
+4. **For the GitHub workflow**: add it as a repo secret named `VSCE_PAT` (Settings → Secrets and variables → Actions → New repository secret).
+5. **For local publishing**: cache it on your machine:
    ```bash
    npx @vscode/vsce login Phel-Lang
    # paste the PAT when prompted
    ```
 
-Subsequent `vsce publish` calls reuse the cached credentials. To rotate, run `vsce logout Phel-Lang` and repeat.
+Rotation: regenerate in Azure DevOps, update the `VSCE_PAT` secret (and `vsce login` again locally if you use the local flow).
 
 ### Marketplace assets
 


### PR DESCRIPTION
## Summary

New `.github/workflows/release.yml`: manual-trigger release that runs `scripts/release.sh` end-to-end on CI. No more local `vsce login`, no manual marketplace upload.

Trigger from <https://github.com/phel-lang/phel-vs-code-extension/actions/workflows/release.yml> -> **Run workflow**:

- `version`: semver, e.g. `0.6.0`.
- `dry_run`: skip git push + Marketplace publish (useful for verifying the pipeline before a real cut).

The job checks out `main`, sets the bot git author, runs `npm ci`, then `scripts/release.sh ${version}` with `VSCE_PAT` from the repo secret and the default `GITHUB_TOKEN` (granted `contents: write`). Produced vsix is also uploaded as a build artifact.

CONTRIBUTING.md now leads with the dispatch flow and documents the one-time `VSCE_PAT` secret + rotation. Local `npm run release -- X.Y.Z` still works.

## One-time setup before the first dispatch

1. Create a Marketplace PAT under the `Phel-Lang` Azure DevOps account (scope: `Marketplace > Manage`).
2. Add it as a repo secret named `VSCE_PAT` (Settings -> Secrets and variables -> Actions).
3. Trigger the workflow with `dry_run: true` once to confirm the pipeline before a real cut.

## Test plan

- [ ] Add `VSCE_PAT` secret.
- [ ] Run dispatch with `dry_run: true` for `0.6.0` -> bumps version, packages vsix, no push, no publish.
- [ ] Run dispatch with `dry_run: false` for the real release -> tag pushed, GH Release created with vsix, Marketplace updated.
- [ ] CI green on this PR.