### PR TITLE
ci(release): add publish_marketplace toggle, default off

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,15 @@
 name: Release
 
 # Manual release: bump version, package the vsix, push the tag, create the
-# GitHub Release, and publish to the VS Code Marketplace.
+# GitHub Release, and (optionally) publish to the VS Code Marketplace.
 #
-# One-time setup:
-#   * Repo secret `VSCE_PAT` with a Marketplace personal access token that
-#     can publish under the `Phel-Lang` publisher.
-#   * Default `GITHUB_TOKEN` is enough for `gh release create` and pushes
-#     because the `contents: write` permission is granted below.
+# Three modes via inputs:
+#   * dry_run = true                     -> bump + package, no push, no publish.
+#   * publish_marketplace = false        -> push tag, create GH release with
+#                                          vsix attached. You upload the vsix
+#                                          to the Marketplace web UI yourself.
+#   * publish_marketplace = true         -> full automation. Requires the
+#                                          `VSCE_PAT` repo secret.
 
 on:
   workflow_dispatch:
@@ -16,8 +18,13 @@ on:
         description: 'Semver version to cut (e.g. 0.6.0)'
         required: true
         type: string
+      publish_marketplace:
+        description: 'Also publish to the VS Code Marketplace (requires VSCE_PAT secret). Uncheck to upload the vsix manually.'
+        required: false
+        type: boolean
+        default: false
       dry_run:
-        description: 'Dry run: skip git push and Marketplace publish'
+        description: 'Dry run: skip git push, GH release, and Marketplace publish'
         required: false
         type: boolean
         default: false
@@ -60,13 +67,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: |
-          if [[ -z "${VSCE_PAT}" && "${{ inputs.dry_run }}" != "true" ]]; then
-            echo "VSCE_PAT secret is missing. Add it in repo Settings > Secrets, or rerun with dry_run=true." >&2
-            exit 1
-          fi
           flags=""
           if [[ "${{ inputs.dry_run }}" == "true" ]]; then
             flags="--no-push --no-publish"
+          elif [[ "${{ inputs.publish_marketplace }}" != "true" ]]; then
+            flags="--no-publish"
+          else
+            if [[ -z "${VSCE_PAT}" ]]; then
+              echo "VSCE_PAT secret is missing but publish_marketplace=true. Add it in repo Settings > Secrets, or uncheck publish_marketplace to upload the vsix manually." >&2
+              exit 1
+            fi
           fi
           ./scripts/release.sh "${{ inputs.version }}" $flags
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Document highlight: putting the cursor on a symbol underlines every occurrence of it in the current file (reusing the find-references scanner so strings and comments are skipped).
 - README + package.json: switch Marketplace / Installs badges from the retired shields.io endpoint to `vsmarketplacebadges.dev` so the badges render real values.
 - Release: new `Release` GitHub Actions workflow with manual `workflow_dispatch` trigger. Runs `scripts/release.sh` end-to-end (bump, tag, GH release, vsix attach, marketplace publish via `VSCE_PAT` secret). Local `npm run release -- X.Y.Z` still works.
+- Release: workflow now exposes a `publish_marketplace` toggle (default off) so you can ship the GitHub Release + vsix without needing the `VSCE_PAT` secret and upload the vsix manually via the Marketplace web UI.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,8 @@ Cut a release entirely from GitHub Actions: no local install, no manual marketpl
 2. Open <https://github.com/phel-lang/phel-vs-code-extension/actions/workflows/release.yml> and click **Run workflow**.
 3. Fill in:
    - `version`: e.g. `0.6.0`
-   - `dry_run`: leave unchecked for a real release; check it to package + push nothing.
+   - `publish_marketplace`: check to publish via `vsce publish` (requires `VSCE_PAT` secret). Uncheck to skip the Marketplace step and upload the vsix yourself via the [publisher web UI](https://marketplace.visualstudio.com/manage/publishers/Phel-Lang). The vsix is attached to the GitHub Release and uploaded as a workflow artifact either way.
+   - `dry_run`: check to bump + package only, with no git push, GH release, or Marketplace publish. Use it once before a real cut to confirm the pipeline.
 4. The workflow:
    - bumps `package.json` + `package-lock.json`,
    - rewrites `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` and re-creates an empty `Unreleased`,


### PR DESCRIPTION
## Summary

Make the manual-upload path first-class. Workflow inputs:

- `version` (required, semver).
- `publish_marketplace` (default **false**): when off, workflow pushes the tag and creates the GH Release with the vsix attached, and you upload that vsix via the Marketplace web UI. When on, runs `vsce publish` (requires `VSCE_PAT` secret).
- `dry_run` (default false): packages the vsix locally on the runner without push/publish.

This removes the Azure DevOps PAT prerequisite for first-cut releases. CONTRIBUTING.md updated.

## Test plan

- [ ] Run dispatch with `publish_marketplace=false` for `0.6.0` -> tag pushed, GH Release created with vsix, no Marketplace publish.
- [ ] Re-run with `publish_marketplace=true` once `VSCE_PAT` is set -> Marketplace also updated.
- [ ] CI green.