### PR TITLE
ci(release): default to GH-only release, --publish opts into Marketplace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,14 +69,13 @@ jobs:
         run: |
           flags=""
           if [[ "${{ inputs.dry_run }}" == "true" ]]; then
-            flags="--no-push --no-publish"
-          elif [[ "${{ inputs.publish_marketplace }}" != "true" ]]; then
-            flags="--no-publish"
-          else
+            flags="--no-push"
+          elif [[ "${{ inputs.publish_marketplace }}" == "true" ]]; then
             if [[ -z "${VSCE_PAT}" ]]; then
               echo "VSCE_PAT secret is missing but publish_marketplace=true. Add it in repo Settings > Secrets, or uncheck publish_marketplace to upload the vsix manually." >&2
               exit 1
             fi
+            flags="--publish"
           fi
           ./scripts/release.sh "${{ inputs.version }}" $flags
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - README + package.json: switch Marketplace / Installs badges from the retired shields.io endpoint to `vsmarketplacebadges.dev` so the badges render real values.
 - Release: new `Release` GitHub Actions workflow with manual `workflow_dispatch` trigger. Runs `scripts/release.sh` end-to-end (bump, tag, GH release, vsix attach, marketplace publish via `VSCE_PAT` secret). Local `npm run release -- X.Y.Z` still works.
 - Release: workflow now exposes a `publish_marketplace` toggle (default off) so you can ship the GitHub Release + vsix without needing the `VSCE_PAT` secret and upload the vsix manually via the Marketplace web UI.
+- Release: `scripts/release.sh` defaults flipped - GitHub Release is created by default, Marketplace publish is opt-in via `--publish`. Old `--no-publish` flag still accepted for backwards compatibility.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,10 +82,12 @@ Same flow, run from a clean `main` checkout:
 npm run release -- 0.6.0
 ```
 
-Useful flags:
+Default behaviour: bump version, build the vsix, push the tag, create the GitHub Release with the vsix attached. Marketplace publish is **off** by default - download the vsix from the GH Release and drop it into <https://marketplace.visualstudio.com/manage/publishers/Phel-Lang>.
 
-- `--no-publish` - everything except the Marketplace upload.
-- `--no-push` - bumps versions and builds the `.vsix` locally, but does not push, tag remotely, create a release, or publish.
+Flags:
+
+- `--publish` - also run `vsce publish` (requires `vsce login Phel-Lang` cached or `VSCE_PAT` env var set).
+- `--no-push` - dry run: bumps versions and builds the `.vsix` locally, no push / tag / GH release.
 
 If the script fails partway through, fix the cause and re-run; each step checks for existing artefacts.
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 # Cut a new release of the Phel Lang VS Code extension.
 #
-#   scripts/release.sh <version> [--no-publish] [--no-push]
+#   scripts/release.sh <version> [--publish] [--no-push]
+#
+# Default flow (no flags): bump version, package the vsix, push the tag,
+# create the GitHub Release with the vsix attached. Marketplace publish is
+# OFF by default - drop the vsix into the Marketplace web UI yourself, or
+# pass `--publish` for full automation.
 #
 # What it does, in order:
 #   1. Sanity checks: on main, working tree clean, version not already tagged.
 #   2. Bumps package.json + package-lock.json to <version>.
 #   3. Renames the CHANGELOG "Unreleased" heading to "[<version>] - <today>"
-#      (if present); otherwise just leaves CHANGELOG as-is so the entry is
+#      (if present); otherwise leaves CHANGELOG as-is so the entry is
 #      assumed already authored.
 #   4. Runs the gate: npm run compile, npm test, npm run tokenize.
 #   5. Builds phel-lang-<version>.vsix via `vsce package`.
@@ -15,28 +20,29 @@
 #      (skip with --no-push to dry-run locally).
 #   7. Creates a GitHub Release with the .vsix attached, using the matching
 #      CHANGELOG section as the release notes.
-#   8. Publishes to the VS Code Marketplace via `vsce publish` (skip with
-#      --no-publish; useful when you want to upload manually via the
-#      Marketplace web UI).
+#   8. (Only with --publish) publishes to the VS Code Marketplace via
+#      `vsce publish`.
 #
 # Pre-reqs (one-time): see CONTRIBUTING.md "Marketplace setup".
-#   - vsce logged in (`npx @vscode/vsce login Phel-Lang`)
 #   - gh authed (`gh auth status`)
+#   - For --publish: vsce logged in (`npx @vscode/vsce login Phel-Lang`)
+#     or VSCE_PAT env var set.
 
 set -euo pipefail
 
-PUBLISH=1
+PUBLISH=0
 PUSH=1
 VERSION=""
 
 usage() {
-    sed -n '2,30p' "$0" >&2
+    sed -n '2,32p' "$0" >&2
     exit 1
 }
 
 for arg in "$@"; do
     case "$arg" in
-        --no-publish) PUBLISH=0 ;;
+        --publish)    PUBLISH=1 ;;
+        --no-publish) PUBLISH=0 ;;  # accepted for backwards compatibility
         --no-push)    PUSH=0 ;;
         -h|--help)    usage ;;
         -*)           echo "unknown flag: $arg" >&2; usage ;;
@@ -45,7 +51,7 @@ for arg in "$@"; do
 done
 
 if [[ -z "$VERSION" ]]; then
-    echo "usage: scripts/release.sh <version> [--no-publish] [--no-push]" >&2
+    echo "usage: scripts/release.sh <version> [--publish] [--no-push]" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Flip the default of `scripts/release.sh`:

- Before: ran `vsce publish` by default; `--no-publish` to skip.
- After: stops after the GitHub Release; pass `--publish` to also push to the Marketplace.

`--no-publish` is still accepted as a no-op so existing aliases / muscle memory don't break. `--no-push` unchanged.

Workflow keeps the same input UI (`publish_marketplace`, `dry_run`) but now passes `--publish` to the script when the user opts in, instead of the old `--no-publish` opt-out.

CONTRIBUTING.md aligned.

## Test plan

- [ ] `bash -n scripts/release.sh` clean.
- [ ] `npm run check:changelog` passes.
- [ ] Local `scripts/release.sh 0.6.0 --no-push` packages a vsix without pushing.
- [ ] CI green.