### PR TITLE
ci(release): auto-bump minor by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,19 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Semver version to cut (e.g. 0.6.0)'
-        required: true
+        description: 'Explicit semver version (leave empty to auto-bump using `bump`)'
+        required: false
         type: string
+        default: ''
+      bump:
+        description: 'Auto-bump level when `version` is empty'
+        required: false
+        type: choice
+        default: 'minor'
+        options:
+          - patch
+          - minor
+          - major
       publish_marketplace:
         description: 'Also publish to the VS Code Marketplace (requires VSCE_PAT secret). Uncheck to upload the vsix manually.'
         required: false
@@ -68,21 +78,26 @@ jobs:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: |
           flags=""
+          if [[ -n "${{ inputs.version }}" ]]; then
+            flags+=" ${{ inputs.version }}"
+          else
+            flags+=" --bump ${{ inputs.bump }}"
+          fi
           if [[ "${{ inputs.dry_run }}" == "true" ]]; then
-            flags="--no-push"
+            flags+=" --no-push"
           elif [[ "${{ inputs.publish_marketplace }}" == "true" ]]; then
             if [[ -z "${VSCE_PAT}" ]]; then
               echo "VSCE_PAT secret is missing but publish_marketplace=true. Add it in repo Settings > Secrets, or uncheck publish_marketplace to upload the vsix manually." >&2
               exit 1
             fi
-            flags="--publish"
+            flags+=" --publish"
           fi
-          ./scripts/release.sh "${{ inputs.version }}" $flags
+          ./scripts/release.sh $flags
 
       - name: Upload vsix artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: phel-lang-${{ inputs.version }}.vsix
-          path: phel-lang-${{ inputs.version }}.vsix
+          name: phel-lang-vsix
+          path: phel-lang-*.vsix
           if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Release: new `Release` GitHub Actions workflow with manual `workflow_dispatch` trigger. Runs `scripts/release.sh` end-to-end (bump, tag, GH release, vsix attach, marketplace publish via `VSCE_PAT` secret). Local `npm run release -- X.Y.Z` still works.
 - Release: workflow now exposes a `publish_marketplace` toggle (default off) so you can ship the GitHub Release + vsix without needing the `VSCE_PAT` secret and upload the vsix manually via the Marketplace web UI.
 - Release: `scripts/release.sh` defaults flipped - GitHub Release is created by default, Marketplace publish is opt-in via `--publish`. Old `--no-publish` flag still accepted for backwards compatibility.
+- Release: `scripts/release.sh` no longer requires an explicit version. With no args it auto-bumps the minor of the current `package.json`. Override with `--bump patch|minor|major` or pass an explicit semver. Workflow exposes the same options.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,8 @@ Cut a release entirely from GitHub Actions: no local install, no manual marketpl
 1. Make sure CHANGELOG `## [Unreleased]` is up to date on `main`.
 2. Open <https://github.com/phel-lang/phel-vs-code-extension/actions/workflows/release.yml> and click **Run workflow**.
 3. Fill in:
-   - `version`: e.g. `0.6.0`
+   - `version`: leave empty to auto-bump from the current `package.json`, or pin an explicit semver like `0.6.0`.
+   - `bump`: when `version` is empty, picks the auto-bump level (`patch` / `minor` / `major`). Default `minor`.
    - `publish_marketplace`: check to publish via `vsce publish` (requires `VSCE_PAT` secret). Uncheck to skip the Marketplace step and upload the vsix yourself via the [publisher web UI](https://marketplace.visualstudio.com/manage/publishers/Phel-Lang). The vsix is attached to the GitHub Release and uploaded as a workflow artifact either way.
    - `dry_run`: check to bump + package only, with no git push, GH release, or Marketplace publish. Use it once before a real cut to confirm the pipeline.
 4. The workflow:
@@ -79,14 +80,18 @@ Cut a release entirely from GitHub Actions: no local install, no manual marketpl
 Same flow, run from a clean `main` checkout:
 
 ```bash
-npm run release -- 0.6.0
+npm run release            # auto-bump minor, build vsix, push tag, create GH Release
+npm run release -- 0.6.0   # explicit version
+npm run release -- --bump patch
+npm run release -- --bump major
 ```
 
-Default behaviour: bump version, build the vsix, push the tag, create the GitHub Release with the vsix attached. Marketplace publish is **off** by default - download the vsix from the GH Release and drop it into <https://marketplace.visualstudio.com/manage/publishers/Phel-Lang>.
+Default behaviour: bump the minor version of the current `package.json`, build the vsix, push the tag, create the GitHub Release with the vsix attached. Marketplace publish is **off** by default - download the vsix from the GH Release and drop it into <https://marketplace.visualstudio.com/manage/publishers/Phel-Lang>.
 
 Flags:
 
 - `--publish` - also run `vsce publish` (requires `vsce login Phel-Lang` cached or `VSCE_PAT` env var set).
+- `--bump <patch|minor|major>` - choose the auto-bump level (default `minor`).
 - `--no-push` - dry run: bumps versions and builds the `.vsix` locally, no push / tag / GH release.
 
 If the script fails partway through, fix the cause and re-run; each step checks for existing artefacts.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,16 +1,21 @@
 #!/usr/bin/env bash
 # Cut a new release of the Phel Lang VS Code extension.
 #
-#   scripts/release.sh <version> [--publish] [--no-push]
+#   scripts/release.sh [<version>] [--bump <major|minor|patch>] [--publish] [--no-push]
 #
-# Default flow (no flags): bump version, package the vsix, push the tag,
-# create the GitHub Release with the vsix attached. Marketplace publish is
-# OFF by default - drop the vsix into the Marketplace web UI yourself, or
-# pass `--publish` for full automation.
+# Default flow (no args): bump the minor version of the current package.json,
+# package the vsix, push the tag, create the GitHub Release with the vsix
+# attached. Marketplace publish is OFF by default - drop the vsix into the
+# Marketplace web UI yourself, or pass `--publish` for full automation.
+#
+# Version selection precedence:
+#   1. Explicit `<version>` arg if given.
+#   2. `--bump major|minor|patch` of the current `package.json` version.
+#   3. Default: `--bump minor`.
 #
 # What it does, in order:
 #   1. Sanity checks: on main, working tree clean, version not already tagged.
-#   2. Bumps package.json + package-lock.json to <version>.
+#   2. Bumps package.json + package-lock.json to the chosen version.
 #   3. Renames the CHANGELOG "Unreleased" heading to "[<version>] - <today>"
 #      (if present); otherwise leaves CHANGELOG as-is so the entry is
 #      assumed already authored.
@@ -33,26 +38,44 @@ set -euo pipefail
 PUBLISH=0
 PUSH=1
 VERSION=""
+BUMP="minor"
 
 usage() {
-    sed -n '2,32p' "$0" >&2
+    sed -n '2,38p' "$0" >&2
     exit 1
 }
 
-for arg in "$@"; do
-    case "$arg" in
-        --publish)    PUBLISH=1 ;;
-        --no-publish) PUBLISH=0 ;;  # accepted for backwards compatibility
-        --no-push)    PUSH=0 ;;
+while (( $# > 0 )); do
+    case "$1" in
+        --publish)    PUBLISH=1; shift ;;
+        --no-publish) PUBLISH=0; shift ;;  # accepted for backwards compatibility
+        --no-push)    PUSH=0; shift ;;
+        --bump)
+            shift
+            case "${1:-}" in
+                major|minor|patch) BUMP="$1"; shift ;;
+                *) echo "--bump expects major|minor|patch (got '${1:-}')" >&2; exit 1 ;;
+            esac
+            ;;
         -h|--help)    usage ;;
-        -*)           echo "unknown flag: $arg" >&2; usage ;;
-        *)            VERSION="$arg" ;;
+        -*)           echo "unknown flag: $1" >&2; usage ;;
+        *)            VERSION="$1"; shift ;;
     esac
 done
 
 if [[ -z "$VERSION" ]]; then
-    echo "usage: scripts/release.sh <version> [--publish] [--no-push]" >&2
-    exit 1
+    CURRENT=$(node -p "require('./package.json').version")
+    VERSION=$(node -e "
+        const [v, level] = process.argv.slice(1);
+        const m = v.match(/^(\d+)\.(\d+)\.(\d+)/);
+        if (!m) { console.error('cannot parse current version: ' + v); process.exit(1); }
+        let [, maj, min, pat] = m.map(Number);
+        if (level === 'major')      { maj++; min = 0; pat = 0; }
+        else if (level === 'minor') { min++; pat = 0; }
+        else                        { pat++; }
+        console.log(\`\${maj}.\${min}.\${pat}\`);
+    " "$CURRENT" "$BUMP")
+    echo "==> auto-bumping $BUMP: $CURRENT -> $VERSION"
 fi
 
 if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then


### PR DESCRIPTION
## Summary

`scripts/release.sh` no longer requires an explicit version. With no args it auto-bumps the minor of the current `package.json`.

| Invocation | Result |
|---|---|
| `scripts/release.sh` | auto-bump minor (default) |
| `scripts/release.sh --bump patch` | auto-bump patch |
| `scripts/release.sh --bump major` | auto-bump major |
| `scripts/release.sh 0.7.2` | pin explicit version |

Workflow gains a `bump` choice input (`patch` / `minor` / `major`, default `minor`) used when `version` is empty. Artifact upload step now globs `phel-lang-*.vsix` so it doesn't need to know the version upfront.

CONTRIBUTING updated.

## Test plan

- [ ] `bash -n scripts/release.sh` clean.
- [ ] Dispatch with `version` empty + `bump=minor` -> bumps `0.5.1 -> 0.6.0`.
- [ ] Dispatch with `version=0.7.0` -> pins `0.7.0`.
- [ ] CI green.