### PR TITLE
fix(lookup): resolve alias/name via :as in current file's (ns ...)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Editor intelligence
+
+- Resolve `alias/name` symbols via the file's `(:require [other.ns :as alias])` clause. Hover, go-to-definition, and signature help now light up for `r/render`-style references when `r` is aliased in the current file.
+
 ## [0.6.1] - 2026-05-07
 
 ### Build

--- a/src/phelDefinitionProvider.ts
+++ b/src/phelDefinitionProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { lookupSymbol } from './phelDocsLookup';
+import { aliasMapFromSource } from './phelNsAnalyzer';
 import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
 import { combineDocs } from './phelWorkspaceIndex';
 import { PHEL_DOCS } from './phelCoreDocs';
@@ -20,7 +21,8 @@ export class PhelDefinitionProvider implements vscode.DefinitionProvider {
         const word = document.getText(range);
 
         const merged = combineDocs(this.indexer.index.allDocs(), PHEL_DOCS);
-        const doc = lookupSymbol(word, merged);
+        const aliases = aliasMapFromSource(document.getText());
+        const doc = lookupSymbol(word, merged, aliases);
         if (!doc) {
             return null;
         }

--- a/src/phelDocsLookup.ts
+++ b/src/phelDocsLookup.ts
@@ -9,15 +9,35 @@ import type { PhelDoc } from './phelDocs';
  * Find the best `PhelDoc` for a typed symbol.
  *
  * - An exact `<ns>/<name>` match always wins.
+ * - When `aliases` is provided and `symbol` is `alias/name`, the alias is
+ *   resolved to its target namespace before looking up `<ns>/<name>`.
  * - Otherwise look for a public symbol with that bare `name`. Prefer
  *   `phel.core` (the auto-imported namespace), then any other public
  *   namespace, then private definitions as a last resort.
  *
  * Returns `undefined` if nothing matches.
  */
-export function lookupSymbol(symbol: string, docs: readonly PhelDoc[]): PhelDoc | undefined {
+export function lookupSymbol(
+    symbol: string,
+    docs: readonly PhelDoc[],
+    aliases?: ReadonlyMap<string, string>
+): PhelDoc | undefined {
     if (!symbol) {
         return undefined;
+    }
+
+    if (aliases && symbol.includes('/')) {
+        const slash = symbol.indexOf('/');
+        const alias = symbol.slice(0, slash);
+        const name = symbol.slice(slash + 1);
+        const targetNs = aliases.get(alias);
+        if (targetNs) {
+            const qualified = `${targetNs}/${name}`;
+            const aliased = docs.find((d) => d.qualifiedName === qualified);
+            if (aliased) {
+                return aliased;
+            }
+        }
     }
 
     const exact = docs.find((d) => d.qualifiedName === symbol);

--- a/src/phelHoverProvider.ts
+++ b/src/phelHoverProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { PHEL_DOCS } from './phelCoreDocs';
 import { lookupSymbol, renderDocMarkdown } from './phelDocsLookup';
+import { aliasMapFromSource } from './phelNsAnalyzer';
 import { combineDocs } from './phelWorkspaceIndex';
 import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
 
@@ -21,7 +22,8 @@ export class PhelHoverProvider implements vscode.HoverProvider {
         const merged = this.indexer
             ? combineDocs(this.indexer.index.allDocs(), PHEL_DOCS)
             : [...PHEL_DOCS];
-        const doc = lookupSymbol(word, merged);
+        const aliases = aliasMapFromSource(document.getText());
+        const doc = lookupSymbol(word, merged, aliases);
         if (!doc) {
             return null;
         }

--- a/src/phelNsAnalyzer.ts
+++ b/src/phelNsAnalyzer.ts
@@ -40,6 +40,26 @@ export interface NsForm {
     requireClause: RequireClause | null;
 }
 
+/**
+ * Build the alias map for the given source: `alias -> target.ns` for every
+ * `[other.ns :as alias]` entry in the file's `(:require ...)` clause. Used
+ * by hover / definition / completion / signature providers to resolve
+ * `alias/name` into a fully-qualified lookup.
+ */
+export function aliasMapFromSource(src: string): Map<string, string> {
+    const map = new Map<string, string>();
+    const ns = parseNsForm(src);
+    if (!ns?.requireClause) {
+        return map;
+    }
+    for (const entry of ns.requireClause.entries) {
+        if (entry.as && entry.ns) {
+            map.set(entry.as, entry.ns);
+        }
+    }
+    return map;
+}
+
 export function parseNsForm(src: string): NsForm | null {
     const forms = parseAll(src);
     for (const form of forms) {

--- a/src/phelSignatureHelpProvider.ts
+++ b/src/phelSignatureHelpProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { PHEL_DOCS } from './phelCoreDocs';
 import { lookupSymbol } from './phelDocsLookup';
+import { aliasMapFromSource } from './phelNsAnalyzer';
 import {
     aritiesOf,
     clampActiveParam,
@@ -27,7 +28,8 @@ export class PhelSignatureHelpProvider implements vscode.SignatureHelpProvider {
         const merged = this.indexer
             ? combineDocs(this.indexer.index.allDocs(), PHEL_DOCS)
             : [...PHEL_DOCS];
-        const doc = lookupSymbol(call.callee, merged);
+        const aliases = aliasMapFromSource(document.getText());
+        const doc = lookupSymbol(call.callee, merged, aliases);
         if (!doc) {
             return null;
         }

--- a/src/test/phelDocsLookup.test.ts
+++ b/src/test/phelDocsLookup.test.ts
@@ -83,6 +83,25 @@ describe('lookupSymbol', function () {
     it('returns undefined for an empty input', function () {
         assert.strictEqual(lookupSymbol('', corpus), undefined);
     });
+
+    it('resolves alias-qualified `alias/name` via the alias map', function () {
+        const aliases = new Map([['r', 'phel.misc']]);
+        const r = lookupSymbol('r/orphan', corpus, aliases);
+        assert.ok(r);
+        assert.strictEqual(r?.qualifiedName, 'phel.misc/orphan');
+    });
+
+    it('falls back to plain lookup when the alias is unknown', function () {
+        const aliases = new Map([['x', 'no.such.ns']]);
+        const r = lookupSymbol('assoc', corpus, aliases);
+        assert.strictEqual(r?.qualifiedName, 'phel.core/assoc');
+    });
+
+    it('returns undefined when alias resolves but the name does not exist', function () {
+        const aliases = new Map([['r', 'phel.misc']]);
+        const r = lookupSymbol('r/missing', corpus, aliases);
+        assert.strictEqual(r, undefined);
+    });
 });
 
 describe('renderDocMarkdown', function () {

--- a/src/test/phelNsAnalyzer.test.ts
+++ b/src/test/phelNsAnalyzer.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert/strict';
-import { buildRequireEdit, parseNsForm } from '../phelNsAnalyzer';
+import { aliasMapFromSource, buildRequireEdit, parseNsForm } from '../phelNsAnalyzer';
 
 function applyEdit(src: string, edit: ReturnType<typeof buildRequireEdit>): string {
     if (!edit) {
@@ -77,5 +77,26 @@ describe('phelNsAnalyzer.buildRequireEdit', () => {
 
     it('returns null when there is no ns form', () => {
         assert.equal(buildRequireEdit(null, 'other.ns', 'foo'), null);
+    });
+});
+
+describe('phelNsAnalyzer.aliasMapFromSource', () => {
+    it('returns an empty map when there is no ns form', () => {
+        assert.equal(aliasMapFromSource('(defn foo [])').size, 0);
+    });
+
+    it('returns an empty map when there is no :require clause', () => {
+        assert.equal(aliasMapFromSource('(ns my.app)').size, 0);
+    });
+
+    it('extracts every :as alias from the require clause', () => {
+        const src = `(ns my.app
+  (:require [phelgeon.render :as r]
+            [phelgeon.input :as i]
+            [other.ns]))`;
+        const map = aliasMapFromSource(src);
+        assert.equal(map.size, 2);
+        assert.equal(map.get('r'), 'phelgeon.render');
+        assert.equal(map.get('i'), 'phelgeon.input');
     });
 });


### PR DESCRIPTION
## Summary

Hover, go-to-definition, and signature help failed for qualified references like `r/render` even when the file declared `(:require [phelgeon.render :as r])`. Reason: `lookupSymbol` only matched bare names or full `<ns>/<name>`.

- `lookupSymbol` now takes an optional `aliases: Map<alias, ns>`.
- When the typed symbol is `alias/name` and the alias resolves, look up `<targetNs>/<name>` first.
- New helper `aliasMapFromSource(src)` extracts every `:as alias -> ns` from the file's `(:require ...)` clause.
- Hover, definition, and signature-help providers plumb the alias map through.

## Caveat: the red diagnostic in the screenshot

`Cannot resolve symbol 'r/render'. Did you mean ...` is `phel(PHEL001)` from `phel analyze`. That diagnostic is produced by the Phel CLI itself; this PR only fixes the **extension-side** resolution so hover / F12 / signature popups work even while the CLI complains.

If `r/render` is still flagged after this PR ships, the next step is one of:
1. Verify the file's `(ns ...)` form has `(:require [phelgeon.render :as r])` exactly.
2. If yes, file an issue against `phel-lang/phel-lang` since `phel analyze` is rejecting a legal alias-qualified reference.

## Test plan

- [ ] Cursor on `r/render` -> hover shows the doc from `phelgeon.render/render`.
- [ ] `F12` jumps to `render` in `render.phel`.
- [ ] Signature help in `(r/render |state)` highlights the `state` parameter.
- [ ] Existing 269 tests still pass; 6 new tests cover alias resolution and the alias-map extractor.