### PR TITLE
feat(settings): add phel.executablePath as workspace-wide CLI override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## [Unreleased]
 
+### Settings
+
+- New `phel.executablePath` (default `vendor/bin/phel`) acts as a single workspace-wide pointer to the Phel CLI for diagnostics, format, test, and REPL. Existing per-subsystem settings (`phel.diagnostics.command`, `phel.format.command`, `phel.test.command`, `phel.repl.command`) still take precedence when set, but their defaults are now empty strings that fall back to `phel.executablePath`. Useful when the binary lives somewhere other than `vendor/bin/phel` (e.g. `bin/phel`, `/usr/local/bin/phel`).
+
 ### Docs
 
 - README trimmed to features + install + docs index. Marketplace install link added.
+- `docs/settings.md` rewritten with a Phel CLI location section, resolution order, and per-subsystem override examples.
 
 ## [0.6.2] - 2026-05-07
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ code --install-extension Phel-Lang.phel-lang
 
 Requires VS Code **1.75+**.
 
+## Configuration
+
+The extension expects the Phel CLI at `vendor/bin/phel` (Composer default). For other layouts, set `phel.executablePath` once in `.vscode/settings.json`:
+
+```jsonc
+{ "phel.executablePath": "bin/phel" }
+```
+
+Per-subsystem overrides (`phel.diagnostics.command`, `phel.format.command`, `phel.test.command`, `phel.repl.command`) take precedence when set. Full settings reference: [docs/settings.md](docs/settings.md).
+
 ## Documentation
 
 | Topic | Link |

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -2,14 +2,73 @@
 
 All settings live under `phel.*` in VS Code's settings (workspace or user level). Set them via the Settings UI, by editing `settings.json`, or per-folder in `.vscode/settings.json`.
 
+## Phel CLI location
+
+The extension shells out to the Phel CLI for diagnostics, formatting, the test runner, and the REPL. By default it expects `vendor/bin/phel` (the path Composer installs to). Override it once with `phel.executablePath`, or per subsystem if a particular feature needs a different binary.
+
 | Setting | Type | Default | Description |
 |---|---|---|---|
-| `phel.cacheDirectory` | string | `""` | Path to the Phel cache directory (where compiled PHP files land). Empty value → the system temp directory (`${os.tmpdir()}/phel`). |
-| `phel.debug.enabled` | boolean | `true` | Enable the bundled Phel debug adapter for source-level debugging. Disable if you want to fall back to a vanilla PHP debug session. |
+| `phel.executablePath` | string | `vendor/bin/phel` | Workspace-wide CLI path. Used by all subsystems unless overridden. Relative paths resolve against the workspace folder; absolute paths are used as-is. |
+| `phel.diagnostics.command` | string | `""` | Override `phel.executablePath` for `phel analyze`. Empty string → fall back to `phel.executablePath`. |
+| `phel.format.command` | string | `""` | Override `phel.executablePath` for `phel format`. Empty string → fall back to `phel.executablePath`. |
+| `phel.test.command` | string | `""` | Override `phel.executablePath` for the test CodeLens / Test Explorer. Empty string → fall back to `phel.executablePath`. |
+| `phel.repl.command` | string | `""` | Override `phel.executablePath` for the REPL terminal. Empty string → fall back to `phel.executablePath`. |
+| `phel.repl.args` | string[] | `["repl"]` | Arguments passed to the Phel CLI when starting the REPL. |
 
-## Examples
+**Resolution order** (per subsystem):
 
-**Project-local cache** (`.vscode/settings.json`):
+1. The per-subsystem setting (`phel.diagnostics.command`, `phel.format.command`, …) when set to a non-empty string.
+2. `phel.executablePath`.
+3. Built-in default `vendor/bin/phel`.
+
+### Example: binary in `bin/phel`
+
+```jsonc
+// .vscode/settings.json
+{
+  "phel.executablePath": "bin/phel"
+}
+```
+
+### Example: absolute path
+
+```jsonc
+{
+  "phel.executablePath": "/usr/local/bin/phel"
+}
+```
+
+### Example: per-subsystem override
+
+The default CLI for everything is `bin/phel`, but the test runner uses a wrapper script:
+
+```jsonc
+{
+  "phel.executablePath": "bin/phel",
+  "phel.test.command": "scripts/phel-with-coverage.sh"
+}
+```
+
+## Feature toggles
+
+| Setting | Type | Default | Description |
+|---|---|---|---|
+| `phel.diagnostics.enabled` | boolean | `true` | Run `phel analyze` on save and surface inline diagnostics. |
+| `phel.format.enabled` | boolean | `true` | Use `phel format` as the document formatter. |
+| `phel.tests.codeLensEnabled` | boolean | `true` | Show inline `▶ Run test` CodeLens above each `deftest`. |
+| `phel.paredit.enabled` | boolean | `true` | Register paredit commands (slurp / barf / raise / wrap). |
+| `phel.repl.enabled` | boolean | `true` | Register REPL commands (start / eval form / eval selection / eval file). |
+| `phel.repl.history.enabled` | boolean | `true` | Append every form sent to the REPL to `.vscode/phel-repl-history.phel`. |
+| `phel.formHighlight.enabled` | boolean | `true` | Subtle background tint on the form enclosing the cursor. |
+| `phel.debug.enabled` | boolean | `true` | Enable the bundled Phel debug adapter. Disable to fall back to a raw PHP debug session. |
+
+## Other
+
+| Setting | Type | Default | Description |
+|---|---|---|---|
+| `phel.cacheDirectory` | string | `""` | Path to the Phel cache directory (where compiled PHP files land). Empty → system temp directory (`${os.tmpdir()}/phel`). |
+
+### Example: project-local cache
 
 ```jsonc
 {
@@ -17,7 +76,7 @@ All settings live under `phel.*` in VS Code's settings (workspace or user level)
 }
 ```
 
-**Disable the debug adapter** for a project that doesn't need it:
+### Example: disable the debug adapter
 
 ```jsonc
 {

--- a/package.json
+++ b/package.json
@@ -356,6 +356,11 @@
                     "default": true,
                     "description": "Enable Phel debug adapter for source-level debugging"
                 },
+                "phel.executablePath": {
+                    "type": "string",
+                    "default": "vendor/bin/phel",
+                    "description": "Workspace-wide path to the Phel CLI. Used by diagnostics, format, test, and REPL unless a per-command setting overrides it. Relative paths resolve against the workspace folder; absolute paths are used as-is."
+                },
                 "phel.diagnostics.enabled": {
                     "type": "boolean",
                     "default": true,
@@ -363,8 +368,8 @@
                 },
                 "phel.diagnostics.command": {
                     "type": "string",
-                    "default": "vendor/bin/phel",
-                    "description": "Path to the Phel CLI used for diagnostics. Relative paths resolve against the workspace folder."
+                    "default": "",
+                    "description": "Override `phel.executablePath` for diagnostics only. Empty string falls back to `phel.executablePath`. Relative paths resolve against the workspace folder."
                 },
                 "phel.format.enabled": {
                     "type": "boolean",
@@ -373,8 +378,8 @@
                 },
                 "phel.format.command": {
                     "type": "string",
-                    "default": "vendor/bin/phel",
-                    "description": "Path to the Phel CLI used for formatting. Relative paths resolve against the workspace folder."
+                    "default": "",
+                    "description": "Override `phel.executablePath` for formatting only. Empty string falls back to `phel.executablePath`. Relative paths resolve against the workspace folder."
                 },
                 "phel.tests.codeLensEnabled": {
                     "type": "boolean",
@@ -383,8 +388,8 @@
                 },
                 "phel.test.command": {
                     "type": "string",
-                    "default": "vendor/bin/phel",
-                    "description": "Path to the Phel CLI used by the test CodeLens. Relative paths resolve against the workspace folder."
+                    "default": "",
+                    "description": "Override `phel.executablePath` for the test CodeLens / Test Explorer. Empty string falls back to `phel.executablePath`. Relative paths resolve against the workspace folder."
                 },
                 "phel.paredit.enabled": {
                     "type": "boolean",
@@ -398,8 +403,8 @@
                 },
                 "phel.repl.command": {
                     "type": "string",
-                    "default": "vendor/bin/phel",
-                    "description": "Path to the Phel CLI used to launch the REPL terminal. Relative paths resolve against the workspace folder."
+                    "default": "",
+                    "description": "Override `phel.executablePath` for the REPL terminal. Empty string falls back to `phel.executablePath`. Relative paths resolve against the workspace folder."
                 },
                 "phel.repl.args": {
                     "type": "array",

--- a/package.json
+++ b/package.json
@@ -359,7 +359,12 @@
                 "phel.executablePath": {
                     "type": "string",
                     "default": "vendor/bin/phel",
-                    "description": "Workspace-wide path to the Phel CLI. Used by diagnostics, format, test, and REPL unless a per-command setting overrides it. Relative paths resolve against the workspace folder; absolute paths are used as-is."
+                    "examples": [
+                        "vendor/bin/phel",
+                        "bin/phel",
+                        "/usr/local/bin/phel"
+                    ],
+                    "markdownDescription": "Workspace-wide path to the Phel CLI. Used by diagnostics, format, test, and REPL unless a per-command setting (`#phel.diagnostics.command#`, `#phel.format.command#`, `#phel.test.command#`, `#phel.repl.command#`) overrides it. Relative paths resolve against the workspace folder; absolute paths are used as-is."
                 },
                 "phel.diagnostics.enabled": {
                     "type": "boolean",
@@ -369,7 +374,7 @@
                 "phel.diagnostics.command": {
                     "type": "string",
                     "default": "",
-                    "description": "Override `phel.executablePath` for diagnostics only. Empty string falls back to `phel.executablePath`. Relative paths resolve against the workspace folder."
+                    "markdownDescription": "Override `#phel.executablePath#` for diagnostics only. Empty string falls back to `#phel.executablePath#`. Relative paths resolve against the workspace folder."
                 },
                 "phel.format.enabled": {
                     "type": "boolean",
@@ -379,7 +384,7 @@
                 "phel.format.command": {
                     "type": "string",
                     "default": "",
-                    "description": "Override `phel.executablePath` for formatting only. Empty string falls back to `phel.executablePath`. Relative paths resolve against the workspace folder."
+                    "markdownDescription": "Override `#phel.executablePath#` for formatting only. Empty string falls back to `#phel.executablePath#`. Relative paths resolve against the workspace folder."
                 },
                 "phel.tests.codeLensEnabled": {
                     "type": "boolean",
@@ -389,7 +394,7 @@
                 "phel.test.command": {
                     "type": "string",
                     "default": "",
-                    "description": "Override `phel.executablePath` for the test CodeLens / Test Explorer. Empty string falls back to `phel.executablePath`. Relative paths resolve against the workspace folder."
+                    "markdownDescription": "Override `#phel.executablePath#` for the test CodeLens / Test Explorer. Empty string falls back to `#phel.executablePath#`. Relative paths resolve against the workspace folder."
                 },
                 "phel.paredit.enabled": {
                     "type": "boolean",
@@ -404,7 +409,7 @@
                 "phel.repl.command": {
                     "type": "string",
                     "default": "",
-                    "description": "Override `phel.executablePath` for the REPL terminal. Empty string falls back to `phel.executablePath`. Relative paths resolve against the workspace folder."
+                    "markdownDescription": "Override `#phel.executablePath#` for the REPL terminal. Empty string falls back to `#phel.executablePath#`. Relative paths resolve against the workspace folder."
                 },
                 "phel.repl.args": {
                     "type": "array",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { PHEL_DOCS } from './phelCoreDocs';
 import { lookupSymbol, renderDocMarkdown } from './phelDocsLookup';
 import { buildQuickPickEntries } from './phelShowDoc';
 import { registerDiagnostics } from './phelDiagnosticsProvider';
+import { resolvePhelExecutable } from './phelExecutable';
 import { PhelFormatProvider } from './phelFormatProvider';
 import { PhelTestCodeLensProvider } from './phelTestCodeLensProvider';
 import { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
@@ -318,9 +319,7 @@ function runPhelTests(uri?: vscode.Uri, testName?: string): void {
         return;
     }
     const folder = vscode.workspace.getWorkspaceFolder(target);
-    const command = vscode.workspace
-        .getConfiguration('phel')
-        .get<string>('test.command', 'vendor/bin/phel');
+    const command = resolvePhelExecutable('test.command', folder);
     const cwd = folder?.uri.fsPath ?? path.dirname(target.fsPath);
     const filePath = path.relative(cwd, target.fsPath) || target.fsPath;
     const args = ['test'];

--- a/src/phelDiagnosticsProvider.ts
+++ b/src/phelDiagnosticsProvider.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'node:child_process';
-import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { parsePhelAnalyzeOutput, toZeroBasedRange, PhelDiagnostic } from './phelDiagnostics';
+import { affectsPhelExecutable, resolvePhelExecutable } from './phelExecutable';
 
 const COLLECTION_NAME = 'phel';
 
@@ -11,8 +11,9 @@ const COLLECTION_NAME = 'phel';
  *
  * Configuration:
  *   - `phel.diagnostics.enabled` (default `true`)
- *   - `phel.diagnostics.command` (default `vendor/bin/phel`, resolved
- *     relative to the workspace folder when not absolute)
+ *   - `phel.diagnostics.command` (overrides `phel.executablePath`; default
+ *     `vendor/bin/phel`, resolved relative to the workspace folder when
+ *     not absolute)
  */
 export function registerDiagnostics(context: vscode.ExtensionContext): void {
     const collection = vscode.languages.createDiagnosticCollection(COLLECTION_NAME);
@@ -45,10 +46,7 @@ export function registerDiagnostics(context: vscode.ExtensionContext): void {
         vscode.workspace.onDidSaveTextDocument(runForDocument),
         vscode.workspace.onDidCloseTextDocument((doc) => collection.delete(doc.uri)),
         vscode.workspace.onDidChangeConfiguration((e) => {
-            if (
-                e.affectsConfiguration('phel.diagnostics.enabled') ||
-                e.affectsConfiguration('phel.diagnostics.command')
-            ) {
+            if (e.affectsConfiguration('phel.diagnostics.enabled') || affectsPhelExecutable(e)) {
                 collection.clear();
                 vscode.workspace.textDocuments.forEach(runForDocument);
             }
@@ -62,18 +60,9 @@ function isEnabled(): boolean {
     return vscode.workspace.getConfiguration('phel').get<boolean>('diagnostics.enabled', true);
 }
 
-function resolveCommand(fileUri: vscode.Uri): string | null {
-    const config = vscode.workspace
-        .getConfiguration('phel')
-        .get<string>('diagnostics.command', 'vendor/bin/phel');
-    if (!config) {
-        return null;
-    }
-    if (path.isAbsolute(config)) {
-        return config;
-    }
+function resolveCommand(fileUri: vscode.Uri): string {
     const folder = vscode.workspace.getWorkspaceFolder(fileUri);
-    return folder ? path.join(folder.uri.fsPath, config) : config;
+    return resolvePhelExecutable('diagnostics.command', folder);
 }
 
 function analyzeFile(command: string, filePath: string): Promise<PhelDiagnostic[]> {

--- a/src/phelDiagnosticsProvider.ts
+++ b/src/phelDiagnosticsProvider.ts
@@ -27,10 +27,8 @@ export function registerDiagnostics(context: vscode.ExtensionContext): void {
             collection.delete(document.uri);
             return;
         }
-        const command = resolveCommand(document.uri);
-        if (!command) {
-            return;
-        }
+        const folder = vscode.workspace.getWorkspaceFolder(document.uri);
+        const command = resolvePhelExecutable('diagnostics.command', folder);
         analyzeFile(command, document.uri.fsPath)
             .then((diagnostics) => {
                 collection.set(document.uri, toVscodeDiagnostics(diagnostics));
@@ -58,11 +56,6 @@ export function registerDiagnostics(context: vscode.ExtensionContext): void {
 
 function isEnabled(): boolean {
     return vscode.workspace.getConfiguration('phel').get<boolean>('diagnostics.enabled', true);
-}
-
-function resolveCommand(fileUri: vscode.Uri): string {
-    const folder = vscode.workspace.getWorkspaceFolder(fileUri);
-    return resolvePhelExecutable('diagnostics.command', folder);
 }
 
 function analyzeFile(command: string, filePath: string): Promise<PhelDiagnostic[]> {

--- a/src/phelExecutable.ts
+++ b/src/phelExecutable.ts
@@ -1,0 +1,44 @@
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+
+const DEFAULT_EXECUTABLE = 'vendor/bin/phel';
+
+export const PHEL_EXECUTABLE_SETTINGS = [
+    'phel.executablePath',
+    'phel.diagnostics.command',
+    'phel.format.command',
+    'phel.test.command',
+    'phel.repl.command',
+] as const;
+
+/**
+ * Resolves the Phel CLI path for a given subsystem.
+ *
+ * Precedence: per-command override (`phel.<key>`) → workspace fallback
+ * (`phel.executablePath`) → built-in default (`vendor/bin/phel`).
+ * Relative paths resolve against `cwd`.
+ */
+export function resolvePhelExecutable(
+    perCommandKey: string,
+    folder: vscode.WorkspaceFolder | undefined
+): string {
+    const config = vscode.workspace.getConfiguration('phel', folder);
+    const explicit = explicitString(config, perCommandKey);
+    const fallback = explicitString(config, 'executablePath') ?? DEFAULT_EXECUTABLE;
+    const cmd = explicit ?? fallback;
+    const cwd = folder?.uri.fsPath ?? process.cwd();
+    return path.isAbsolute(cmd) ? cmd : path.join(cwd, cmd);
+}
+
+function explicitString(config: vscode.WorkspaceConfiguration, key: string): string | undefined {
+    const inspected = config.inspect<string>(key);
+    const value =
+        inspected?.workspaceFolderValue ??
+        inspected?.workspaceValue ??
+        inspected?.globalValue;
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+export function affectsPhelExecutable(e: vscode.ConfigurationChangeEvent): boolean {
+    return PHEL_EXECUTABLE_SETTINGS.some((key) => e.affectsConfiguration(key));
+}

--- a/src/phelExecutable.ts
+++ b/src/phelExecutable.ts
@@ -33,9 +33,7 @@ export function resolvePhelExecutable(
 function explicitString(config: vscode.WorkspaceConfiguration, key: string): string | undefined {
     const inspected = config.inspect<string>(key);
     const value =
-        inspected?.workspaceFolderValue ??
-        inspected?.workspaceValue ??
-        inspected?.globalValue;
+        inspected?.workspaceFolderValue ?? inspected?.workspaceValue ?? inspected?.globalValue;
     return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 

--- a/src/phelExecutable.ts
+++ b/src/phelExecutable.ts
@@ -1,33 +1,43 @@
-import * as path from 'node:path';
 import * as vscode from 'vscode';
+import { resolveExecutablePath } from './phelExecutablePath';
 
-const DEFAULT_EXECUTABLE = 'vendor/bin/phel';
+const FALLBACK_KEY = 'executablePath';
 
-export const PHEL_EXECUTABLE_SETTINGS = [
-    'phel.executablePath',
-    'phel.diagnostics.command',
-    'phel.format.command',
-    'phel.test.command',
-    'phel.repl.command',
-] as const;
+export type PhelExecutableSubsystem =
+    | 'diagnostics.command'
+    | 'format.command'
+    | 'test.command'
+    | 'repl.command';
+
+const SUBSYSTEM_KEYS: readonly PhelExecutableSubsystem[] = [
+    'diagnostics.command',
+    'format.command',
+    'test.command',
+    'repl.command',
+];
+
+export const PHEL_EXECUTABLE_SETTINGS: readonly string[] = [
+    `phel.${FALLBACK_KEY}`,
+    ...SUBSYSTEM_KEYS.map((k) => `phel.${k}`),
+];
 
 /**
  * Resolves the Phel CLI path for a given subsystem.
  *
- * Precedence: per-command override (`phel.<key>`) → workspace fallback
+ * Precedence: per-command override (`phel.<subsystem>`) → workspace fallback
  * (`phel.executablePath`) → built-in default (`vendor/bin/phel`).
- * Relative paths resolve against `cwd`.
  */
 export function resolvePhelExecutable(
-    perCommandKey: string,
+    subsystem: PhelExecutableSubsystem,
     folder: vscode.WorkspaceFolder | undefined
 ): string {
     const config = vscode.workspace.getConfiguration('phel', folder);
-    const explicit = explicitString(config, perCommandKey);
-    const fallback = explicitString(config, 'executablePath') ?? DEFAULT_EXECUTABLE;
-    const cmd = explicit ?? fallback;
     const cwd = folder?.uri.fsPath ?? process.cwd();
-    return path.isAbsolute(cmd) ? cmd : path.join(cwd, cmd);
+    return resolveExecutablePath(
+        explicitString(config, subsystem),
+        explicitString(config, FALLBACK_KEY),
+        cwd
+    );
 }
 
 function explicitString(config: vscode.WorkspaceConfiguration, key: string): string | undefined {

--- a/src/phelExecutablePath.ts
+++ b/src/phelExecutablePath.ts
@@ -1,0 +1,20 @@
+// Pure path-resolution helper. Kept free of `vscode` imports so unit tests
+// can exercise it directly. The vscode-aware glue lives in
+// `phelExecutable.ts`.
+
+import * as path from 'node:path';
+
+export const DEFAULT_PHEL_EXECUTABLE = 'vendor/bin/phel';
+
+/**
+ * Picks the explicit override, then the fallback, then the built-in
+ * default. Relative paths are anchored to `cwd`.
+ */
+export function resolveExecutablePath(
+    explicit: string | undefined,
+    fallback: string | undefined,
+    cwd: string
+): string {
+    const cmd = explicit ?? fallback ?? DEFAULT_PHEL_EXECUTABLE;
+    return path.isAbsolute(cmd) ? cmd : path.join(cwd, cmd);
+}

--- a/src/phelFormatProvider.ts
+++ b/src/phelFormatProvider.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { buildFormatEdits } from './phelFormat';
+import { resolvePhelExecutable } from './phelExecutable';
 
 export class PhelFormatProvider implements vscode.DocumentFormattingEditProvider {
     async provideDocumentFormattingEdits(
@@ -47,18 +48,9 @@ function isEnabled(): boolean {
     return vscode.workspace.getConfiguration('phel').get<boolean>('format.enabled', true);
 }
 
-function resolveCommand(fileUri: vscode.Uri): string | null {
-    const config = vscode.workspace
-        .getConfiguration('phel')
-        .get<string>('format.command', 'vendor/bin/phel');
-    if (!config) {
-        return null;
-    }
-    if (path.isAbsolute(config)) {
-        return config;
-    }
+function resolveCommand(fileUri: vscode.Uri): string {
     const folder = vscode.workspace.getWorkspaceFolder(fileUri);
-    return folder ? path.join(folder.uri.fsPath, config) : config;
+    return resolvePhelExecutable('format.command', folder);
 }
 
 /**

--- a/src/phelFormatProvider.ts
+++ b/src/phelFormatProvider.ts
@@ -15,10 +15,8 @@ export class PhelFormatProvider implements vscode.DocumentFormattingEditProvider
         if (!isEnabled()) {
             return [];
         }
-        const command = resolveCommand(document.uri);
-        if (!command) {
-            return [];
-        }
+        const folder = vscode.workspace.getWorkspaceFolder(document.uri);
+        const command = resolvePhelExecutable('format.command', folder);
 
         const original = document.getText();
         try {
@@ -46,11 +44,6 @@ export class PhelFormatProvider implements vscode.DocumentFormattingEditProvider
 
 function isEnabled(): boolean {
     return vscode.workspace.getConfiguration('phel').get<boolean>('format.enabled', true);
-}
-
-function resolveCommand(fileUri: vscode.Uri): string {
-    const folder = vscode.workspace.getWorkspaceFolder(fileUri);
-    return resolvePhelExecutable('format.command', folder);
 }
 
 /**

--- a/src/phelReplProvider.ts
+++ b/src/phelReplProvider.ts
@@ -12,8 +12,8 @@
 // in the corresponding workspace folder when `phel.repl.history.enabled` is
 // true (the default).
 
-import * as path from 'node:path';
 import * as vscode from 'vscode';
+import { resolvePhelExecutable } from './phelExecutable';
 import { parseNsForm } from './phelNsAnalyzer';
 import { flattenForTerminal, nextTopLevelFormAfter, topLevelFormAt } from './phelRepl';
 
@@ -36,10 +36,9 @@ function workspaceFolderForDoc(doc?: vscode.TextDocument): vscode.WorkspaceFolde
 
 function resolveCommand(folder: vscode.WorkspaceFolder | undefined): ReplCommandConfig {
     const config = vscode.workspace.getConfiguration('phel', folder);
-    const cmd = config.get<string>('repl.command', 'vendor/bin/phel');
     const args = config.get<string[]>('repl.args', ['repl']);
     const cwd = folder?.uri.fsPath ?? process.cwd();
-    const absolute = path.isAbsolute(cmd) ? cmd : path.join(cwd, cmd);
+    const absolute = resolvePhelExecutable('repl.command', folder);
     return { command: absolute, args, cwd };
 }
 

--- a/src/phelTestController.ts
+++ b/src/phelTestController.ts
@@ -10,6 +10,7 @@ import { spawn } from 'node:child_process';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 import * as vscode from 'vscode';
+import { resolvePhelExecutable } from './phelExecutable';
 import { findDeftests } from './phelTestScanner';
 
 interface ResolvedCommand {
@@ -19,11 +20,11 @@ interface ResolvedCommand {
 }
 
 function resolveTestCommand(folder: vscode.WorkspaceFolder): ResolvedCommand {
-    const config = vscode.workspace.getConfiguration('phel', folder);
-    const cmd = config.get<string>('test.command', 'vendor/bin/phel');
-    const cwd = folder.uri.fsPath;
-    const command = path.isAbsolute(cmd) ? cmd : path.join(cwd, cmd);
-    return { command, args: ['test'], cwd };
+    return {
+        command: resolvePhelExecutable('test.command', folder),
+        args: ['test'],
+        cwd: folder.uri.fsPath,
+    };
 }
 
 async function readFile(uri: vscode.Uri): Promise<string | null> {

--- a/src/test/phelExecutablePath.test.ts
+++ b/src/test/phelExecutablePath.test.ts
@@ -1,0 +1,33 @@
+import * as assert from 'node:assert/strict';
+import * as path from 'node:path';
+import { resolveExecutablePath } from '../phelExecutablePath';
+
+describe('phelExecutablePath.resolveExecutablePath', () => {
+    const cwd = path.resolve('/ws');
+
+    it('uses explicit override when set', () => {
+        const out = resolveExecutablePath('bin/phel', 'fallback/phel', cwd);
+        assert.equal(out, path.join(cwd, 'bin/phel'));
+    });
+
+    it('falls back to workspace executablePath when override is missing', () => {
+        const out = resolveExecutablePath(undefined, 'tools/phel', cwd);
+        assert.equal(out, path.join(cwd, 'tools/phel'));
+    });
+
+    it('uses built-in default when nothing is set', () => {
+        const out = resolveExecutablePath(undefined, undefined, cwd);
+        assert.equal(out, path.join(cwd, 'vendor/bin/phel'));
+    });
+
+    it('returns absolute paths unchanged', () => {
+        const abs = path.resolve('/usr/local/bin/phel');
+        assert.equal(resolveExecutablePath(abs, undefined, cwd), abs);
+        assert.equal(resolveExecutablePath(undefined, abs, cwd), abs);
+    });
+
+    it('joins relative paths against the given cwd', () => {
+        const out = resolveExecutablePath('bin/phel', undefined, path.resolve('/elsewhere'));
+        assert.equal(out, path.join(path.resolve('/elsewhere'), 'bin/phel'));
+    });
+});


### PR DESCRIPTION
## Summary

- One workspace-wide setting for the Phel CLI path: `phel.executablePath` (default `vendor/bin/phel`). Used by diagnostics, format, test, and REPL.
- Existing per-subsystem settings (`phel.diagnostics.command`, `phel.format.command`, `phel.test.command`, `phel.repl.command`) still override when set, but their defaults are now empty strings that fall back to `phel.executablePath`.
- New `src/phelExecutable.ts` centralises the resolution logic (per-key override → workspace fallback → built-in default; absolute paths used as-is, relative paths resolve against the workspace folder).

## Why

Users with non-Composer layouts (`bin/phel`, `/usr/local/bin/phel`, …) had to set 4 identical settings. Now: set one.

## Backwards compatibility

A user who had no override before kept the built-in `vendor/bin/phel`. A user who had an explicit override kept theirs. Same for both after this change.

## Docs

- `docs/settings.md` rewritten with a Phel CLI location section, resolution order, per-subsystem override examples.
- README gets a small Configuration section pointing at `phel.executablePath`.
- CHANGELOG `[Unreleased]` updated.

## Test plan

- [x] `npm run compile`
- [x] `npm run lint`
- [x] `npm test` (275 passing)
- [x] `npm run bundle:prod`
- [ ] Manual: set `phel.executablePath` to `bin/phel` in a workspace and confirm format / diagnostics / test / REPL all use it