### PR TITLE
feat(lsp): delegate language intelligence to the phel lsp server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Language server
+
+- Delegate language intelligence to the Phel language server (`phel lsp`) when available (the default). Completion, hover, signature help, go-to-definition, find references, rename, document/workspace symbols, formatting, and diagnostics now come from the Phel compiler itself — adding PHP-interop intelligence (`php/->`, `php/::`, `php/new`) and semantically scoped rename/references that the bundled providers could not offer. New settings: `phel.lsp.enabled` (default `true`), `phel.lsp.command`, `phel.lsp.args`. When the server is disabled or the installed Phel is too old to provide `phel lsp`, the extension falls back to its bundled TypeScript providers.
+
 ### Language support
 
 - Completion, hover, and signature help for the REPL workflow fns (`reload!`, `reload-all!`, `run-test`, `run-tests`), new core helpers (`clamp-int`, `defs->map`), and `phel.json` / `phel.string` / `phel.transit` / `phel.ai` additions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
             "license": "MIT",
             "dependencies": {
                 "@vscode/debugadapter": "^1.64.0",
-                "@vscode/debugprotocol": "^1.64.0"
+                "@vscode/debugprotocol": "^1.64.0",
+                "vscode-languageclient": "^8.1.0"
             },
             "devDependencies": {
                 "@types/mocha": "^10.0.6",
@@ -1996,7 +1997,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/base64-js": {
@@ -2068,7 +2068,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
             "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -5335,7 +5334,6 @@
             "version": "7.7.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -6096,6 +6094,57 @@
             "funding": {
                 "url": "https://bevry.me/fund"
             }
+        },
+        "node_modules/vscode-jsonrpc": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+            "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/vscode-languageclient": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
+            "integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
+            "license": "MIT",
+            "dependencies": {
+                "minimatch": "^5.1.0",
+                "semver": "^7.3.7",
+                "vscode-languageserver-protocol": "3.17.3"
+            },
+            "engines": {
+                "vscode": "^1.67.0"
+            }
+        },
+        "node_modules/vscode-languageclient/node_modules/minimatch": {
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/vscode-languageserver-protocol": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+            "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode-jsonrpc": "8.1.0",
+                "vscode-languageserver-types": "3.17.3"
+            }
+        },
+        "node_modules/vscode-languageserver-types": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+            "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==",
+            "license": "MIT"
         },
         "node_modules/vscode-oniguruma": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -346,6 +346,26 @@
         "configuration": {
             "title": "Phel",
             "properties": {
+                "phel.lsp.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Use the Phel language server (`phel lsp`) for completion, hover, signature help, go-to-definition, find references, rename, symbols, formatting, and diagnostics. The server is backed by the Phel compiler and understands PHP interop (`php/->`, `php/::`, `php/new`). When disabled (or when the installed Phel is too old to provide `phel lsp`), the extension falls back to its bundled providers. Requires a reload to take effect."
+                },
+                "phel.lsp.command": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "Override `#phel.executablePath#` for the language server only. Empty string falls back to `#phel.executablePath#`. Relative paths resolve against the workspace folder."
+                },
+                "phel.lsp.args": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "lsp"
+                    ],
+                    "description": "Arguments passed to the Phel CLI when starting the language server."
+                },
                 "phel.cacheDirectory": {
                     "type": "string",
                     "default": "",
@@ -364,7 +384,7 @@
                         "bin/phel",
                         "/usr/local/bin/phel"
                     ],
-                    "markdownDescription": "Workspace-wide path to the Phel CLI. Used by diagnostics, format, test, and REPL unless a per-command setting (`#phel.diagnostics.command#`, `#phel.format.command#`, `#phel.test.command#`, `#phel.repl.command#`) overrides it. Relative paths resolve against the workspace folder; absolute paths are used as-is."
+                    "markdownDescription": "Workspace-wide path to the Phel CLI. Used by the language server, diagnostics, format, test, and REPL unless a per-command setting (`#phel.lsp.command#`, `#phel.diagnostics.command#`, `#phel.format.command#`, `#phel.test.command#`, `#phel.repl.command#`) overrides it. Relative paths resolve against the workspace folder; absolute paths are used as-is."
                 },
                 "phel.diagnostics.enabled": {
                     "type": "boolean",
@@ -472,7 +492,8 @@
     },
     "dependencies": {
         "@vscode/debugadapter": "^1.64.0",
-        "@vscode/debugprotocol": "^1.64.0"
+        "@vscode/debugprotocol": "^1.64.0",
+        "vscode-languageclient": "^8.1.0"
     },
     "overrides": {
         "serialize-javascript": "^7.0.5",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,11 @@ import { PhelFormHighlight } from './phelFormHighlight';
 import { PhelInlineValuesProvider } from './phelInlineValuesProvider';
 import { PhelStatusBar } from './phelStatusBar';
 import { PhelTestController } from './phelTestController';
+import {
+    isLanguageServerEnabled,
+    startLanguageClient,
+    stopLanguageClient,
+} from './phelLanguageClient';
 
 let sourceMapManager: SourceMapManager;
 
@@ -134,6 +139,97 @@ export function activate(context: vscode.ExtensionContext) {
         sourceMapManager.addCacheDirectory(cacheDir);
     }
 
+    // Language intelligence (completion / hover / signature help / definition /
+    // references / rename / symbols / diagnostics / formatting) is provided
+    // either by the Phel language server (`phel lsp`, the default) or by the
+    // bundled TypeScript providers as a fallback. We never run both, to avoid
+    // duplicate completions and conflicting results.
+    if (isLanguageServerEnabled()) {
+        void startLanguageClient(context).then((started) => {
+            if (!started) {
+                console.warn(
+                    'Phel language server could not start; using bundled language providers.'
+                );
+                registerLanguageProviders(context);
+            }
+        });
+    } else {
+        registerLanguageProviders(context);
+    }
+
+    context.subscriptions.push(
+        vscode.languages.registerCodeLensProvider('phel', new PhelTestCodeLensProvider())
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('phel.runTest', (uri?: vscode.Uri, testName?: string) => {
+            runPhelTests(uri, testName);
+        }),
+        vscode.commands.registerCommand('phel.runTestsInFile', (uri?: vscode.Uri) => {
+            runPhelTests(uri);
+        })
+    );
+
+    if (vscode.workspace.getConfiguration('phel').get<boolean>('paredit.enabled', true)) {
+        registerPareditCommands(context);
+    }
+
+    if (vscode.workspace.getConfiguration('phel').get<boolean>('repl.enabled', true)) {
+        registerReplCommands(context);
+    }
+
+    registerSelectionCommands(context);
+
+    void new PhelStatusBar().start(context);
+
+    context.subscriptions.push(new PhelTestController());
+    context.subscriptions.push(new PhelFormHighlight());
+
+    context.subscriptions.push(
+        vscode.languages.registerInlineValuesProvider('phel', new PhelInlineValuesProvider())
+    );
+
+    // Provide hover information for breakpoints
+    context.subscriptions.push(
+        vscode.languages.registerHoverProvider('phel', {
+            provideHover(document, position, _token) {
+                // Check if there's a breakpoint on this line
+                const breakpoints = vscode.debug.breakpoints.filter(
+                    (bp) =>
+                        bp instanceof vscode.SourceBreakpoint &&
+                        bp.location.uri.fsPath === document.fileName &&
+                        bp.location.range.start.line === position.line
+                );
+
+                if (breakpoints.length > 0) {
+                    const line = position.line + 1;
+                    const translation = sourceMapManager.translateToPhp(document.fileName, line);
+
+                    if (translation) {
+                        return new vscode.Hover(
+                            new vscode.MarkdownString(
+                                `**Phel Breakpoint**\n\nMaps to: \`${path.basename(translation.file)}:${translation.line}\``
+                            )
+                        );
+                    }
+                }
+
+                return null;
+            },
+        })
+    );
+}
+
+export function deactivate(): Thenable<void> | undefined {
+    return stopLanguageClient();
+}
+
+/**
+ * Register the bundled TypeScript language-feature providers. Used only when
+ * the Phel language server is disabled or fails to start; otherwise `phel lsp`
+ * serves these features (with PHP-interop intelligence the TS providers lack).
+ */
+function registerLanguageProviders(context: vscode.ExtensionContext): void {
     const workspaceIndexer = new PhelWorkspaceIndexer();
     context.subscriptions.push(workspaceIndexer);
     void workspaceIndexer.start();
@@ -207,72 +303,6 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.languages.registerDocumentFormattingEditProvider('phel', new PhelFormatProvider())
     );
-
-    context.subscriptions.push(
-        vscode.languages.registerCodeLensProvider('phel', new PhelTestCodeLensProvider())
-    );
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand('phel.runTest', (uri?: vscode.Uri, testName?: string) => {
-            runPhelTests(uri, testName);
-        }),
-        vscode.commands.registerCommand('phel.runTestsInFile', (uri?: vscode.Uri) => {
-            runPhelTests(uri);
-        })
-    );
-
-    if (vscode.workspace.getConfiguration('phel').get<boolean>('paredit.enabled', true)) {
-        registerPareditCommands(context);
-    }
-
-    if (vscode.workspace.getConfiguration('phel').get<boolean>('repl.enabled', true)) {
-        registerReplCommands(context);
-    }
-
-    registerSelectionCommands(context);
-
-    void new PhelStatusBar().start(context);
-
-    context.subscriptions.push(new PhelTestController());
-    context.subscriptions.push(new PhelFormHighlight());
-
-    context.subscriptions.push(
-        vscode.languages.registerInlineValuesProvider('phel', new PhelInlineValuesProvider())
-    );
-
-    // Provide hover information for breakpoints
-    context.subscriptions.push(
-        vscode.languages.registerHoverProvider('phel', {
-            provideHover(document, position, _token) {
-                // Check if there's a breakpoint on this line
-                const breakpoints = vscode.debug.breakpoints.filter(
-                    (bp) =>
-                        bp instanceof vscode.SourceBreakpoint &&
-                        bp.location.uri.fsPath === document.fileName &&
-                        bp.location.range.start.line === position.line
-                );
-
-                if (breakpoints.length > 0) {
-                    const line = position.line + 1;
-                    const translation = sourceMapManager.translateToPhp(document.fileName, line);
-
-                    if (translation) {
-                        return new vscode.Hover(
-                            new vscode.MarkdownString(
-                                `**Phel Breakpoint**\n\nMaps to: \`${path.basename(translation.file)}:${translation.line}\``
-                            )
-                        );
-                    }
-                }
-
-                return null;
-            },
-        })
-    );
-}
-
-export function deactivate() {
-    // Cleanup
 }
 
 /**

--- a/src/phelExecutable.ts
+++ b/src/phelExecutable.ts
@@ -7,13 +7,15 @@ export type PhelExecutableSubsystem =
     | 'diagnostics.command'
     | 'format.command'
     | 'test.command'
-    | 'repl.command';
+    | 'repl.command'
+    | 'lsp.command';
 
 const SUBSYSTEM_KEYS: readonly PhelExecutableSubsystem[] = [
     'diagnostics.command',
     'format.command',
     'test.command',
     'repl.command',
+    'lsp.command',
 ];
 
 export const PHEL_EXECUTABLE_SETTINGS: readonly string[] = [

--- a/src/phelLanguageClient.ts
+++ b/src/phelLanguageClient.ts
@@ -1,0 +1,138 @@
+// Language Server Protocol client.
+//
+// phel-lang ships a full LSP v3.17 server (`phel lsp`, stdio, JSON-RPC 2.0
+// with Content-Length framing) backed by the same semantic analyzer the
+// compiler uses. When enabled (the default), we spawn it and delegate
+// completion, hover, signature help, go-to-definition, find-references,
+// rename, document/workspace symbols, formatting, and diagnostics to it —
+// gaining PHP-interop intelligence (reflection over `php/->`, `php/::`,
+// `php/new`) and semantically scoped rename/references that the bundled
+// TypeScript providers cannot match.
+//
+// The client probes whether `phel lsp` is runnable; if the installed Phel is
+// too old to know the command (or the spawn fails), it reports failure so the
+// caller can fall back to the in-TypeScript providers.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import {
+    LanguageClient,
+    type LanguageClientOptions,
+    type ServerOptions,
+    State,
+    TransportKind,
+} from 'vscode-languageclient/node';
+import { resolvePhelExecutable } from './phelExecutable';
+
+const OUTPUT_CHANNEL_NAME = 'Phel Language Server';
+
+let client: LanguageClient | undefined;
+let outputChannel: vscode.OutputChannel | undefined;
+
+export function isLanguageServerEnabled(): boolean {
+    return vscode.workspace.getConfiguration('phel').get<boolean>('lsp.enabled', true);
+}
+
+export function isLanguageServerRunning(): boolean {
+    return client !== undefined && client.state === State.Running;
+}
+
+/**
+ * Resolve the command + args used to launch the language server. The command
+ * follows the same precedence as every other Phel subsystem
+ * (`phel.lsp.command` → `phel.executablePath` → `vendor/bin/phel`); extra
+ * server args come from `phel.lsp.args` (default `["lsp"]`).
+ */
+function resolveServerCommand(folder: vscode.WorkspaceFolder | undefined): {
+    command: string;
+    args: string[];
+} {
+    const config = vscode.workspace.getConfiguration('phel', folder);
+    const override = config.get<string>('lsp.command', '');
+    let command: string;
+    if (override && override.length > 0) {
+        command = path.isAbsolute(override)
+            ? override
+            : path.resolve(folder?.uri.fsPath ?? process.cwd(), override);
+    } else {
+        command = resolvePhelExecutable('lsp.command', folder);
+    }
+    const args = config.get<string[]>('lsp.args', ['lsp']);
+    return { command, args: [...args] };
+}
+
+/**
+ * Start the language client. Returns true when the server was launched and
+ * reached the running state, false when it could not be started (so the
+ * caller can fall back to the bundled providers).
+ */
+export async function startLanguageClient(context: vscode.ExtensionContext): Promise<boolean> {
+    if (client) {
+        return isLanguageServerRunning();
+    }
+
+    const folder = vscode.workspace.workspaceFolders?.[0];
+    const { command, args } = resolveServerCommand(folder);
+
+    // A relative path that doesn't resolve to a real file means Phel isn't
+    // installed where we expect; bail quietly so the TS providers take over.
+    if (path.isAbsolute(command) && !fs.existsSync(command)) {
+        log(`Phel executable not found at ${command}; language server disabled.`);
+        return false;
+    }
+
+    outputChannel ??= vscode.window.createOutputChannel(OUTPUT_CHANNEL_NAME);
+
+    const serverOptions: ServerOptions = {
+        run: { command, args, transport: TransportKind.stdio },
+        debug: { command, args, transport: TransportKind.stdio },
+    };
+
+    const clientOptions: LanguageClientOptions = {
+        documentSelector: [{ scheme: 'file', language: 'phel' }],
+        synchronize: {
+            fileEvents: vscode.workspace.createFileSystemWatcher('**/*.phel'),
+        },
+        outputChannel,
+        // Phel diagnostics already flow through the server's publishDiagnostics;
+        // don't also reveal the output on every error.
+        revealOutputChannelOn: 4, // RevealOutputChannelOn.Never
+    };
+
+    client = new LanguageClient('phel', 'Phel Language Server', serverOptions, clientOptions);
+
+    try {
+        await client.start();
+        context.subscriptions.push(client);
+        log(`Phel language server started (${command} ${args.join(' ')}).`);
+        return true;
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log(`Phel language server failed to start: ${message}`);
+        try {
+            await client.dispose();
+        } catch {
+            // ignore dispose errors on a server that never came up
+        }
+        client = undefined;
+        return false;
+    }
+}
+
+export async function stopLanguageClient(): Promise<void> {
+    if (!client) {
+        return;
+    }
+    const current = client;
+    client = undefined;
+    try {
+        await current.stop();
+    } catch {
+        // ignore: the server may already be gone
+    }
+}
+
+function log(message: string): void {
+    outputChannel?.appendLine(message);
+}


### PR DESCRIPTION
## What

phel-lang ships a full **LSP v3.17 server** (`phel lsp`, stdio, JSON-RPC 2.0 with `Content-Length` framing) backed by the same semantic analyzer the compiler uses. This PR adds a `vscode-languageclient` that spawns it and delegates language intelligence to it:

- completion, hover, signature help
- go-to-definition, find references, rename
- document & workspace symbols
- formatting
- diagnostics (push, debounced server-side)

## Why

The extension currently re-implements all of this in ~2,800 lines of TypeScript over a generated 600 KB symbol corpus. The server gives us things the TS reimplementation structurally cannot:

- **PHP-interop intelligence** — reflection-driven completion/hover/signature help for `(php/-> …)`, `(php/:: …)`, `(php/new …)`.
- **Semantically scoped** rename & references (won't clobber a shadowed local that shares a name with a global).
- **Go-to-definition into phel-core**, not just a GitHub URL.
- A single source of truth that tracks the compiler — no more regenerating the corpus every release.

## How it's wired

- New module `src/phelLanguageClient.ts` resolves the server command with the same precedence as every other subsystem (`phel.lsp.command` → `phel.executablePath` → `vendor/bin/phel`), spawns `phel lsp`, and reports whether it reached the running state.
- `extension.ts` runs **either** the server **or** the bundled providers — never both. When `phel.lsp.enabled` is `false`, or when startup fails (e.g. an older Phel that doesn't know `phel lsp`), it falls back to the bundled TypeScript providers via the new `registerLanguageProviders()` helper.
- This is a **hybrid**: the debug adapter, paredit, REPL, selection, Test Explorer/CodeLens, inline values, and form highlight are untouched.

## New settings

| Setting | Default | Purpose |
|---|---|---|
| `phel.lsp.enabled` | `true` | Use `phel lsp` for language intelligence (reload to apply). |
| `phel.lsp.command` | `""` | Override `phel.executablePath` for the server only. |
| `phel.lsp.args` | `["lsp"]` | Args passed to the Phel CLI to start the server. |

## Dependency

Adds `vscode-languageclient@^8.1.0` (compatible with the current `engines.vscode ^1.75.0`; v9 would require ^1.82). It bundles cleanly via esbuild (pulls in only `vscode-languageserver-protocol`). No new audit findings are introduced by it.

## Verification

- `tsc --noEmit` clean, `eslint` clean, all **280** existing tests pass.
- Production esbuild bundle succeeds; `vscode-languageclient/node` is fully bundled (no leftover external require).
- The bundled-provider fallback path is preserved verbatim, so behavior is unchanged when the server is disabled/absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)