### PR TITLE
feat(nrepl): connect to phel nrepl for structured eval and live test runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### REPL & runtime
+
+- Add an nREPL client that connects to a `phel nrepl` server (bencode-over-TCP, started automatically on a random free port). Commands: connect / disconnect, structured eval of the form under the cursor or the selection, load file, reload changed namespaces (`phel.nrepl.reload`) or all (`phel.nrepl.reloadAll`), run a namespace's tests (`phel.nrepl.runTestsInNs`), and run the `deftest` under the cursor (`phel.nrepl.runTestUnderCursor`). Results — values, captured stdout, and errors — are shown in a dedicated "Phel nREPL" output channel. New settings: `phel.nrepl.enabled` (default `true`) and `phel.nrepl.reloadOnSave` (default `false`).
+
 ### Language server
 
 - Delegate language intelligence to the Phel language server (`phel lsp`) when available (the default). Completion, hover, signature help, go-to-definition, find references, rename, document/workspace symbols, formatting, and diagnostics now come from the Phel compiler itself — adding PHP-interop intelligence (`php/->`, `php/::`, `php/new`) and semantically scoped rename/references that the bundled providers could not offer. New settings: `phel.lsp.enabled` (default `true`), `phel.lsp.command`, `phel.lsp.args`. When the server is disabled or the installed Phel is too old to provide `phel lsp`, the extension falls back to its bundled TypeScript providers.

--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ VS Code support for [Phel](https://phel-lang.org/), a functional Lisp that compi
 ## Features
 
 - **Highlighting** for forms, macros, reader macros, tagged literals, and reader conditionals.
-- **Completion, hover, signature help** for every public `phel.core` symbol and workspace `defn`/`defmacro`/`def`. Cross-namespace accepts auto-add the `:require`.
+- **Language server** (`phel lsp`, on by default): completion, hover, signature help, go-to-definition, find references, rename, symbols, formatting, and diagnostics straight from the Phel compiler — including PHP-interop intelligence for `php/->`, `php/::`, and `php/new`. Falls back to bundled providers when disabled or unavailable.
 - **Go to / Find / Rename** (`F12`, `shift+F12`, `F2`, `cmd+T`).
-- **Diagnostics** on save (`phel analyze`), **format** on save (`phel format`).
+- **Diagnostics** and **format** on save.
 - **REPL** in an integrated terminal with `(in-ns)` follow and history.
+- **nREPL client** (`phel nrepl`): structured eval results, reload changed namespaces, and run a namespace's tests or the test under the cursor against the live runtime.
 - **Test Explorer + CodeLens** for `deftest`.
 - **Paredit**: slurp / barf / raise / wrap, sexp selection.
 - **Native debug adapter** with breakpoints in `.phel` files.

--- a/package.json
+++ b/package.json
@@ -272,6 +272,51 @@
                 "category": "Phel"
             },
             {
+                "command": "phel.nrepl.connect",
+                "title": "Phel: Connect to nREPL Server",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.nrepl.disconnect",
+                "title": "Phel: Disconnect from nREPL Server",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.nrepl.eval",
+                "title": "Phel: nREPL Eval Form Under Cursor",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.nrepl.evalSelection",
+                "title": "Phel: nREPL Eval Selection",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.nrepl.loadFile",
+                "title": "Phel: nREPL Load File",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.nrepl.reload",
+                "title": "Phel: nREPL Reload Changed Namespaces",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.nrepl.reloadAll",
+                "title": "Phel: nREPL Reload All Namespaces",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.nrepl.runTestsInNs",
+                "title": "Phel: nREPL Run Tests in Namespace",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.nrepl.runTestUnderCursor",
+                "title": "Phel: nREPL Run Test Under Cursor",
+                "category": "Phel"
+            },
+            {
                 "command": "phel.selection.expand",
                 "title": "Phel: Expand Selection",
                 "category": "Phel"
@@ -445,6 +490,16 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Append every form sent to the REPL to `.vscode/phel-repl-history.phel` in the workspace."
+                },
+                "phel.nrepl.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Register Phel nREPL commands (connect, structured eval, reload, run tests in namespace / under cursor). The extension starts `phel nrepl` on a random free port and connects over the bencode-over-TCP protocol, giving structured eval results and live-runtime test runs."
+                },
+                "phel.nrepl.reloadOnSave": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "When an nREPL connection is active, reload changed namespaces automatically every time a `.phel` file is saved. Does not start a connection on its own."
                 },
                 "phel.formHighlight.enabled": {
                     "type": "boolean",

--- a/src/bencode.ts
+++ b/src/bencode.ts
@@ -1,0 +1,195 @@
+// Minimal bencode codec for the nREPL wire protocol.
+//
+// nREPL frames are bencoded dictionaries. We support the four bencode types:
+//   integers     i<n>e
+//   byte strings <len>:<bytes>
+//   lists        l<elem...>e
+//   dictionaries d<key><value>...e   (keys are byte strings, sorted on encode)
+//
+// Decoding is incremental: a TCP read may contain a partial frame or several
+// frames, so `decode` returns every complete value it can parse plus the
+// number of bytes consumed, leaving any trailing partial frame in the buffer.
+
+export type BencodeValue = number | string | BencodeValue[] | { [key: string]: BencodeValue };
+
+const COLON = 0x3a; // ':'
+const END = 0x65; // 'e'
+const INT = 0x69; // 'i'
+const LIST = 0x6c; // 'l'
+const DICT = 0x64; // 'd'
+const ZERO = 0x30; // '0'
+const NINE = 0x39; // '9'
+
+export function encode(value: BencodeValue): Buffer {
+    const parts: Buffer[] = [];
+    encodeInto(value, parts);
+    return Buffer.concat(parts);
+}
+
+function encodeInto(value: BencodeValue, out: Buffer[]): void {
+    if (typeof value === 'number') {
+        if (!Number.isInteger(value)) {
+            throw new Error(`bencode: cannot encode non-integer number ${value}`);
+        }
+        out.push(Buffer.from(`i${value}e`, 'utf-8'));
+        return;
+    }
+    if (typeof value === 'string') {
+        const buf = Buffer.from(value, 'utf-8');
+        out.push(Buffer.from(`${buf.length}:`, 'utf-8'), buf);
+        return;
+    }
+    if (Array.isArray(value)) {
+        out.push(Buffer.from('l', 'utf-8'));
+        for (const item of value) {
+            encodeInto(item, out);
+        }
+        out.push(Buffer.from('e', 'utf-8'));
+        return;
+    }
+    // dictionary — keys sorted lexicographically per the spec
+    out.push(Buffer.from('d', 'utf-8'));
+    for (const key of Object.keys(value).sort()) {
+        encodeInto(key, out);
+        encodeInto(value[key], out);
+    }
+    out.push(Buffer.from('e', 'utf-8'));
+}
+
+export interface DecodeResult {
+    /** Fully parsed top-level values. */
+    values: BencodeValue[];
+    /** Number of bytes consumed from the start of the buffer. */
+    consumed: number;
+}
+
+/**
+ * Decode as many complete bencode values from the front of `buf` as possible.
+ * Stops at the first incomplete value, returning the count of bytes consumed
+ * so the caller can keep the remainder for the next read.
+ */
+export function decode(buf: Buffer): DecodeResult {
+    const values: BencodeValue[] = [];
+    let offset = 0;
+    while (offset < buf.length) {
+        const parsed = parseValue(buf, offset);
+        if (parsed === null) {
+            break;
+        }
+        values.push(parsed.value);
+        offset = parsed.offset;
+    }
+    return { values, consumed: offset };
+}
+
+interface Parsed {
+    value: BencodeValue;
+    offset: number;
+}
+
+function parseValue(buf: Buffer, offset: number): Parsed | null {
+    if (offset >= buf.length) {
+        return null;
+    }
+    const tag = buf[offset];
+    if (tag === INT) {
+        return parseInt_(buf, offset);
+    }
+    if (tag === LIST) {
+        return parseList(buf, offset);
+    }
+    if (tag === DICT) {
+        return parseDict(buf, offset);
+    }
+    if (tag >= ZERO && tag <= NINE) {
+        return parseString(buf, offset);
+    }
+    throw new Error(`bencode: unexpected byte 0x${tag.toString(16)} at offset ${offset}`);
+}
+
+function parseInt_(buf: Buffer, offset: number): Parsed | null {
+    const end = buf.indexOf(END, offset + 1);
+    if (end === -1) {
+        return null;
+    }
+    const text = buf.toString('utf-8', offset + 1, end);
+    if (!/^-?\d+$/.test(text)) {
+        throw new Error(`bencode: invalid integer "${text}"`);
+    }
+    return { value: Number.parseInt(text, 10), offset: end + 1 };
+}
+
+function parseString(buf: Buffer, offset: number): Parsed | null {
+    const colon = buf.indexOf(COLON, offset);
+    if (colon === -1) {
+        return null;
+    }
+    const lenText = buf.toString('utf-8', offset, colon);
+    if (!/^\d+$/.test(lenText)) {
+        throw new Error(`bencode: invalid string length "${lenText}"`);
+    }
+    const len = Number.parseInt(lenText, 10);
+    const start = colon + 1;
+    const end = start + len;
+    if (end > buf.length) {
+        return null; // incomplete
+    }
+    return { value: buf.toString('utf-8', start, end), offset: end };
+}
+
+function parseList(buf: Buffer, offset: number): Parsed | null {
+    const items: BencodeValue[] = [];
+    let cursor = offset + 1;
+    while (cursor < buf.length && buf[cursor] !== END) {
+        const parsed = parseValue(buf, cursor);
+        if (parsed === null) {
+            return null;
+        }
+        items.push(parsed.value);
+        cursor = parsed.offset;
+    }
+    if (cursor >= buf.length) {
+        return null; // no terminating 'e' yet
+    }
+    return { value: items, offset: cursor + 1 };
+}
+
+function parseDict(buf: Buffer, offset: number): Parsed | null {
+    const dict: { [key: string]: BencodeValue } = {};
+    let cursor = offset + 1;
+    while (cursor < buf.length && buf[cursor] !== END) {
+        const key = parseString(buf, cursor);
+        if (key === null) {
+            return null;
+        }
+        const value = parseValue(buf, key.offset);
+        if (value === null) {
+            return null;
+        }
+        dict[String(key.value)] = value.value;
+        cursor = value.offset;
+    }
+    if (cursor >= buf.length) {
+        return null; // no terminating 'e' yet
+    }
+    return { value: dict, offset: cursor + 1 };
+}
+
+/** Coerce a bencode value that should be a string (nREPL sends most as byte strings). */
+export function asString(value: BencodeValue | undefined): string {
+    if (typeof value === 'string') {
+        return value;
+    }
+    if (typeof value === 'number') {
+        return String(value);
+    }
+    return '';
+}
+
+/** Coerce a bencode value that should be a list of strings (e.g. `status`). */
+export function asStringList(value: BencodeValue | undefined): string[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+    return value.map((v) => asString(v));
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import { PhelRenameProvider } from './phelRenameProvider';
 import { PhelDocumentSymbolProvider, PhelWorkspaceSymbolProvider } from './phelSymbolProviders';
 import { registerPareditCommands } from './phelPareditProvider';
 import { registerReplCommands } from './phelReplProvider';
+import { registerNreplCommands } from './phelNreplProvider';
 import { registerSelectionCommands } from './phelSelectionProvider';
 import { PhelFormHighlight } from './phelFormHighlight';
 import { PhelInlineValuesProvider } from './phelInlineValuesProvider';
@@ -176,6 +177,10 @@ export function activate(context: vscode.ExtensionContext) {
 
     if (vscode.workspace.getConfiguration('phel').get<boolean>('repl.enabled', true)) {
         registerReplCommands(context);
+    }
+
+    if (vscode.workspace.getConfiguration('phel').get<boolean>('nrepl.enabled', true)) {
+        registerNreplCommands(context);
     }
 
     registerSelectionCommands(context);

--- a/src/phelNreplClient.ts
+++ b/src/phelNreplClient.ts
@@ -1,0 +1,303 @@
+// nREPL client.
+//
+// phel-lang ships an nREPL server (`phel nrepl`, bencode-over-TCP). Connecting
+// to it gives us structured eval results and errors, completion from the live
+// runtime, and the editor-targeted ops `reload` (reload changed namespaces)
+// and `run-tests` / `run-test` (run a namespace's tests, or a single test).
+//
+// We start one server per workspace folder on a random free port (`--port=0`),
+// parse the bound port from its banner, open a TCP socket, and `clone` a
+// session. Ops are bencoded dicts correlated by an `id` we generate; the server
+// streams one or more response frames per op, terminated by a `status`
+// containing `done`.
+
+import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
+import * as net from 'node:net';
+import * as vscode from 'vscode';
+import { asString, asStringList, type BencodeValue, decode, encode } from './bencode';
+import { resolvePhelExecutable } from './phelExecutable';
+
+const BANNER_RE = /nREPL server started on (\d{1,3}(?:\.\d{1,3}){3}):(\d+)/;
+const STARTUP_TIMEOUT_MS = 15000;
+const OP_TIMEOUT_MS = 60000;
+
+export interface OpResult {
+    /** Concatenated `value` frames (eval results). */
+    values: string[];
+    /** Concatenated `out` frames (stdout from the evaluated code). */
+    out: string;
+    /** Concatenated `err` frames plus any `ex` / error-status detail. */
+    err: string;
+    /** Union of every `status` token seen across the response frames. */
+    status: string[];
+}
+
+interface PendingOp {
+    resolve: (result: OpResult) => void;
+    reject: (err: Error) => void;
+    timer: NodeJS.Timeout;
+    acc: OpResult;
+    /** Captured `new-session` value (only set for the `clone` op). */
+    newSession?: string;
+}
+
+/**
+ * A live connection to a `phel nrepl` server for one workspace folder.
+ */
+export class PhelNreplConnection {
+    private proc?: ChildProcessWithoutNullStreams;
+    private socket?: net.Socket;
+    private sessionId = '';
+    private buffer = Buffer.alloc(0);
+    private nextId = 1;
+    private readonly pending = new Map<string, PendingOp>();
+    private disposed = false;
+
+    private constructor(
+        readonly folder: vscode.WorkspaceFolder,
+        private readonly output: vscode.OutputChannel
+    ) {}
+
+    static async connect(
+        folder: vscode.WorkspaceFolder,
+        output: vscode.OutputChannel
+    ): Promise<PhelNreplConnection> {
+        const conn = new PhelNreplConnection(folder, output);
+        await conn.startServerAndConnect();
+        return conn;
+    }
+
+    get connected(): boolean {
+        return !this.disposed && this.socket !== undefined && this.sessionId !== '';
+    }
+
+    private async startServerAndConnect(): Promise<void> {
+        const command = resolvePhelExecutable('repl.command', this.folder);
+        const cwd = this.folder.uri.fsPath;
+        this.output.appendLine(`Starting nREPL server: ${command} nrepl --port=0 (cwd ${cwd})`);
+
+        const port = await this.spawnAndAwaitPort(command, cwd);
+        await this.openSocket(port);
+        this.sessionId = await this.cloneSession();
+        this.output.appendLine(
+            `nREPL session ready on 127.0.0.1:${port} (session ${this.sessionId}).`
+        );
+    }
+
+    private spawnAndAwaitPort(command: string, cwd: string): Promise<number> {
+        return new Promise((resolve, reject) => {
+            const proc = spawn(command, ['nrepl', '--port=0'], { cwd });
+            this.proc = proc;
+            let settled = false;
+            let stderr = '';
+
+            const timer = setTimeout(() => {
+                if (!settled) {
+                    settled = true;
+                    proc.kill();
+                    reject(new Error('Timed out waiting for the nREPL server to start.'));
+                }
+            }, STARTUP_TIMEOUT_MS);
+
+            const onData = (chunk: Buffer): void => {
+                const text = chunk.toString();
+                this.output.append(text);
+                const match = BANNER_RE.exec(text);
+                if (match && !settled) {
+                    settled = true;
+                    clearTimeout(timer);
+                    resolve(Number.parseInt(match[2], 10));
+                }
+            };
+
+            proc.stdout.on('data', onData);
+            proc.stderr.on('data', (chunk: Buffer) => {
+                stderr += chunk.toString();
+                this.output.append(chunk.toString());
+            });
+            proc.on('error', (err) => {
+                if (!settled) {
+                    settled = true;
+                    clearTimeout(timer);
+                    reject(err);
+                }
+            });
+            proc.on('exit', (code) => {
+                if (!settled) {
+                    settled = true;
+                    clearTimeout(timer);
+                    reject(
+                        new Error(
+                            `nREPL server exited (code ${code ?? 'unknown'}) before binding a port.` +
+                                (stderr ? `\n${stderr.trim()}` : '')
+                        )
+                    );
+                }
+                this.handleClose();
+            });
+        });
+    }
+
+    private openSocket(port: number): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const socket = net.createConnection({ host: '127.0.0.1', port }, () => resolve());
+            this.socket = socket;
+            socket.on('data', (chunk) => this.onSocketData(chunk));
+            socket.on('error', (err) => {
+                reject(err);
+                this.failAllPending(err);
+            });
+            socket.on('close', () => this.handleClose());
+        });
+    }
+
+    private onSocketData(chunk: Buffer): void {
+        this.buffer = Buffer.concat([this.buffer, chunk]);
+        const { values, consumed } = decode(this.buffer);
+        if (consumed > 0) {
+            this.buffer = this.buffer.subarray(consumed);
+        }
+        for (const value of values) {
+            if (value && typeof value === 'object' && !Array.isArray(value)) {
+                this.handleFrame(value);
+            }
+        }
+    }
+
+    private handleFrame(frame: { [key: string]: BencodeValue }): void {
+        const id = asString(frame['id']);
+        const op = this.pending.get(id);
+        if (!op) {
+            return;
+        }
+        if (frame['value'] !== undefined) {
+            op.acc.values.push(asString(frame['value']));
+        }
+        if (frame['out'] !== undefined) {
+            op.acc.out += asString(frame['out']);
+        }
+        if (frame['err'] !== undefined) {
+            op.acc.err += asString(frame['err']);
+        }
+        if (frame['ex'] !== undefined) {
+            op.acc.err += asString(frame['ex']);
+        }
+        if (frame['new-session'] !== undefined) {
+            op.newSession = asString(frame['new-session']);
+        }
+        const status = asStringList(frame['status']);
+        for (const token of status) {
+            if (!op.acc.status.includes(token)) {
+                op.acc.status.push(token);
+            }
+        }
+        if (status.includes('done')) {
+            clearTimeout(op.timer);
+            this.pending.delete(id);
+            op.resolve(op.acc);
+        }
+    }
+
+    private send(op: { [key: string]: BencodeValue }): Promise<OpResult> {
+        const { promise } = this.sendTracked(op);
+        return promise;
+    }
+
+    /**
+     * Send an op and return both the result promise and the pending record, so
+     * callers that need response fields outside `OpResult` (e.g. `clone`'s
+     * `new-session`) can read them once the promise resolves.
+     */
+    private sendTracked(op: { [key: string]: BencodeValue }): {
+        promise: Promise<OpResult>;
+        getNewSession: () => string | undefined;
+    } {
+        let pendingRef: PendingOp | undefined;
+        const promise = new Promise<OpResult>((resolve, reject) => {
+            if (!this.socket || this.disposed) {
+                reject(new Error('nREPL connection is not open.'));
+                return;
+            }
+            const id = String(this.nextId++);
+            const frame: { [key: string]: BencodeValue } = { ...op, id };
+            if (this.sessionId && frame['session'] === undefined) {
+                frame['session'] = this.sessionId;
+            }
+            const timer = setTimeout(() => {
+                this.pending.delete(id);
+                reject(new Error(`nREPL op "${asString(op['op'])}" timed out.`));
+            }, OP_TIMEOUT_MS);
+            const pending: PendingOp = {
+                resolve,
+                reject,
+                timer,
+                acc: { values: [], out: '', err: '', status: [] },
+            };
+            pendingRef = pending;
+            this.pending.set(id, pending);
+            this.socket.write(encode(frame));
+        });
+        return { promise, getNewSession: () => pendingRef?.newSession };
+    }
+
+    private async cloneSession(): Promise<string> {
+        const { promise, getNewSession } = this.sendTracked({ op: 'clone' });
+        await promise;
+        return getNewSession() ?? '';
+    }
+
+    eval(code: string, ns?: string): Promise<OpResult> {
+        const op: { [key: string]: BencodeValue } = { op: 'eval', code };
+        if (ns) {
+            op['ns'] = ns;
+        }
+        return this.send(op);
+    }
+
+    loadFile(content: string, filePath: string): Promise<OpResult> {
+        return this.send({ op: 'load-file', file: content, 'file-path': filePath });
+    }
+
+    reload(all = false): Promise<OpResult> {
+        return this.send({ op: 'reload', all: all ? '1' : '0' });
+    }
+
+    runTests(ns: string, testVar?: string): Promise<OpResult> {
+        const op: { [key: string]: BencodeValue } = { op: 'run-tests', ns };
+        if (testVar) {
+            op['var'] = testVar;
+        }
+        return this.send(op);
+    }
+
+    private failAllPending(err: Error): void {
+        for (const [id, op] of this.pending) {
+            clearTimeout(op.timer);
+            op.reject(err);
+            this.pending.delete(id);
+        }
+    }
+
+    private handleClose(): void {
+        if (this.disposed) {
+            return;
+        }
+        this.failAllPending(new Error('nREPL connection closed.'));
+        this.sessionId = '';
+    }
+
+    dispose(): void {
+        if (this.disposed) {
+            return;
+        }
+        this.disposed = true;
+        this.failAllPending(new Error('nREPL connection disposed.'));
+        this.socket?.destroy();
+        this.socket = undefined;
+        if (this.proc && !this.proc.killed) {
+            this.proc.kill();
+        }
+        this.proc = undefined;
+        this.sessionId = '';
+    }
+}

--- a/src/phelNreplProvider.ts
+++ b/src/phelNreplProvider.ts
@@ -1,0 +1,308 @@
+// nREPL integration: commands that connect to a `phel nrepl` server and run
+// structured ops against the live runtime.
+//
+//   phel.nrepl.connect / phel.nrepl.disconnect
+//   phel.nrepl.eval            — eval the form under the cursor, show the result
+//   phel.nrepl.evalSelection   — eval the selection
+//   phel.nrepl.loadFile        — load the whole file
+//   phel.nrepl.reload          — reload changed namespaces
+//   phel.nrepl.reloadAll       — reload every project namespace
+//   phel.nrepl.runTestsInNs    — run every test in the current file's namespace
+//   phel.nrepl.runTestUnderCursor — run the single deftest under the cursor
+//
+// Unlike the terminal REPL, results come back as structured frames, so we can
+// show the value, captured stdout, and errors distinctly. A connection is
+// started lazily per workspace folder and reused. When `phel.nrepl.reloadOnSave`
+// is enabled, saving a `.phel` file triggers a reload of changed namespaces.
+
+import * as vscode from 'vscode';
+import { type OpResult, PhelNreplConnection } from './phelNreplClient';
+import { parseNsForm } from './phelNsAnalyzer';
+import { topLevelFormAt } from './phelRepl';
+
+const OUTPUT_CHANNEL_NAME = 'Phel nREPL';
+const DEFTEST_HEAD_RE = /^\(deftest\s+(?:\^\S+\s+)*([^\s()[\]{}]+)/;
+
+let output: vscode.OutputChannel | undefined;
+const connections = new Map<string, PhelNreplConnection>();
+const connecting = new Map<string, Promise<PhelNreplConnection>>();
+
+function channel(): vscode.OutputChannel {
+    output ??= vscode.window.createOutputChannel(OUTPUT_CHANNEL_NAME);
+    return output;
+}
+
+function folderForDoc(doc?: vscode.TextDocument): vscode.WorkspaceFolder | undefined {
+    if (doc && doc.uri.scheme === 'file') {
+        return vscode.workspace.getWorkspaceFolder(doc.uri) ?? undefined;
+    }
+    return vscode.workspace.workspaceFolders?.[0];
+}
+
+async function getConnection(
+    folder: vscode.WorkspaceFolder,
+    { create }: { create: boolean } = { create: true }
+): Promise<PhelNreplConnection | undefined> {
+    const key = folder.uri.toString();
+    const existing = connections.get(key);
+    if (existing && existing.connected) {
+        return existing;
+    }
+    if (!create) {
+        return undefined;
+    }
+    const inflight = connecting.get(key);
+    if (inflight) {
+        return inflight;
+    }
+    const promise = PhelNreplConnection.connect(folder, channel())
+        .then((conn) => {
+            connections.set(key, conn);
+            connecting.delete(key);
+            return conn;
+        })
+        .catch((err) => {
+            connecting.delete(key);
+            throw err;
+        });
+    connecting.set(key, promise);
+    return promise;
+}
+
+async function withConnection(
+    doc: vscode.TextDocument | undefined,
+    action: (conn: PhelNreplConnection) => Promise<void>
+): Promise<void> {
+    const folder = folderForDoc(doc);
+    if (!folder) {
+        vscode.window.showWarningMessage('Open a file inside a Phel project first.');
+        return;
+    }
+    let conn: PhelNreplConnection | undefined;
+    try {
+        conn = await vscode.window.withProgress(
+            { location: vscode.ProgressLocation.Window, title: 'Phel nREPL' },
+            () => getConnection(folder)
+        );
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        channel().appendLine(`Failed to connect: ${message}`);
+        channel().show(true);
+        vscode.window.showErrorMessage(`Phel nREPL: ${message}`);
+        return;
+    }
+    if (!conn) {
+        return;
+    }
+    try {
+        await action(conn);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        channel().appendLine(`Error: ${message}`);
+        channel().show(true);
+        vscode.window.showErrorMessage(`Phel nREPL: ${message}`);
+    }
+}
+
+function reportResult(label: string, result: OpResult): void {
+    const ch = channel();
+    ch.appendLine(`;; ${label}`);
+    if (result.out.trim()) {
+        ch.append(result.out.endsWith('\n') ? result.out : result.out + '\n');
+    }
+    for (const value of result.values) {
+        ch.appendLine(`=> ${value}`);
+    }
+    const failed = result.status.includes('error') || result.status.includes('eval-error');
+    if (result.err.trim()) {
+        ch.appendLine(result.err.trim());
+    }
+    if (failed) {
+        ch.show(true);
+    }
+}
+
+function nsFor(doc: vscode.TextDocument): string | undefined {
+    return parseNsForm(doc.getText())?.name ?? undefined;
+}
+
+async function evalForm(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'phel') {
+        return;
+    }
+    const doc = editor.document;
+    const offset = doc.offsetAt(editor.selection.active);
+    const form = topLevelFormAt(doc.getText(), offset);
+    if (!form) {
+        vscode.window.showWarningMessage('No Phel form under cursor.');
+        return;
+    }
+    await withConnection(doc, async (conn) => {
+        const result = await conn.eval(form.text, nsFor(doc));
+        reportResult('eval', result);
+    });
+}
+
+async function evalSelection(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'phel') {
+        return;
+    }
+    const doc = editor.document;
+    const sel = editor.selection;
+    const text = sel.isEmpty ? doc.lineAt(sel.active.line).text : doc.getText(sel);
+    if (!text.trim()) {
+        return;
+    }
+    await withConnection(doc, async (conn) => {
+        const result = await conn.eval(text, nsFor(doc));
+        reportResult('eval selection', result);
+    });
+}
+
+async function loadFile(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'phel') {
+        return;
+    }
+    const doc = editor.document;
+    await withConnection(doc, async (conn) => {
+        const result = await conn.loadFile(doc.getText(), doc.uri.fsPath);
+        reportResult(`load-file ${doc.uri.fsPath}`, result);
+    });
+}
+
+async function reload(all: boolean): Promise<void> {
+    const doc = vscode.window.activeTextEditor?.document;
+    await withConnection(doc, async (conn) => {
+        const result = await conn.reload(all);
+        reportResult(all ? 'reload-all' : 'reload', result);
+    });
+}
+
+/** Find the name of the `deftest` whose top-level form encloses the cursor. */
+function deftestUnderCursor(doc: vscode.TextDocument, offset: number): string | undefined {
+    const form = topLevelFormAt(doc.getText(), offset);
+    if (!form) {
+        return undefined;
+    }
+    const match = DEFTEST_HEAD_RE.exec(form.text.trimStart());
+    return match ? match[1] : undefined;
+}
+
+async function runTestsInNs(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'phel') {
+        return;
+    }
+    const doc = editor.document;
+    const ns = nsFor(doc);
+    if (!ns) {
+        vscode.window.showWarningMessage('No (ns ...) form in this file.');
+        return;
+    }
+    await withConnection(doc, async (conn) => {
+        const result = await conn.runTests(ns);
+        reportResult(`run-tests ${ns}`, result);
+    });
+}
+
+async function runTestUnderCursor(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'phel') {
+        return;
+    }
+    const doc = editor.document;
+    const ns = nsFor(doc);
+    if (!ns) {
+        vscode.window.showWarningMessage('No (ns ...) form in this file.');
+        return;
+    }
+    const offset = doc.offsetAt(editor.selection.active);
+    const testName = deftestUnderCursor(doc, offset);
+    if (!testName) {
+        vscode.window.showWarningMessage('Place the cursor inside a (deftest ...) form.');
+        return;
+    }
+    await withConnection(doc, async (conn) => {
+        const result = await conn.runTests(ns, testName);
+        reportResult(`run-test ${ns}/${testName}`, result);
+    });
+}
+
+async function connect(): Promise<void> {
+    const doc = vscode.window.activeTextEditor?.document;
+    const folder = folderForDoc(doc);
+    if (!folder) {
+        vscode.window.showWarningMessage('Open a file inside a Phel project first.');
+        return;
+    }
+    await withConnection(doc, async () => {
+        channel().show(true);
+        vscode.window.showInformationMessage('Connected to the Phel nREPL server.');
+    });
+}
+
+function disconnect(): void {
+    const doc = vscode.window.activeTextEditor?.document;
+    const folder = folderForDoc(doc);
+    if (folder) {
+        const key = folder.uri.toString();
+        connections.get(key)?.dispose();
+        connections.delete(key);
+    } else {
+        disposeAll();
+    }
+}
+
+function disposeAll(): void {
+    for (const conn of connections.values()) {
+        conn.dispose();
+    }
+    connections.clear();
+    connecting.clear();
+}
+
+export function registerNreplCommands(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand('phel.nrepl.connect', connect),
+        vscode.commands.registerCommand('phel.nrepl.disconnect', disconnect),
+        vscode.commands.registerCommand('phel.nrepl.eval', evalForm),
+        vscode.commands.registerCommand('phel.nrepl.evalSelection', evalSelection),
+        vscode.commands.registerCommand('phel.nrepl.loadFile', loadFile),
+        vscode.commands.registerCommand('phel.nrepl.reload', () => reload(false)),
+        vscode.commands.registerCommand('phel.nrepl.reloadAll', () => reload(true)),
+        vscode.commands.registerCommand('phel.nrepl.runTestsInNs', runTestsInNs),
+        vscode.commands.registerCommand('phel.nrepl.runTestUnderCursor', runTestUnderCursor),
+        vscode.workspace.onDidSaveTextDocument(async (doc) => {
+            if (doc.languageId !== 'phel') {
+                return;
+            }
+            const folder = folderForDoc(doc);
+            if (!folder) {
+                return;
+            }
+            const reloadOnSave = vscode.workspace
+                .getConfiguration('phel', folder)
+                .get<boolean>('nrepl.reloadOnSave', false);
+            if (!reloadOnSave) {
+                return;
+            }
+            // Only reload if a connection already exists; don't spin one up on save.
+            const conn = await getConnection(folder, { create: false });
+            if (!conn) {
+                return;
+            }
+            try {
+                const result = await conn.reload(false);
+                reportResult('reload (on save)', result);
+            } catch (err) {
+                channel().appendLine(
+                    `reload on save failed: ${err instanceof Error ? err.message : String(err)}`
+                );
+            }
+        }),
+        new vscode.Disposable(disposeAll)
+    );
+}

--- a/src/test/bencode.test.ts
+++ b/src/test/bencode.test.ts
@@ -1,0 +1,107 @@
+import * as assert from 'node:assert/strict';
+import { asString, asStringList, decode, encode, type BencodeValue } from '../bencode';
+
+function roundtrip(value: BencodeValue): BencodeValue {
+    const buf = encode(value);
+    const { values, consumed } = decode(buf);
+    assert.equal(consumed, buf.length, 'should consume the whole buffer');
+    assert.equal(values.length, 1, 'should decode exactly one value');
+    return values[0];
+}
+
+describe('bencode.encode', () => {
+    it('encodes integers', () => {
+        assert.equal(encode(42).toString(), 'i42e');
+        assert.equal(encode(0).toString(), 'i0e');
+        assert.equal(encode(-7).toString(), 'i-7e');
+    });
+
+    it('encodes byte strings with utf-8 byte length', () => {
+        assert.equal(encode('spam').toString(), '4:spam');
+        assert.equal(encode('').toString(), '0:');
+        // 'é' is two bytes in UTF-8
+        assert.equal(encode('é').toString(), '2:é');
+    });
+
+    it('encodes lists', () => {
+        assert.equal(encode(['spam', 42]).toString(), 'l4:spami42ee');
+        assert.equal(encode([]).toString(), 'le');
+    });
+
+    it('encodes dictionaries with sorted keys', () => {
+        assert.equal(
+            encode({ op: 'eval', code: '(+ 1 2)' }).toString(),
+            'd4:code7:(+ 1 2)2:op4:evale'
+        );
+    });
+
+    it('rejects non-integer numbers', () => {
+        assert.throws(() => encode(3.14));
+    });
+});
+
+describe('bencode.decode', () => {
+    it('round-trips nested structures', () => {
+        const value: BencodeValue = {
+            op: 'eval',
+            id: '1',
+            session: 'abc',
+            nested: { status: ['done'], items: [1, 2, 3] },
+        };
+        assert.deepEqual(roundtrip(value), value);
+    });
+
+    it('decodes multiple concatenated frames', () => {
+        const a = encode({ id: '1', status: ['done'] });
+        const b = encode({ id: '2', value: '42' });
+        const { values, consumed } = decode(Buffer.concat([a, b]));
+        assert.equal(values.length, 2);
+        assert.equal(consumed, a.length + b.length);
+        assert.deepEqual(values[0], { id: '1', status: ['done'] });
+        assert.deepEqual(values[1], { id: '2', value: '42' });
+    });
+
+    it('stops at a partial frame and reports bytes consumed', () => {
+        const whole = encode({ id: '1', status: ['done'] });
+        const partial = encode({ id: '2', value: 'longvalue' });
+        const truncated = Buffer.concat([whole, partial.subarray(0, partial.length - 3)]);
+        const { values, consumed } = decode(truncated);
+        assert.equal(values.length, 1, 'only the complete frame decodes');
+        assert.equal(consumed, whole.length, 'consumes only the complete frame');
+        // Feeding the remainder + the rest should then decode the second frame.
+        const rest = Buffer.concat([
+            truncated.subarray(consumed),
+            partial.subarray(partial.length - 3),
+        ]);
+        const second = decode(rest);
+        assert.equal(second.values.length, 1);
+        assert.deepEqual(second.values[0], { id: '2', value: 'longvalue' });
+    });
+
+    it('returns nothing for an empty or incomplete leading frame', () => {
+        assert.deepEqual(decode(Buffer.from('')), { values: [], consumed: 0 });
+        assert.deepEqual(decode(Buffer.from('d2:id')), { values: [], consumed: 0 });
+        assert.deepEqual(decode(Buffer.from('i42')), { values: [], consumed: 0 });
+    });
+
+    it('handles string payloads containing bencode delimiters', () => {
+        // A value whose bytes look like bencode control chars must not confuse the parser.
+        const tricky = { out: 'lei42e:d' };
+        assert.deepEqual(roundtrip(tricky), tricky);
+    });
+});
+
+describe('bencode coercion helpers', () => {
+    it('asString coerces strings and numbers', () => {
+        assert.equal(asString('hi'), 'hi');
+        assert.equal(asString(42), '42');
+        assert.equal(asString(undefined), '');
+        assert.equal(asString(['x']), '');
+    });
+
+    it('asStringList coerces lists', () => {
+        assert.deepEqual(asStringList(['done', 'error']), ['done', 'error']);
+        assert.deepEqual(asStringList(undefined), []);
+        assert.deepEqual(asStringList('done'), []);
+    });
+});


### PR DESCRIPTION
## What

Adds a real **nREPL client** that connects to a `phel nrepl` server (bencode-over-TCP), replacing the "pipe text into a terminal" model for evaluation with structured ops against the live runtime.

New commands (all `Phel: nREPL …`):

- **Connect / Disconnect**
- **Eval Form Under Cursor / Eval Selection** — structured value, captured stdout, and errors
- **Load File**
- **Reload Changed Namespaces** / **Reload All Namespaces**
- **Run Tests in Namespace** / **Run Test Under Cursor**

Results go to a dedicated **Phel nREPL** output channel (`=> value`, stdout, and error text, auto-revealed on error).

## Why

The terminal REPL can only fling flattened text at a shell and read it back as noise. phel-lang's nREPL server exposes structured ops the CHANGELOG explicitly added "so editors can bind 'reload changed' and 'run test under cursor'": `eval`, `load-file`, `reload`, `run-tests` / `run-test`, `completions`, `lookup`. This PR uses them to get real values, real errors, and live-runtime test runs.

## How

- `src/bencode.ts` — a dependency-free, incremental bencode codec (handles partial TCP frames). Fully unit-tested (`src/test/bencode.test.ts`, 12 cases).
- `src/phelNreplClient.ts` — `PhelNreplConnection`: spawns `phel nrepl --port=0`, parses the `nREPL server started on 127.0.0.1:PORT` banner, opens a TCP socket, `clone`s a session, and correlates response frames by a generated `id` until `status` contains `done`.
- `src/phelNreplProvider.ts` — registers the commands, manages one lazily-created connection per workspace folder, and an opt-in reload-on-save (`phel.nrepl.reloadOnSave`, only fires when a connection already exists).
- Gated behind `phel.nrepl.enabled` (default `true`). The terminal REPL (`phel.repl.*`) is untouched and remains available alongside.

## Verification

- **End-to-end against a live server**: a smoke test drove the compiled codec through a real `phel nrepl` (Phel v0.45.1-beta) — `clone` → session, `eval (+ 1 2)` → `["3"]` / `done`, an undefined-symbol eval → `["eval-error","done"]` with error text, and `completions`. All passed. (The provider keys error reporting off the `eval-error` status token confirmed here.)
- `tsc --noEmit` clean, `eslint` clean, **292** tests pass (280 existing + 12 new bencode), production bundle succeeds with `net`/`child_process` bundled.

## New settings

| Setting | Default | Purpose |
|---|---|---|
| `phel.nrepl.enabled` | `true` | Register the nREPL commands. |
| `phel.nrepl.reloadOnSave` | `false` | Reload changed namespaces on save when a connection is open. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)