### PR TITLE
feat(test): per-test results in the Test Explorer via --reporter=junit-xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Test Explorer
+
+- Report per-test pass/fail in the Test Explorer by running `phel test --reporter=junit-xml` and parsing the JUnit report, instead of inferring a single pass/fail from the process exit code. Failing tests now show the assertion message and the failing form, and each file's tests run in one subprocess. Tests absent from the report are marked skipped.
+
 ### REPL & runtime
 
 - Add an nREPL client that connects to a `phel nrepl` server (bencode-over-TCP, started automatically on a random free port). Commands: connect / disconnect, structured eval of the form under the cursor or the selection, load file, reload changed namespaces (`phel.nrepl.reload`) or all (`phel.nrepl.reloadAll`), run a namespace's tests (`phel.nrepl.runTestsInNs`), and run the `deftest` under the cursor (`phel.nrepl.runTestUnderCursor`). Results — values, captured stdout, and errors — are shown in a dedicated "Phel nREPL" output channel. New settings: `phel.nrepl.enabled` (default `true`) and `phel.nrepl.reloadOnSave` (default `false`).

--- a/src/junitParser.ts
+++ b/src/junitParser.ts
@@ -1,0 +1,155 @@
+// Parser for the JUnit XML that `phel test --reporter=junit-xml` emits.
+//
+// Phel's schema (verified against the CLI):
+//
+//   <testsuites tests= failures= errors= time=>
+//     <testsuite name="<namespace>" ...>
+//       <testcase name="<deftest>" classname="" file="<abs path>" line="<n>">
+//         <failure message="<msg>" type="<type>"><failing form></failure>?
+//         <error   message="<msg>" type="<type>">...</error>?
+//       </testcase>
+//       ...
+//     </testsuite>
+//   </testsuites>
+//
+// One `<testcase>` is emitted per assertion, so a single `deftest` produces
+// several rows that share `name`/`file`/`line`; rows carry a `<failure>` only
+// when that assertion failed. Callers aggregate by name (see groupByName).
+
+export interface JUnitFailure {
+    message: string;
+    type: string;
+    /** Text content of the failure element (the failing form, for Phel). */
+    detail: string;
+    /** True for `<error>` (a thrown exception) rather than `<failure>`. */
+    isError: boolean;
+}
+
+export interface JUnitTestCase {
+    name: string;
+    suite: string;
+    file?: string;
+    line?: number;
+    failures: JUnitFailure[];
+}
+
+/** All testcases flattened across suites, in document order. */
+export function parseJUnit(xml: string): JUnitTestCase[] {
+    const cases: JUnitTestCase[] = [];
+    const suiteRe = /<testsuite\b([^>]*)>([\s\S]*?)<\/testsuite>/g;
+    let suiteMatch: RegExpExecArray | null;
+    let matchedAnySuite = false;
+    while ((suiteMatch = suiteRe.exec(xml)) !== null) {
+        matchedAnySuite = true;
+        const suiteName = attr(suiteMatch[1], 'name') ?? '';
+        collectCases(suiteMatch[2], suiteName, cases);
+    }
+    // Some reporters omit <testsuite> and put <testcase> directly under
+    // <testsuites>; handle that by scanning the whole doc as a fallback.
+    if (!matchedAnySuite) {
+        collectCases(xml, '', cases);
+    }
+    return cases;
+}
+
+function collectCases(scope: string, suiteName: string, out: JUnitTestCase[]): void {
+    // Self-closing testcases (no failure/error child).
+    const selfClosingRe = /<testcase\b([^>]*?)\/>/g;
+    // Testcases with a body (may contain failure/error children).
+    const bodyRe = /<testcase\b([^>]*?)>([\s\S]*?)<\/testcase>/g;
+
+    let m: RegExpExecArray | null;
+    while ((m = bodyRe.exec(scope)) !== null) {
+        out.push(buildCase(m[1], m[2], suiteName));
+    }
+    while ((m = selfClosingRe.exec(scope)) !== null) {
+        out.push(buildCase(m[1], '', suiteName));
+    }
+}
+
+function buildCase(attrs: string, body: string, suiteName: string): JUnitTestCase {
+    const lineRaw = attr(attrs, 'line');
+    const line = lineRaw !== undefined ? Number.parseInt(lineRaw, 10) : undefined;
+    return {
+        name: attr(attrs, 'name') ?? '',
+        suite: suiteName,
+        file: attr(attrs, 'file'),
+        line: line !== undefined && Number.isFinite(line) ? line : undefined,
+        failures: parseFailures(body),
+    };
+}
+
+function parseFailures(body: string): JUnitFailure[] {
+    const failures: JUnitFailure[] = [];
+    const re = /<(failure|error)\b([^>]*?)(?:\/>|>([\s\S]*?)<\/\1>)/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(body)) !== null) {
+        failures.push({
+            isError: m[1] === 'error',
+            message: decodeEntities(attr(m[2], 'message') ?? ''),
+            type: decodeEntities(attr(m[2], 'type') ?? ''),
+            detail: decodeEntities((m[3] ?? '').trim()),
+        });
+    }
+    return failures;
+}
+
+/** Read a double- or single-quoted attribute value (raw, not entity-decoded). */
+function attr(attrs: string, name: string): string | undefined {
+    const re = new RegExp(`\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)')`);
+    const m = re.exec(attrs);
+    if (!m) {
+        return undefined;
+    }
+    return m[2] ?? m[3] ?? '';
+}
+
+function decodeEntities(text: string): string {
+    return text
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&apos;/g, "'")
+        .replace(/&#(\d+);/g, (_, code: string) => String.fromCodePoint(Number.parseInt(code, 10)))
+        .replace(/&#x([0-9a-fA-F]+);/g, (_, code: string) =>
+            String.fromCodePoint(Number.parseInt(code, 16))
+        )
+        .replace(/&amp;/g, '&'); // last, so we don't double-decode
+}
+
+export interface AggregatedCase {
+    name: string;
+    suite: string;
+    file?: string;
+    line?: number;
+    failures: JUnitFailure[];
+    passed: boolean;
+}
+
+/**
+ * Collapse the per-assertion rows into one entry per test name (within a
+ * suite). A test passes only if none of its rows carried a failure/error.
+ */
+export function groupByName(cases: JUnitTestCase[]): Map<string, AggregatedCase> {
+    const byKey = new Map<string, AggregatedCase>();
+    for (const c of cases) {
+        const key = `${c.suite}::${c.name}`;
+        const existing = byKey.get(key);
+        if (existing) {
+            existing.failures.push(...c.failures);
+            existing.passed &&= c.failures.length === 0;
+            existing.file ??= c.file;
+            existing.line ??= c.line;
+        } else {
+            byKey.set(key, {
+                name: c.name,
+                suite: c.suite,
+                file: c.file,
+                line: c.line,
+                failures: [...c.failures],
+                passed: c.failures.length === 0,
+            });
+        }
+    }
+    return byKey;
+}

--- a/src/phelTestController.ts
+++ b/src/phelTestController.ts
@@ -1,28 +1,29 @@
 // VS Code Test Explorer integration for Phel.
 //
 // Each `.phel` file with at least one `deftest` becomes a TestItem; each
-// `deftest` becomes a child item. Running an item shells out to `phel test
-// --filter` and reports pass / fail based on the exit code. We don't parse
-// the textual output yet — when the Phel CLI gains structured (JSON / TAP)
-// output we can attach per-assertion messages.
+// `deftest` becomes a child item. Running items shells out to
+// `phel test --reporter=junit-xml -o <tmp>` and parses the JUnit report, so
+// individual tests get pass / fail status plus the failing assertion message
+// and (for the failing form) detail. Tests not present in the report are
+// marked skipped.
 
 import { spawn } from 'node:child_process';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 import * as vscode from 'vscode';
 import { resolvePhelExecutable } from './phelExecutable';
 import { findDeftests } from './phelTestScanner';
+import { type AggregatedCase, groupByName, parseJUnit } from './junitParser';
 
 interface ResolvedCommand {
     command: string;
-    args: string[];
     cwd: string;
 }
 
 function resolveTestCommand(folder: vscode.WorkspaceFolder): ResolvedCommand {
     return {
         command: resolvePhelExecutable('test.command', folder),
-        args: ['test'],
         cwd: folder.uri.fsPath,
     };
 }
@@ -71,58 +72,113 @@ async function loadAllTests(controller: vscode.TestController): Promise<void> {
     }
 }
 
-interface TestRunOutcome {
-    code: number;
+interface JUnitRunOutcome {
+    /** Aggregated results keyed by test name (the deftest name). */
+    byName: Map<string, AggregatedCase>;
+    /** Raw combined stdout+stderr, surfaced when the report is missing. */
     output: string;
+    code: number;
+    /** True when a JUnit report was produced and parsed. */
+    parsed: boolean;
 }
 
-function runPhelTest(folder: vscode.WorkspaceFolder, filter: string): Promise<TestRunOutcome> {
-    return new Promise((resolve) => {
-        const cmd = resolveTestCommand(folder);
-        const proc = spawn(cmd.command, [...cmd.args, '--filter', filter], { cwd: cmd.cwd });
+/**
+ * Run `phel test` for one file with the JUnit reporter and return the parsed,
+ * per-test results. We pass the file as a positional path so every `deftest`
+ * in it runs in a single subprocess.
+ */
+async function runPhelTestFile(
+    folder: vscode.WorkspaceFolder,
+    fileUri: vscode.Uri,
+    token: vscode.CancellationToken
+): Promise<JUnitRunOutcome> {
+    const cmd = resolveTestCommand(folder);
+    const relPath = path.relative(cmd.cwd, fileUri.fsPath) || fileUri.fsPath;
+    const reportPath = path.join(
+        os.tmpdir(),
+        `phel-junit-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.xml`
+    );
+    const args = ['test', '--reporter=junit-xml', '-o', reportPath, relPath];
+
+    const outcome = await new Promise<{ code: number; output: string }>((resolve) => {
+        const proc = spawn(cmd.command, args, { cwd: cmd.cwd });
         let output = '';
-        proc.stdout?.on('data', (d) => {
-            output += d.toString();
-        });
-        proc.stderr?.on('data', (d) => {
-            output += d.toString();
-        });
+        proc.stdout?.on('data', (d) => (output += d.toString()));
+        proc.stderr?.on('data', (d) => (output += d.toString()));
         proc.on('close', (code) => resolve({ code: code ?? 1, output }));
         proc.on('error', (err) => resolve({ code: 1, output: err.message }));
+        token.onCancellationRequested(() => proc.kill());
     });
+
+    let byName = new Map<string, AggregatedCase>();
+    let parsed = false;
+    try {
+        const xml = await fs.readFile(reportPath, 'utf-8');
+        byName = groupByName(parseJUnit(xml));
+        parsed = byName.size > 0 || xml.includes('<testsuite');
+    } catch {
+        // No report written (e.g. a compile error before any test ran).
+    } finally {
+        await fs.rm(reportPath, { force: true }).catch(() => undefined);
+    }
+
+    return { byName, output: outcome.output, code: outcome.code, parsed };
 }
 
-function expandQueue(
+interface QueueGroups {
+    /** File item → the set of leaf test items requested under it. */
+    byFile: Map<vscode.TestItem, vscode.TestItem[]>;
+}
+
+function groupQueue(
     queue: readonly vscode.TestItem[],
     request: vscode.TestRunRequest
-): vscode.TestItem[] {
-    const flat: vscode.TestItem[] = [];
-    const visit = (item: vscode.TestItem): void => {
+): QueueGroups {
+    const byFile = new Map<vscode.TestItem, vscode.TestItem[]>();
+    const addLeaf = (item: vscode.TestItem): void => {
         if (request.exclude?.includes(item)) {
             return;
         }
-        if (item.children.size === 0) {
-            flat.push(item);
+        // A leaf (deftest) item has an id of the form "<fileUri>::<name>".
+        const isLeaf = item.id.includes('::');
+        const fileItem = isLeaf ? item.parent : item;
+        if (!fileItem) {
             return;
         }
-        item.children.forEach(visit);
+        const leaves = byFile.get(fileItem) ?? [];
+        if (isLeaf) {
+            leaves.push(item);
+        } else {
+            item.children.forEach((child) => {
+                if (!request.exclude?.includes(child)) {
+                    leaves.push(child);
+                }
+            });
+        }
+        byFile.set(fileItem, leaves);
     };
     for (const item of queue) {
-        visit(item);
+        addLeaf(item);
     }
-    return flat;
+    return { byFile };
 }
 
-function filterFor(item: vscode.TestItem): string {
+function nameForLeaf(item: vscode.TestItem): string {
     const sep = item.id.indexOf('::');
-    if (sep < 0) {
-        return '.*';
-    }
-    return `^${escapeRegex(item.id.slice(sep + 2))}$`;
+    return sep < 0 ? item.label : item.id.slice(sep + 2);
 }
 
-function escapeRegex(s: string): string {
-    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+function messageFor(aggregated: AggregatedCase): vscode.TestMessage[] {
+    return aggregated.failures.map((f) => {
+        const parts = [f.message || (f.isError ? 'Error' : 'Assertion failed')];
+        if (f.detail) {
+            parts.push('', f.detail);
+        }
+        if (f.type) {
+            parts.push('', `(${f.type})`);
+        }
+        return new vscode.TestMessage(parts.join('\n'));
+    });
 }
 
 export class PhelTestController implements vscode.Disposable {
@@ -161,23 +217,47 @@ export class PhelTestController implements vscode.Disposable {
         } else {
             this.controller.items.forEach((it) => queue.push(it));
         }
-        const items = expandQueue(queue, request);
+        const { byFile } = groupQueue(queue, request);
         const run = this.controller.createTestRun(request);
-        for (const item of items) {
+
+        for (const [fileItem, leaves] of byFile) {
             if (token.isCancellationRequested) {
                 break;
             }
-            const folder = item.uri ? vscode.workspace.getWorkspaceFolder(item.uri) : undefined;
-            if (!folder) {
-                run.skipped(item);
+            const folder = fileItem.uri
+                ? vscode.workspace.getWorkspaceFolder(fileItem.uri)
+                : undefined;
+            if (!folder || !fileItem.uri) {
+                leaves.forEach((l) => run.skipped(l));
                 continue;
             }
-            run.started(item);
-            const outcome = await runPhelTest(folder, filterFor(item));
-            if (outcome.code === 0) {
-                run.passed(item);
-            } else {
-                run.failed(item, new vscode.TestMessage(outcome.output || `exit ${outcome.code}`));
+            leaves.forEach((l) => run.started(l));
+
+            const outcome = await runPhelTestFile(folder, fileItem.uri, token);
+
+            for (const leaf of leaves) {
+                const name = nameForLeaf(leaf);
+                // A leaf only knows the deftest name, not its namespace, so we
+                // match by name (test names are unique within a file).
+                const result = findByName(outcome.byName, name);
+                if (!result) {
+                    if (outcome.parsed) {
+                        run.skipped(leaf);
+                    } else {
+                        run.errored(
+                            leaf,
+                            new vscode.TestMessage(
+                                outcome.output.trim() || `phel test exited ${outcome.code}`
+                            )
+                        );
+                    }
+                    continue;
+                }
+                if (result.passed) {
+                    run.passed(leaf);
+                } else {
+                    run.failed(leaf, messageFor(result));
+                }
             }
         }
         run.end();
@@ -188,4 +268,13 @@ export class PhelTestController implements vscode.Disposable {
             d.dispose();
         }
     }
+}
+
+function findByName(byName: Map<string, AggregatedCase>, name: string): AggregatedCase | undefined {
+    for (const value of byName.values()) {
+        if (value.name === name) {
+            return value;
+        }
+    }
+    return undefined;
 }

--- a/src/test/junitParser.test.ts
+++ b/src/test/junitParser.test.ts
@@ -1,0 +1,103 @@
+import * as assert from 'node:assert/strict';
+import { groupByName, parseJUnit } from '../junitParser';
+
+// Captured verbatim from `phel test --reporter=junit-xml` (Phel v0.45.x):
+// one passing deftest with two assertions (two <testcase> rows) and one
+// failing deftest with one assertion.
+const REAL_XML =
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<testsuites tests="3" failures="1" errors="0" time="0.0">' +
+    '<testsuite name="jtest.sample-test" tests="3" failures="1" errors="0" time="0.0">' +
+    '<testcase name="test-passes" classname="" file="/abs/sample_test.phel" line="4"></testcase>' +
+    '<testcase name="test-passes" classname="" file="/abs/sample_test.phel" line="4"></testcase>' +
+    '<testcase name="test-fails" classname="" file="/abs/sample_test.phel" line="8">' +
+    '<failure message="one should equal two" type="AssertionFailed">(= 1 2)</failure>' +
+    '</testcase>' +
+    '</testsuite></testsuites>';
+
+describe('junitParser.parseJUnit', () => {
+    it('parses the real Phel reporter output', () => {
+        const cases = parseJUnit(REAL_XML);
+        assert.equal(cases.length, 3);
+        assert.equal(cases[0].name, 'test-passes');
+        assert.equal(cases[0].suite, 'jtest.sample-test');
+        assert.equal(cases[0].file, '/abs/sample_test.phel');
+        assert.equal(cases[0].line, 4);
+        assert.deepEqual(cases[0].failures, []);
+
+        assert.equal(cases[2].name, 'test-fails');
+        assert.equal(cases[2].line, 8);
+        assert.equal(cases[2].failures.length, 1);
+        assert.equal(cases[2].failures[0].message, 'one should equal two');
+        assert.equal(cases[2].failures[0].type, 'AssertionFailed');
+        assert.equal(cases[2].failures[0].detail, '(= 1 2)');
+        assert.equal(cases[2].failures[0].isError, false);
+    });
+
+    it('aggregates per-assertion rows by test name', () => {
+        const grouped = groupByName(parseJUnit(REAL_XML));
+        assert.equal(grouped.size, 2);
+        const passes = grouped.get('jtest.sample-test::test-passes');
+        assert.ok(passes);
+        assert.equal(passes.passed, true);
+        assert.equal(passes.failures.length, 0);
+
+        const fails = grouped.get('jtest.sample-test::test-fails');
+        assert.ok(fails);
+        assert.equal(fails.passed, false);
+        assert.equal(fails.failures.length, 1);
+    });
+
+    it('marks a test failed if any of its rows failed', () => {
+        const xml =
+            '<testsuites><testsuite name="ns">' +
+            '<testcase name="t" file="/f.phel" line="1"></testcase>' +
+            '<testcase name="t" file="/f.phel" line="1"><failure message="boom" type="AssertionFailed">(x)</failure></testcase>' +
+            '</testsuite></testsuites>';
+        const grouped = groupByName(parseJUnit(xml));
+        const t = grouped.get('ns::t');
+        assert.ok(t);
+        assert.equal(t.passed, false);
+        assert.equal(t.failures.length, 1);
+        assert.equal(t.failures[0].message, 'boom');
+    });
+
+    it('decodes XML entities in messages and detail', () => {
+        const xml =
+            '<testsuites><testsuite name="ns">' +
+            '<testcase name="t" file="/f.phel" line="1">' +
+            '<failure message="expected &lt;a&gt; &amp; &quot;b&quot;" type="T">(= &lt;a&gt; b)</failure>' +
+            '</testcase></testsuite></testsuites>';
+        const [c] = parseJUnit(xml);
+        assert.equal(c.failures[0].message, 'expected <a> & "b"');
+        assert.equal(c.failures[0].detail, '(= <a> b)');
+    });
+
+    it('handles <error> elements as errors', () => {
+        const xml =
+            '<testsuites><testsuite name="ns">' +
+            '<testcase name="t" file="/f.phel" line="1">' +
+            '<error message="kaboom" type="RuntimeException">stack</error>' +
+            '</testcase></testsuite></testsuites>';
+        const [c] = parseJUnit(xml);
+        assert.equal(c.failures[0].isError, true);
+        assert.equal(c.failures[0].message, 'kaboom');
+    });
+
+    it('handles self-closing testcase tags', () => {
+        const xml =
+            '<testsuites><testsuite name="ns">' +
+            '<testcase name="t" file="/f.phel" line="3"/>' +
+            '</testsuite></testsuites>';
+        const cases = parseJUnit(xml);
+        assert.equal(cases.length, 1);
+        assert.equal(cases[0].name, 't');
+        assert.equal(cases[0].line, 3);
+        assert.deepEqual(cases[0].failures, []);
+    });
+
+    it('returns an empty array for empty or malformed input', () => {
+        assert.deepEqual(parseJUnit(''), []);
+        assert.deepEqual(parseJUnit('not xml'), []);
+    });
+});


### PR DESCRIPTION
## What

The Test Explorer now reports **per-test** pass/fail with failure detail, instead of inferring a single outcome per run from the process exit code.

This satisfies the long-standing TODO in `phelTestController.ts`:

> We don't parse the textual output yet — when the Phel CLI gains structured (JSON / TAP) output we can attach per-assertion messages.

`phel test` now ships `--reporter=junit-xml`, so we can.

## How

- New module `src/junitParser.ts` parses Phel's JUnit XML (schema captured verbatim from the CLI). Phel emits **one `<testcase>` per assertion**, so rows share a `deftest` name; `groupByName()` aggregates them — a test passes only if none of its rows carried a `<failure>`/`<error>`. Handles entity decoding, `<error>` vs `<failure>`, and self-closing tags. Fully unit-tested (`src/test/junitParser.test.ts`, 7 cases).
- `phelTestController.ts` now runs `phel test --reporter=junit-xml -o <tmpfile> <file>` (one subprocess per file, every `deftest` in it), reads the **report file** (the XML is suppressed from stdout, and stdout otherwise carries a trailing `Time:` line), and maps results back to each `TestItem`:
  - passed → `run.passed`
  - failed → `run.failed` with the assertion **message** + the **failing form** + the assertion type
  - missing from the report → `run.skipped`
  - no report at all (e.g. a compile error) → `run.errored` with the captured output

## Verification

- **End-to-end against the real CLI**: ran `phel test --reporter=junit-xml -o run.xml <file>` on a fixture with a passing and a failing deftest, then fed the report through the compiled parser → `test-passes` passed, `test-fails` failed with message `one should equal two` and detail `(= 1 2)`. Exactly what the UI will show.
- `tsc --noEmit` clean, `eslint` clean, **299** tests pass (292 + 7 new), production bundle succeeds.

## Notes / follow-ups

- Discovery is still the regex `deftest` scan; this PR only changes result reporting.
- Coverage (`TestRunProfileKind.Coverage` via `--coverage=clover`) is the next PR (P4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)