### PR TITLE
fix(build): pin @types/vscode to 1.88.0 and raise engines to ^1.88.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Test Explorer
 
-- Add a "Run with Coverage" profile that runs `phel test --coverage=clover` and lights up native line coverage (gutter highlights + the Test Coverage view) from the Clover report, mapped back to `.phel` sources. Available on VS Code 1.88+ (the coverage API); older builds keep the plain Run profile. When neither pcov nor xdebug is installed, tests still run and a one-time warning explains why coverage is empty.
+- Add a "Run with Coverage" profile that runs `phel test --coverage=clover` and lights up native line coverage (gutter highlights + the Test Coverage view) from the Clover report, mapped back to `.phel` sources. When neither pcov nor xdebug is installed, tests still run and a one-time warning explains why coverage is empty.
+- Raise the minimum VS Code version to **1.88** (required for the test-coverage API).
 - Report per-test pass/fail in the Test Explorer by running `phel test --reporter=junit-xml` and parsing the JUnit report, instead of inferring a single pass/fail from the process exit code. Failing tests now show the assertion message and the failing form, and each file's tests run in one subprocess. Tests absent from the report are marked skipped.
 
 ### REPL & runtime

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Open Extensions (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>), search **"Phel L
 code --install-extension Phel-Lang.phel-lang
 ```
 
-Requires VS Code **1.75+**.
+Requires VS Code **1.88+**.
 
 ## Configuration
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Requires **VS Code 1.75+**. Published on the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Phel-Lang.phel-lang) under publisher `Phel-Lang`.
+Requires **VS Code 1.88+**. Published on the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Phel-Lang.phel-lang) under publisher `Phel-Lang`.
 
 ## Option 1 - Marketplace (recommended)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
             "devDependencies": {
                 "@types/mocha": "^10.0.6",
                 "@types/node": "^20.10.0",
-                "@types/vscode": "^1.125.0",
+                "@types/vscode": "1.88.0",
                 "@typescript-eslint/eslint-plugin": "^7.0.0",
                 "@typescript-eslint/parser": "^7.0.0",
                 "@vscode/vsce": "^3.0.0",
@@ -1284,9 +1284,9 @@
             "license": "MIT"
         },
         "node_modules/@types/vscode": {
-            "version": "1.125.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
-            "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+            "version": "1.88.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.88.0.tgz",
+            "integrity": "sha512-rWY+Bs6j/f1lvr8jqZTyp5arRMfovdxolcqGi+//+cPDOh8SBvzXH90e7BiSXct5HJ9HGW6jATchbRTpTJpEkw==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "publisher": "Phel-Lang",
     "license": "MIT",
     "engines": {
-        "vscode": "^1.75.0"
+        "vscode": "^1.88.0"
     },
     "categories": [
         "Programming Languages",
@@ -533,7 +533,7 @@
     "devDependencies": {
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.10.0",
-        "@types/vscode": "^1.125.0",
+        "@types/vscode": "1.88.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "@vscode/vsce": "^3.0.0",


### PR DESCRIPTION
## Problem

The coverage PR (#66) bumped `@types/vscode` to `^1.88.0`, which npm resolved up to `1.125.0`, while `engines.vscode` stayed `^1.75.0`. `vsce package` rejects that combination:

```
@types/vscode ^1.125.0 greater than engines.vscode ^1.75.0.
Either upgrade engines.vscode or use an older @types/vscode version
```

This broke the **`vsce package (sanity)`** CI step on `main` (Node 20 and 22). The local gate (tsc/eslint/mocha/esbuild) didn't catch it because it doesn't run `vsce package`.

## Fix

- Pin `@types/vscode` to **exactly `1.88.0`** (no caret) so it can't float above the engine again.
- Raise `engines.vscode` to **`^1.88.0`** so the two agree. 1.88 is also the floor for the test-coverage API the extension started using in #66, so this is the correct minimum regardless.
- Update the documented minimum (README, docs/installation.md) to 1.88.

## Verification

- Reproduced the failure locally, then confirmed **`vsce package` now succeeds** (`Packaged: phel-lang.vsix`).
- `tsc --noEmit` clean (1.88.0 types still expose `FileCoverage`/`StatementCoverage`/`TestRunProfileKind.Coverage`), `eslint` clean, **305** tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)