### PR TITLE
feat(commands): wrap phel test --watch, build, and init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Commands
 
 - Add **Phel: Doctor** (`phel doctor`) for project/environment health, and **Phel: Show Effective Configuration** (`phel config`).
+- Add **Phel: Watch Tests** (`phel test --watch`), **Phel: Build** (`phel build`, with optimization-level / report prompts), and **Phel: Init Project** (`phel init`, with a template picker).
 
 ### Language support
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ VS Code support for [Phel](https://phel-lang.org/), a functional Lisp that compi
 - **Test Explorer + CodeLens** for `deftest`, with per-test results and a **Run with Coverage** profile (`phel test --coverage=clover`, VS Code 1.88+).
 - **Paredit**: slurp / barf / raise / wrap, sexp selection.
 - **Native debug adapter** with breakpoints in `.phel` files.
-- **Project health** commands: **Phel: Doctor** (`phel doctor`) and **Phel: Show Effective Configuration** (`phel config`).
+- **CLI commands**: Doctor (`phel doctor`), Show Effective Configuration (`phel config`), Watch Tests, Build, and Init Project (with a template picker).
 - **Snippets** for `defn`, `let`, `cond`, `try`, `deftest`, `->`, …
 
 ## Install

--- a/package.json
+++ b/package.json
@@ -212,6 +212,21 @@
                 "category": "Phel"
             },
             {
+                "command": "phel.test.watch",
+                "title": "Phel: Watch Tests",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.build",
+                "title": "Phel: Build",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.init",
+                "title": "Phel: Init Project",
+                "category": "Phel"
+            },
+            {
                 "command": "phel.paredit.slurpForward",
                 "title": "Phel: Slurp Forward",
                 "category": "Phel"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,7 @@ import { registerPareditCommands } from './phelPareditProvider';
 import { registerReplCommands } from './phelReplProvider';
 import { registerNreplCommands } from './phelNreplProvider';
 import { registerDoctorCommands } from './phelDoctorProvider';
+import { registerCliCommands } from './phelCliCommandsProvider';
 import { registerSelectionCommands } from './phelSelectionProvider';
 import { PhelFormHighlight } from './phelFormHighlight';
 import { PhelInlineValuesProvider } from './phelInlineValuesProvider';
@@ -187,6 +188,8 @@ export function activate(context: vscode.ExtensionContext) {
     registerSelectionCommands(context);
 
     registerDoctorCommands(context);
+
+    registerCliCommands(context);
 
     void new PhelStatusBar().start(context);
 

--- a/src/phelCliCommands.ts
+++ b/src/phelCliCommands.ts
@@ -1,0 +1,54 @@
+// Pure helpers for the Phel CLI command wrappers (template parsing, build
+// args). Kept free of `vscode` so they can be unit-tested.
+
+export interface PhelTemplate {
+    name: string;
+    description: string;
+}
+
+/**
+ * Parse the output of `phel init --list-templates`. Each template line looks
+ * like `  <name> - <description>`; the surrounding banner lines are ignored.
+ */
+export function parseTemplates(output: string): PhelTemplate[] {
+    const templates: PhelTemplate[] = [];
+    for (const rawLine of output.split(/\r?\n/)) {
+        const line = rawLine.trimEnd();
+        // Template rows are indented; skip headings/blank/usage lines.
+        if (!/^\s{2,}\S/.test(line)) {
+            continue;
+        }
+        const trimmed = line.trim();
+        const sep = trimmed.indexOf(' - ');
+        if (sep < 0) {
+            // A bare template name with no description.
+            if (/^[A-Za-z0-9._-]+$/.test(trimmed)) {
+                templates.push({ name: trimmed, description: '' });
+            }
+            continue;
+        }
+        const name = trimmed.slice(0, sep).trim();
+        const description = trimmed.slice(sep + 3).trim();
+        if (/^[A-Za-z0-9._-]+$/.test(name)) {
+            templates.push({ name, description });
+        }
+    }
+    return templates;
+}
+
+export type OptimizationLevel = '0' | '2';
+
+/** Build the argument list for `phel build`. */
+export function buildArgs(options: {
+    optimizationLevel?: OptimizationLevel;
+    report?: boolean;
+}): string[] {
+    const args = ['build'];
+    if (options.optimizationLevel !== undefined) {
+        args.push('-O', options.optimizationLevel);
+    }
+    if (options.report) {
+        args.push('--report');
+    }
+    return args;
+}

--- a/src/phelCliCommandsProvider.ts
+++ b/src/phelCliCommandsProvider.ts
@@ -1,0 +1,150 @@
+// Thin wrappers around long-running / interactive Phel CLI commands:
+//
+//   phel.test.watch  — `phel test --watch` in a terminal
+//   phel.build       — `phel build` with an optimization-level / report prompt
+//   phel.init        — `phel init <name> --template=<t>` with template picker
+//
+// These run in an integrated terminal (they are long-running or scaffold files
+// the user wants to see), matching the existing terminal-based test commands.
+
+import { spawn } from 'node:child_process';
+import * as vscode from 'vscode';
+import { resolvePhelExecutable } from './phelExecutable';
+import {
+    buildArgs,
+    type OptimizationLevel,
+    parseTemplates,
+    type PhelTemplate,
+} from './phelCliCommands';
+
+function activeFolder(): vscode.WorkspaceFolder | undefined {
+    const doc = vscode.window.activeTextEditor?.document;
+    if (doc && doc.uri.scheme === 'file') {
+        const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+        if (folder) {
+            return folder;
+        }
+    }
+    return vscode.workspace.workspaceFolders?.[0];
+}
+
+function quote(arg: string): string {
+    return /[\s"'$`\\]/.test(arg) ? `'${arg.replace(/'/g, "'\\''")}'` : arg;
+}
+
+function runInTerminal(name: string, command: string, args: string[], cwd: string): void {
+    const terminal = vscode.window.createTerminal({ name, cwd });
+    terminal.show(true);
+    terminal.sendText([command, ...args].map(quote).join(' '));
+}
+
+function testWatch(): void {
+    const folder = activeFolder();
+    if (!folder) {
+        vscode.window.showWarningMessage('Open a Phel project folder first.');
+        return;
+    }
+    const command = resolvePhelExecutable('test.command', folder);
+    runInTerminal('Phel Test (watch)', command, ['test', '--watch'], folder.uri.fsPath);
+}
+
+async function build(): Promise<void> {
+    const folder = activeFolder();
+    if (!folder) {
+        vscode.window.showWarningMessage('Open a Phel project folder first.');
+        return;
+    }
+    const level = await vscode.window.showQuickPick(
+        [
+            {
+                label: 'Default',
+                description: 'Use the level from phel-config.php',
+                value: undefined,
+            },
+            { label: '-O0', description: 'Optimization off', value: '0' as OptimizationLevel },
+            {
+                label: '-O2',
+                description: 'Inline + tail-call rewrite',
+                value: '2' as OptimizationLevel,
+            },
+        ],
+        { placeHolder: 'Optimization level for phel build' }
+    );
+    if (level === undefined) {
+        return; // cancelled
+    }
+    const report = await vscode.window.showQuickPick(
+        [
+            { label: 'No report', value: false },
+            { label: 'Print build report', value: true },
+        ],
+        { placeHolder: 'Print a build report (namespace count, sizes, time)?' }
+    );
+    if (report === undefined) {
+        return; // cancelled
+    }
+    const command = resolvePhelExecutable('diagnostics.command', folder);
+    const args = buildArgs({ optimizationLevel: level.value, report: report.value });
+    runInTerminal('Phel Build', command, args, folder.uri.fsPath);
+}
+
+function listTemplates(command: string, cwd: string): Promise<PhelTemplate[]> {
+    return new Promise((resolve) => {
+        const proc = spawn(command, ['init', '--list-templates'], { cwd });
+        let output = '';
+        proc.stdout?.on('data', (d) => (output += d.toString()));
+        proc.stderr?.on('data', (d) => (output += d.toString()));
+        proc.on('close', () => resolve(parseTemplates(output)));
+        proc.on('error', () => resolve([]));
+    });
+}
+
+async function init(): Promise<void> {
+    const folder = activeFolder();
+    const cwd = folder?.uri.fsPath ?? process.cwd();
+    const command = resolvePhelExecutable('diagnostics.command', folder);
+
+    const templates = await vscode.window.withProgress(
+        { location: vscode.ProgressLocation.Window, title: 'Loading Phel templates…' },
+        () => listTemplates(command, cwd)
+    );
+
+    const items: (vscode.QuickPickItem & { template?: string })[] = [
+        { label: 'Default project', description: 'phel init (no template)' },
+        ...templates.map((t) => ({ label: t.name, description: t.description, template: t.name })),
+    ];
+    const picked = await vscode.window.showQuickPick(items, {
+        placeHolder: 'Project template',
+    });
+    if (!picked) {
+        return;
+    }
+
+    const projectName = await vscode.window.showInputBox({
+        prompt: 'Project name (creates a subdirectory; leave empty for the default "app")',
+        validateInput: (value) =>
+            value && !/^[A-Za-z0-9._-]+$/.test(value)
+                ? 'Use letters, numbers, dots, dashes or underscores.'
+                : undefined,
+    });
+    if (projectName === undefined) {
+        return; // cancelled
+    }
+
+    const args = ['init'];
+    if (projectName.trim()) {
+        args.push(projectName.trim());
+    }
+    if (picked.template) {
+        args.push(`--template=${picked.template}`);
+    }
+    runInTerminal('Phel Init', command, args, cwd);
+}
+
+export function registerCliCommands(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand('phel.test.watch', testWatch),
+        vscode.commands.registerCommand('phel.build', build),
+        vscode.commands.registerCommand('phel.init', init)
+    );
+}

--- a/src/test/phelCliCommands.test.ts
+++ b/src/test/phelCliCommands.test.ts
@@ -1,0 +1,71 @@
+import * as assert from 'node:assert/strict';
+import { buildArgs, parseTemplates } from '../phelCliCommands';
+
+// Captured verbatim from `phel init --list-templates`.
+const LIST_OUTPUT = [
+    'Available templates:',
+    '  http-json-api - Minimal HTTP JSON API (phel\\http routing, handlers, public/index.php)',
+    '  todo-app - HTTP todo app with an in-memory store and route handlers',
+    '  cli-wordcount - CLI word-count tool reading stdin or file arguments',
+    '',
+    'Scaffold one with: phel init my-app --template=<name>',
+].join('\n');
+
+describe('phelCliCommands.parseTemplates', () => {
+    it('parses the real --list-templates output', () => {
+        const templates = parseTemplates(LIST_OUTPUT);
+        assert.deepEqual(
+            templates.map((t) => t.name),
+            ['http-json-api', 'todo-app', 'cli-wordcount']
+        );
+        assert.equal(
+            templates[0].description,
+            'Minimal HTTP JSON API (phel\\http routing, handlers, public/index.php)'
+        );
+        assert.equal(
+            templates[2].description,
+            'CLI word-count tool reading stdin or file arguments'
+        );
+    });
+
+    it('ignores the heading and the usage footer', () => {
+        const templates = parseTemplates(LIST_OUTPUT);
+        assert.equal(templates.length, 3);
+        assert.ok(!templates.some((t) => t.name.includes('Scaffold')));
+        assert.ok(!templates.some((t) => t.name === 'Available'));
+    });
+
+    it('handles a bare template name with no description', () => {
+        const templates = parseTemplates('Available templates:\n  minimal\n');
+        assert.deepEqual(templates, [{ name: 'minimal', description: '' }]);
+    });
+
+    it('returns an empty array when nothing matches', () => {
+        assert.deepEqual(parseTemplates(''), []);
+        assert.deepEqual(parseTemplates('No templates found.'), []);
+    });
+});
+
+describe('phelCliCommands.buildArgs', () => {
+    it('returns just "build" with no options', () => {
+        assert.deepEqual(buildArgs({}), ['build']);
+    });
+
+    it('adds -O with the optimization level', () => {
+        assert.deepEqual(buildArgs({ optimizationLevel: '2' }), ['build', '-O', '2']);
+        assert.deepEqual(buildArgs({ optimizationLevel: '0' }), ['build', '-O', '0']);
+    });
+
+    it('adds --report', () => {
+        assert.deepEqual(buildArgs({ report: true }), ['build', '--report']);
+    });
+
+    it('combines optimization level and report', () => {
+        assert.deepEqual(buildArgs({ optimizationLevel: '2', report: true }), [
+            'build',
+            '-O',
+            '2',
+            '--report',
+        ]);
+    });
+});


### PR DESCRIPTION
## What

Three command wrappers around interactive / long-running Phel CLI commands:

- **Phel: Watch Tests** — `phel test --watch` in a terminal.
- **Phel: Build** — `phel build` with optimization-level (`-O0` / `-O2`) and build-report prompts.
- **Phel: Init Project** — lists templates via `phel init --list-templates`, shows a picker (`http-json-api`, `todo-app`, `cli-wordcount`), asks for a project name, then runs `phel init`.

## How

- `src/phelCliCommands.ts` — pure, unit-tested helpers: `parseTemplates()` (parses the real `--list-templates` output) and `buildArgs()`. (`src/test/phelCliCommands.test.ts`, 8 cases.)
- `src/phelCliCommandsProvider.ts` — registers the commands; they run in an integrated terminal (consistent with the existing terminal-based test commands), with args shell-quoted.

## Verification

- Template/flag formats captured from the real CLI (`-O 0|2`, `--report`, the `  <name> - <desc>` template rows).
- `tsc`/`eslint` clean, **313** tests pass (305 + 8 new), and `vsce package` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)