### PR TITLE
refactor(src): extract shared helpers, harden nREPL, parallelize test load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
 - Add `php/callable` (first-class callable interop) to the `php/*` completion list.
 - Rename `argv` → `*argv*`.
 
+### Internal
+
+- Deduplicate shared logic into focused modules: `xml` (attribute/entity/int parsing used by the JUnit and Clover parsers), `phelCli` (one-shot CLI spawn + output collection), `phelWorkspace` (active-folder resolution), and `phelTerminal` (terminal launch + shell quoting). Harden the nREPL reader against malformed frames and reap the server process on socket close; read test files concurrently when populating the Test Explorer.
+
 ## [0.8.0] - 2026-06-05
 
 ### Language support

--- a/src/bencode.ts
+++ b/src/bencode.ts
@@ -20,6 +20,12 @@ const DICT = 0x64; // 'd'
 const ZERO = 0x30; // '0'
 const NINE = 0x39; // '9'
 
+// Structural bytes are never mutated, so they're allocated once and shared
+// across every encode call.
+const BUF_LIST = Buffer.from('l');
+const BUF_DICT = Buffer.from('d');
+const BUF_END = Buffer.from('e');
+
 export function encode(value: BencodeValue): Buffer {
     const parts: Buffer[] = [];
     encodeInto(value, parts);
@@ -40,20 +46,20 @@ function encodeInto(value: BencodeValue, out: Buffer[]): void {
         return;
     }
     if (Array.isArray(value)) {
-        out.push(Buffer.from('l', 'utf-8'));
+        out.push(BUF_LIST);
         for (const item of value) {
             encodeInto(item, out);
         }
-        out.push(Buffer.from('e', 'utf-8'));
+        out.push(BUF_END);
         return;
     }
     // dictionary — keys sorted lexicographically per the spec
-    out.push(Buffer.from('d', 'utf-8'));
+    out.push(BUF_DICT);
     for (const key of Object.keys(value).sort()) {
         encodeInto(key, out);
         encodeInto(value[key], out);
     }
-    out.push(Buffer.from('e', 'utf-8'));
+    out.push(BUF_END);
 }
 
 export interface DecodeResult {

--- a/src/cloverParser.ts
+++ b/src/cloverParser.ts
@@ -16,6 +16,8 @@
 // `count` is binary (0 = not executed, 1 = executed) and `num` is a 1-based
 // line number into the `.phel` source named by the enclosing `<file>`.
 
+import { decodeEntities, readAttr as attr, toInt } from './xml';
+
 export interface CloverLine {
     /** 1-based line number. */
     line: number;
@@ -85,30 +87,4 @@ function lastMetrics(body: string): { statements?: number; coveredStatements?: n
     const statements = toInt(attr(last, 'statements'));
     const coveredStatements = toInt(attr(last, 'coveredstatements'));
     return { statements, coveredStatements };
-}
-
-function toInt(value: string | undefined): number | undefined {
-    if (value === undefined) {
-        return undefined;
-    }
-    const n = Number.parseInt(value, 10);
-    return Number.isFinite(n) ? n : undefined;
-}
-
-function attr(attrs: string, name: string): string | undefined {
-    const re = new RegExp(`\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)')`);
-    const m = re.exec(attrs);
-    if (!m) {
-        return undefined;
-    }
-    return m[2] ?? m[3] ?? '';
-}
-
-function decodeEntities(text: string): string {
-    return text
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .replace(/&quot;/g, '"')
-        .replace(/&apos;/g, "'")
-        .replace(/&amp;/g, '&');
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ import { registerReplCommands } from './phelReplProvider';
 import { registerNreplCommands } from './phelNreplProvider';
 import { registerDoctorCommands } from './phelDoctorProvider';
 import { registerCliCommands } from './phelCliCommandsProvider';
+import { runInTerminal } from './phelTerminal';
 import { registerSelectionCommands } from './phelSelectionProvider';
 import { PhelFormHighlight } from './phelFormHighlight';
 import { PhelInlineValuesProvider } from './phelInlineValuesProvider';
@@ -368,9 +369,7 @@ function runPhelTests(uri?: vscode.Uri, testName?: string): void {
         args.push('--filter', testName);
     }
     args.push(filePath);
-    const terminal = vscode.window.createTerminal({ name: 'Phel Tests', cwd });
-    terminal.show(true);
-    terminal.sendText(`${command} ${args.join(' ')}`);
+    runInTerminal('Phel Tests', command, args, cwd);
 }
 
 async function pickSymbol(): Promise<string | undefined> {

--- a/src/junitParser.ts
+++ b/src/junitParser.ts
@@ -16,6 +16,8 @@
 // several rows that share `name`/`file`/`line`; rows carry a `<failure>` only
 // when that assertion failed. Callers aggregate by name (see groupByName).
 
+import { decodeEntities, readAttr as attr } from './xml';
+
 export interface JUnitFailure {
     message: string;
     type: string;
@@ -92,29 +94,6 @@ function parseFailures(body: string): JUnitFailure[] {
         });
     }
     return failures;
-}
-
-/** Read a double- or single-quoted attribute value (raw, not entity-decoded). */
-function attr(attrs: string, name: string): string | undefined {
-    const re = new RegExp(`\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)')`);
-    const m = re.exec(attrs);
-    if (!m) {
-        return undefined;
-    }
-    return m[2] ?? m[3] ?? '';
-}
-
-function decodeEntities(text: string): string {
-    return text
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .replace(/&quot;/g, '"')
-        .replace(/&apos;/g, "'")
-        .replace(/&#(\d+);/g, (_, code: string) => String.fromCodePoint(Number.parseInt(code, 10)))
-        .replace(/&#x([0-9a-fA-F]+);/g, (_, code: string) =>
-            String.fromCodePoint(Number.parseInt(code, 16))
-        )
-        .replace(/&amp;/g, '&'); // last, so we don't double-decode
 }
 
 export interface AggregatedCase {

--- a/src/phelCli.ts
+++ b/src/phelCli.ts
@@ -1,0 +1,48 @@
+// Shared helper for running a one-shot Phel CLI command and collecting its
+// output. Long-running / streaming servers (nrepl, lsp, test --watch) and the
+// Test Explorer's per-file run have bespoke spawn logic; this covers the
+// common "run it, wait, read stdout/stderr/exit-code" case.
+
+import { spawn } from 'node:child_process';
+import * as vscode from 'vscode';
+
+export interface PhelCliResult {
+    code: number;
+    stdout: string;
+    stderr: string;
+}
+
+export interface RunPhelCliOptions {
+    /** Called with each stdout chunk as it arrives (e.g. to stream into a channel). */
+    onStdout?: (chunk: string) => void;
+    /** Kills the process when cancelled. */
+    token?: vscode.CancellationToken;
+}
+
+/**
+ * Spawn `command args` in `cwd`, resolving once it exits. Never rejects:
+ * a spawn error resolves with code 1 and the error text in `stderr`.
+ */
+export function runPhelCli(
+    command: string,
+    args: readonly string[],
+    cwd: string,
+    options: RunPhelCliOptions = {}
+): Promise<PhelCliResult> {
+    return new Promise((resolve) => {
+        const proc = spawn(command, [...args], { cwd });
+        let stdout = '';
+        let stderr = '';
+        proc.stdout?.on('data', (d) => {
+            const text = d.toString();
+            stdout += text;
+            options.onStdout?.(text);
+        });
+        proc.stderr?.on('data', (d) => {
+            stderr += d.toString();
+        });
+        proc.on('close', (code) => resolve({ code: code ?? 1, stdout, stderr }));
+        proc.on('error', (err) => resolve({ code: 1, stdout, stderr: err.message }));
+        options.token?.onCancellationRequested(() => proc.kill());
+    });
+}

--- a/src/phelCliCommands.ts
+++ b/src/phelCliCommands.ts
@@ -1,5 +1,10 @@
 // Pure helpers for the Phel CLI command wrappers (template parsing, build
-// args). Kept free of `vscode` so they can be unit-tested.
+// args, shell quoting). Kept free of `vscode` so they can be unit-tested.
+
+/** POSIX-quote a single argument so paths/names with spaces survive the shell. */
+export function shellQuote(arg: string): string {
+    return /[\s"'$`\\]/.test(arg) ? `'${arg.replace(/'/g, "'\\''")}'` : arg;
+}
 
 export interface PhelTemplate {
     name: string;

--- a/src/phelCliCommandsProvider.ts
+++ b/src/phelCliCommandsProvider.ts
@@ -7,9 +7,11 @@
 // These run in an integrated terminal (they are long-running or scaffold files
 // the user wants to see), matching the existing terminal-based test commands.
 
-import { spawn } from 'node:child_process';
 import * as vscode from 'vscode';
 import { resolvePhelExecutable } from './phelExecutable';
+import { runPhelCli } from './phelCli';
+import { runInTerminal } from './phelTerminal';
+import { activeWorkspaceFolder } from './phelWorkspace';
 import {
     buildArgs,
     type OptimizationLevel,
@@ -17,29 +19,8 @@ import {
     type PhelTemplate,
 } from './phelCliCommands';
 
-function activeFolder(): vscode.WorkspaceFolder | undefined {
-    const doc = vscode.window.activeTextEditor?.document;
-    if (doc && doc.uri.scheme === 'file') {
-        const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
-        if (folder) {
-            return folder;
-        }
-    }
-    return vscode.workspace.workspaceFolders?.[0];
-}
-
-function quote(arg: string): string {
-    return /[\s"'$`\\]/.test(arg) ? `'${arg.replace(/'/g, "'\\''")}'` : arg;
-}
-
-function runInTerminal(name: string, command: string, args: string[], cwd: string): void {
-    const terminal = vscode.window.createTerminal({ name, cwd });
-    terminal.show(true);
-    terminal.sendText([command, ...args].map(quote).join(' '));
-}
-
 function testWatch(): void {
-    const folder = activeFolder();
+    const folder = activeWorkspaceFolder();
     if (!folder) {
         vscode.window.showWarningMessage('Open a Phel project folder first.');
         return;
@@ -49,7 +30,7 @@ function testWatch(): void {
 }
 
 async function build(): Promise<void> {
-    const folder = activeFolder();
+    const folder = activeWorkspaceFolder();
     if (!folder) {
         vscode.window.showWarningMessage('Open a Phel project folder first.');
         return;
@@ -83,26 +64,22 @@ async function build(): Promise<void> {
     if (report === undefined) {
         return; // cancelled
     }
-    const command = resolvePhelExecutable('diagnostics.command', folder);
+    // build has no per-command override; resolve from phel.executablePath.
+    const command = resolvePhelExecutable(undefined, folder);
     const args = buildArgs({ optimizationLevel: level.value, report: report.value });
     runInTerminal('Phel Build', command, args, folder.uri.fsPath);
 }
 
-function listTemplates(command: string, cwd: string): Promise<PhelTemplate[]> {
-    return new Promise((resolve) => {
-        const proc = spawn(command, ['init', '--list-templates'], { cwd });
-        let output = '';
-        proc.stdout?.on('data', (d) => (output += d.toString()));
-        proc.stderr?.on('data', (d) => (output += d.toString()));
-        proc.on('close', () => resolve(parseTemplates(output)));
-        proc.on('error', () => resolve([]));
-    });
+async function listTemplates(command: string, cwd: string): Promise<PhelTemplate[]> {
+    const result = await runPhelCli(command, ['init', '--list-templates'], cwd);
+    return parseTemplates(result.stdout + result.stderr);
 }
 
 async function init(): Promise<void> {
-    const folder = activeFolder();
+    const folder = activeWorkspaceFolder();
     const cwd = folder?.uri.fsPath ?? process.cwd();
-    const command = resolvePhelExecutable('diagnostics.command', folder);
+    // init has no per-command override; resolve from phel.executablePath.
+    const command = resolvePhelExecutable(undefined, folder);
 
     const templates = await vscode.window.withProgress(
         { location: vscode.ProgressLocation.Window, title: 'Loading Phel templates…' },

--- a/src/phelDoctorProvider.ts
+++ b/src/phelDoctorProvider.ts
@@ -5,9 +5,10 @@
 //   phel.showConfig  — run `phel config --format=json` and open the effective
 //                      configuration as a pretty-printed JSON document.
 
-import { spawn } from 'node:child_process';
 import * as vscode from 'vscode';
 import { resolvePhelExecutable } from './phelExecutable';
+import { runPhelCli } from './phelCli';
+import { activeWorkspaceFolder } from './phelWorkspace';
 
 const OUTPUT_CHANNEL_NAME = 'Phel Doctor';
 
@@ -18,49 +19,18 @@ function channel(): vscode.OutputChannel {
     return output;
 }
 
-function activeFolder(): vscode.WorkspaceFolder | undefined {
-    const doc = vscode.window.activeTextEditor?.document;
-    if (doc && doc.uri.scheme === 'file') {
-        const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
-        if (folder) {
-            return folder;
-        }
-    }
-    return vscode.workspace.workspaceFolders?.[0];
-}
-
-interface RunResult {
-    code: number;
-    stdout: string;
-    stderr: string;
-}
-
 function runPhel(
     args: string[],
     folder: vscode.WorkspaceFolder,
     onStdout?: (chunk: string) => void
-): Promise<RunResult> {
-    return new Promise((resolve) => {
-        // doctor/config follow the same executable precedence as diagnostics.
-        const command = resolvePhelExecutable('diagnostics.command', folder);
-        const proc = spawn(command, args, { cwd: folder.uri.fsPath });
-        let stdout = '';
-        let stderr = '';
-        proc.stdout?.on('data', (d) => {
-            const text = d.toString();
-            stdout += text;
-            onStdout?.(text);
-        });
-        proc.stderr?.on('data', (d) => {
-            stderr += d.toString();
-        });
-        proc.on('close', (code) => resolve({ code: code ?? 1, stdout, stderr }));
-        proc.on('error', (err) => resolve({ code: 1, stdout, stderr: err.message }));
-    });
+): ReturnType<typeof runPhelCli> {
+    // doctor/config have no per-command override; resolve from phel.executablePath.
+    const command = resolvePhelExecutable(undefined, folder);
+    return runPhelCli(command, args, folder.uri.fsPath, { onStdout });
 }
 
 async function runDoctor(): Promise<void> {
-    const folder = activeFolder();
+    const folder = activeWorkspaceFolder();
     if (!folder) {
         vscode.window.showWarningMessage('Open a Phel project folder first.');
         return;
@@ -91,7 +61,7 @@ async function runDoctor(): Promise<void> {
 }
 
 async function showConfig(): Promise<void> {
-    const folder = activeFolder();
+    const folder = activeWorkspaceFolder();
     if (!folder) {
         vscode.window.showWarningMessage('Open a Phel project folder first.');
         return;

--- a/src/phelExecutable.ts
+++ b/src/phelExecutable.ts
@@ -28,15 +28,18 @@ export const PHEL_EXECUTABLE_SETTINGS: readonly string[] = [
  *
  * Precedence: per-command override (`phel.<subsystem>`) → workspace fallback
  * (`phel.executablePath`) → built-in default (`vendor/bin/phel`).
+ *
+ * Pass `undefined` for commands without their own override (doctor, config,
+ * build, init) to resolve straight from `phel.executablePath`.
  */
 export function resolvePhelExecutable(
-    subsystem: PhelExecutableSubsystem,
+    subsystem: PhelExecutableSubsystem | undefined,
     folder: vscode.WorkspaceFolder | undefined
 ): string {
     const config = vscode.workspace.getConfiguration('phel', folder);
     const cwd = folder?.uri.fsPath ?? process.cwd();
     return resolveExecutablePath(
-        explicitString(config, subsystem),
+        subsystem !== undefined ? explicitString(config, subsystem) : undefined,
         explicitString(config, FALLBACK_KEY),
         cwd
     );

--- a/src/phelNreplClient.ts
+++ b/src/phelNreplClient.ts
@@ -153,7 +153,20 @@ export class PhelNreplConnection {
 
     private onSocketData(chunk: Buffer): void {
         this.buffer = Buffer.concat([this.buffer, chunk]);
-        const { values, consumed } = decode(this.buffer);
+        let values;
+        let consumed;
+        try {
+            ({ values, consumed } = decode(this.buffer));
+        } catch (err) {
+            // A malformed frame would otherwise throw out of this 'data' handler
+            // as an unhandled error and hang every pending op. Recover instead:
+            // log, drop the corrupt buffer, and reject in-flight ops.
+            const message = err instanceof Error ? err.message : String(err);
+            this.output.appendLine(`nREPL: discarding malformed frame (${message}).`);
+            this.buffer = Buffer.alloc(0);
+            this.failAllPending(new Error(`nREPL protocol error: ${message}`));
+            return;
+        }
         if (consumed > 0) {
             this.buffer = this.buffer.subarray(consumed);
         }
@@ -284,6 +297,12 @@ export class PhelNreplConnection {
         }
         this.failAllPending(new Error('nREPL connection closed.'));
         this.sessionId = '';
+        // Reap the server process if it outlived the socket so it isn't orphaned
+        // until the next explicit disconnect.
+        if (this.proc && !this.proc.killed) {
+            this.proc.kill();
+        }
+        this.proc = undefined;
     }
 
     dispose(): void {

--- a/src/phelNreplProvider.ts
+++ b/src/phelNreplProvider.ts
@@ -19,6 +19,7 @@ import * as vscode from 'vscode';
 import { type OpResult, PhelNreplConnection } from './phelNreplClient';
 import { parseNsForm } from './phelNsAnalyzer';
 import { topLevelFormAt } from './phelRepl';
+import { folderForDocument as folderForDoc } from './phelWorkspace';
 
 const OUTPUT_CHANNEL_NAME = 'Phel nREPL';
 const DEFTEST_HEAD_RE = /^\(deftest\s+(?:\^\S+\s+)*([^\s()[\]{}]+)/;
@@ -30,13 +31,6 @@ const connecting = new Map<string, Promise<PhelNreplConnection>>();
 function channel(): vscode.OutputChannel {
     output ??= vscode.window.createOutputChannel(OUTPUT_CHANNEL_NAME);
     return output;
-}
-
-function folderForDoc(doc?: vscode.TextDocument): vscode.WorkspaceFolder | undefined {
-    if (doc && doc.uri.scheme === 'file') {
-        return vscode.workspace.getWorkspaceFolder(doc.uri) ?? undefined;
-    }
-    return vscode.workspace.workspaceFolders?.[0];
 }
 
 async function getConnection(

--- a/src/phelReplProvider.ts
+++ b/src/phelReplProvider.ts
@@ -16,6 +16,7 @@ import * as vscode from 'vscode';
 import { resolvePhelExecutable } from './phelExecutable';
 import { parseNsForm } from './phelNsAnalyzer';
 import { flattenForTerminal, nextTopLevelFormAfter, topLevelFormAt } from './phelRepl';
+import { folderForDocument as workspaceFolderForDoc } from './phelWorkspace';
 
 const REPL_TERMINAL_NAME = 'Phel REPL';
 const HISTORY_FILE = '.vscode/phel-repl-history.phel';
@@ -25,13 +26,6 @@ interface ReplCommandConfig {
     command: string;
     args: readonly string[];
     cwd: string;
-}
-
-function workspaceFolderForDoc(doc?: vscode.TextDocument): vscode.WorkspaceFolder | undefined {
-    if (doc && doc.uri.scheme === 'file') {
-        return vscode.workspace.getWorkspaceFolder(doc.uri) ?? undefined;
-    }
-    return vscode.workspace.workspaceFolders?.[0];
 }
 
 function resolveCommand(folder: vscode.WorkspaceFolder | undefined): ReplCommandConfig {

--- a/src/phelTerminal.ts
+++ b/src/phelTerminal.ts
@@ -1,0 +1,18 @@
+// Shared helpers for running a Phel CLI command in an integrated terminal
+// (used for interactive / long-running commands: REPL, test runs, watch,
+// build, init).
+
+import * as vscode from 'vscode';
+import { shellQuote } from './phelCliCommands';
+
+/** Open (or reuse a freshly created) terminal and run `command args` in `cwd`. */
+export function runInTerminal(
+    name: string,
+    command: string,
+    args: readonly string[],
+    cwd: string
+): void {
+    const terminal = vscode.window.createTerminal({ name, cwd });
+    terminal.show(true);
+    terminal.sendText([command, ...args].map(shellQuote).join(' '));
+}

--- a/src/phelTestController.ts
+++ b/src/phelTestController.ts
@@ -7,12 +7,12 @@
 // and (for the failing form) detail. Tests not present in the report are
 // marked skipped.
 
-import { spawn } from 'node:child_process';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 import * as vscode from 'vscode';
 import { resolvePhelExecutable } from './phelExecutable';
+import { runPhelCli } from './phelCli';
 import { findDeftests } from './phelTestScanner';
 import { type AggregatedCase, groupByName, parseJUnit } from './junitParser';
 import { type CloverFile, parseClover } from './cloverParser';
@@ -72,12 +72,13 @@ function attachItems(
 
 async function loadAllTests(controller: vscode.TestController): Promise<void> {
     const uris = await vscode.workspace.findFiles('**/*.phel', '**/node_modules/**');
-    for (const uri of uris) {
-        const text = await readFile(uri);
-        if (text === null) {
-            continue;
+    // Read files concurrently; attach serially afterwards (attachItems mutates
+    // the controller and is cheap/synchronous).
+    const read = await Promise.all(uris.map(async (uri) => ({ uri, text: await readFile(uri) })));
+    for (const { uri, text } of read) {
+        if (text !== null) {
+            attachItems(controller, uri, text);
         }
-        attachItems(controller, uri, text);
     }
 }
 
@@ -124,15 +125,8 @@ async function runPhelTestFile(
     }
     args.push(relPath);
 
-    const outcome = await new Promise<{ code: number; output: string }>((resolve) => {
-        const proc = spawn(cmd.command, args, { cwd: cmd.cwd });
-        let output = '';
-        proc.stdout?.on('data', (d) => (output += d.toString()));
-        proc.stderr?.on('data', (d) => (output += d.toString()));
-        proc.on('close', (code) => resolve({ code: code ?? 1, output }));
-        proc.on('error', (err) => resolve({ code: 1, output: err.message }));
-        token.onCancellationRequested(() => proc.kill());
-    });
+    const result = await runPhelCli(cmd.command, args, cmd.cwd, { token });
+    const outcome = { code: result.code, output: result.stdout + result.stderr };
 
     let byName = new Map<string, AggregatedCase>();
     let parsed = false;

--- a/src/phelWorkspace.ts
+++ b/src/phelWorkspace.ts
@@ -1,0 +1,21 @@
+// Shared workspace-folder resolution. Several features need "the folder this
+// document belongs to, or the first workspace folder as a fallback"; this is
+// the single source of that logic.
+
+import * as vscode from 'vscode';
+
+/** The workspace folder owning `doc`, else the first workspace folder. */
+export function folderForDocument(doc?: vscode.TextDocument): vscode.WorkspaceFolder | undefined {
+    if (doc && doc.uri.scheme === 'file') {
+        const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+        if (folder) {
+            return folder;
+        }
+    }
+    return vscode.workspace.workspaceFolders?.[0];
+}
+
+/** The folder for the active editor's document, else the first workspace folder. */
+export function activeWorkspaceFolder(): vscode.WorkspaceFolder | undefined {
+    return folderForDocument(vscode.window.activeTextEditor?.document);
+}

--- a/src/test/phelCliCommands.test.ts
+++ b/src/test/phelCliCommands.test.ts
@@ -1,5 +1,29 @@
 import * as assert from 'node:assert/strict';
-import { buildArgs, parseTemplates } from '../phelCliCommands';
+import { buildArgs, parseTemplates, shellQuote } from '../phelCliCommands';
+
+describe('phelCliCommands.shellQuote', () => {
+    it('leaves simple tokens unquoted', () => {
+        assert.equal(shellQuote('test'), 'test');
+        assert.equal(shellQuote('vendor/bin/phel'), 'vendor/bin/phel');
+        assert.equal(shellQuote('--filter'), '--filter');
+    });
+
+    it('quotes arguments containing spaces', () => {
+        assert.equal(shellQuote('my test'), "'my test'");
+        assert.equal(shellQuote('/path with spaces/phel'), "'/path with spaces/phel'");
+    });
+
+    it('quotes shell-significant characters', () => {
+        assert.equal(shellQuote('a$b'), "'a$b'");
+        assert.equal(shellQuote('a`b'), "'a`b'");
+        assert.equal(shellQuote('a"b'), "'a\"b'");
+        assert.equal(shellQuote('a\\b'), "'a\\b'");
+    });
+
+    it('escapes embedded single quotes', () => {
+        assert.equal(shellQuote("it's"), "'it'\\''s'");
+    });
+});
 
 // Captured verbatim from `phel init --list-templates`.
 const LIST_OUTPUT = [

--- a/src/test/xml.test.ts
+++ b/src/test/xml.test.ts
@@ -1,0 +1,61 @@
+import * as assert from 'node:assert/strict';
+import { decodeEntities, readAttr, toInt } from '../xml';
+
+describe('xml.readAttr', () => {
+    it('reads double-quoted values', () => {
+        assert.equal(readAttr('name="t" line="4"', 'name'), 't');
+        assert.equal(readAttr('name="t" line="4"', 'line'), '4');
+    });
+
+    it('reads single-quoted values', () => {
+        assert.equal(readAttr("name='t'", 'name'), 't');
+    });
+
+    it('returns undefined for a missing attribute', () => {
+        assert.equal(readAttr('name="t"', 'file'), undefined);
+    });
+
+    it('returns empty string for an empty value', () => {
+        assert.equal(readAttr('classname=""', 'classname'), '');
+    });
+
+    it('matches on a word boundary, not a substring', () => {
+        // `num` must not match inside `linenum`.
+        assert.equal(readAttr('linenum="9" num="3"', 'num'), '3');
+    });
+});
+
+describe('xml.decodeEntities', () => {
+    it('decodes the named entities', () => {
+        assert.equal(
+            decodeEntities('a &lt;b&gt; &amp; &quot;c&quot; &apos;d&apos;'),
+            'a <b> & "c" \'d\''
+        );
+    });
+
+    it('decodes decimal and hex numeric entities', () => {
+        assert.equal(decodeEntities('&#65;&#x42;'), 'AB');
+    });
+
+    it('does not double-decode an escaped ampersand', () => {
+        // &amp;lt; should become &lt; (literal), not <
+        assert.equal(decodeEntities('&amp;lt;'), '&lt;');
+    });
+
+    it('returns the input unchanged when there are no entities', () => {
+        assert.equal(decodeEntities('/abs/path/file.phel'), '/abs/path/file.phel');
+    });
+});
+
+describe('xml.toInt', () => {
+    it('parses integers', () => {
+        assert.equal(toInt('42'), 42);
+        assert.equal(toInt('0'), 0);
+    });
+
+    it('returns undefined for missing or non-numeric values', () => {
+        assert.equal(toInt(undefined), undefined);
+        assert.equal(toInt(''), undefined);
+        assert.equal(toInt('abc'), undefined);
+    });
+});

--- a/src/xml.ts
+++ b/src/xml.ts
@@ -1,0 +1,60 @@
+// Small XML helpers shared by the JUnit and Clover report parsers. Both
+// reports are flat, attribute-heavy XML, so a full DOM parser would be
+// overkill; these cover reading an attribute value and decoding entities.
+
+// Attribute names come from a small fixed set, so the per-name regex is
+// compiled once and cached (a coverage report can have thousands of <line>
+// elements, each read twice).
+const attrRegexCache = new Map<string, RegExp>();
+
+function attrRegex(name: string): RegExp {
+    let re = attrRegexCache.get(name);
+    if (re === undefined) {
+        re = new RegExp(`\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)')`);
+        attrRegexCache.set(name, re);
+    }
+    return re;
+}
+
+/**
+ * Read a double- or single-quoted attribute value from a tag's attribute
+ * string. Returns the raw value (not entity-decoded); use {@link decodeEntities}
+ * on the result when the value may contain entities.
+ *
+ * Note: the surrounding parsers capture attribute blobs with `[^>]*`, which
+ * assumes any literal `>` inside a value is XML-escaped as `&gt;` — true for
+ * the PHP XML writer that produces these reports.
+ */
+export function readAttr(attrs: string, name: string): string | undefined {
+    const m = attrRegex(name).exec(attrs);
+    if (!m) {
+        return undefined;
+    }
+    return m[2] ?? m[3] ?? '';
+}
+
+/** Parse an integer attribute value, returning undefined when absent/invalid. */
+export function toInt(value: string | undefined): number | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+    const n = Number.parseInt(value, 10);
+    return Number.isFinite(n) ? n : undefined;
+}
+
+/** Decode the XML entities that the Phel reporters emit (named + numeric). */
+export function decodeEntities(text: string): string {
+    if (!text.includes('&')) {
+        return text;
+    }
+    return text
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&apos;/g, "'")
+        .replace(/&#(\d+);/g, (_, code: string) => String.fromCodePoint(Number.parseInt(code, 10)))
+        .replace(/&#x([0-9a-fA-F]+);/g, (_, code: string) =>
+            String.fromCodePoint(Number.parseInt(code, 16))
+        )
+        .replace(/&amp;/g, '&'); // last, so we don't double-decode
+}


### PR DESCRIPTION
## What

A quality + performance pass over `src/`, focused on the recently-added feature code. No user-facing behavior change.

### Deduplication (the bulk of the win)

Four small, focused modules replace logic that had been copy-pasted across the feature PRs:

- **`src/xml.ts`** — `readAttr` / `decodeEntities` / `toInt`, shared by `junitParser` and `cloverParser`. Removes 3 duplicated private helpers. The Clover copy of `decodeEntities` was a strict *subset* that silently dropped numeric character references (`&#123;`) — a latent path-corruption bug, now fixed by using the complete version. Attribute regexes are compiled once and cached by name (a coverage file has thousands of `<line>` elements).
- **`src/phelCli.ts`** — one `runPhelCli(command, args, cwd, {onStdout?, token?})` replacing the `spawn` + stdout/stderr-accumulation boilerplate in the doctor, cli-commands, and test-controller modules.
- **`src/phelWorkspace.ts`** — one `folderForDocument` / `activeWorkspaceFolder`, replacing four near-identical local copies (doctor, cli, nrepl, repl).
- **`src/phelTerminal.ts`** (+ `shellQuote` in the pure `phelCliCommands`) — shared terminal launch with POSIX quoting; also fixes a space-in-path bug in the terminal test command.

### Correctness / performance

- **nREPL `onSocketData`** now wraps `decode()` in try/catch. A malformed frame previously threw out of the socket `'data'` handler as an unhandled error and left every pending op hanging until its 60s timeout; it now logs, drops the corrupt buffer, and rejects in-flight ops.
- **nREPL `handleClose`** reaps the server process so it isn't orphaned when the socket closes before an explicit disconnect.
- **`loadAllTests`** reads `.phel` files concurrently (`Promise.all`) instead of awaiting each one serially on the Test Explorer's first expand.

### Convention fix

`resolvePhelExecutable` now accepts an `undefined` subsystem (resolve straight from `phel.executablePath`). Doctor / config / build / init previously borrowed `'diagnostics.command'`, whose documented contract is "diagnostics only".

## Verification

- `tsc --noEmit` clean, `eslint` clean, **328** tests pass (313 + 15 new for the extracted pure helpers — `xml` and `shellQuote`).
- Production bundle + `vsce package` both succeed.
- The pure modules (`xml`, `phelCliCommands`) remain free of `vscode` imports so they stay unit-testable under plain mocha.

Findings were sourced from two independent reviews; I applied the high-value, low-risk subset and deliberately left a few cosmetic items (e.g. splitting up `extension.ts`'s `activate()`) out to keep the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)