### PR TITLE
fix(quality): correctness + robustness pass (Windows, nREPL namespace/file-name, LSP restart)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,15 @@
 - Add `php/callable` (first-class callable interop) to the `php/*` completion list.
 - Rename `argv` → `*argv*`.
 
+### Fixed
+
+- Terminal commands (test / watch / build / init) now launch the CLI as the terminal's process instead of a shell-quoted command line, so they work on Windows (PowerShell/cmd) and with paths containing spaces.
+- nREPL eval now runs in the open file's namespace, and nREPL "load file" reports compile-error locations with the real file path instead of `NO_SOURCE_FILE`.
+- The language server now restarts automatically when `phel.lsp.command`, `phel.lsp.args`, or `phel.executablePath` changes (toggling `phel.lsp.enabled` offers a reload); coverage from several test files merges into one report per source; cancelling a test run resolves every started test.
+
 ### Internal
 
-- Deduplicate shared logic into focused modules: `xml` (attribute/entity/int parsing used by the JUnit and Clover parsers), `phelCli` (one-shot CLI spawn + output collection), `phelWorkspace` (active-folder resolution), and `phelTerminal` (terminal launch + shell quoting). Harden the nREPL reader against malformed frames and reap the server process on socket close; read test files concurrently when populating the Test Explorer.
+- Deduplicate shared logic into focused modules: `xml` (attribute/entity/int parsing used by the JUnit and Clover parsers), `phelCli` (one-shot CLI spawn + output collection), `phelWorkspace` (active-folder resolution), and `phelTerminal` (terminal launch). Harden the nREPL reader against malformed frames, unref pending timers, and reap the server process on socket close; dispose output channels, run profiles, and per-folder file watchers; read test files concurrently when populating the Test Explorer.
 
 ## [0.8.0] - 2026-06-05
 

--- a/package.json
+++ b/package.json
@@ -424,7 +424,7 @@
                 "phel.lsp.command": {
                     "type": "string",
                     "default": "",
-                    "markdownDescription": "Override `#phel.executablePath#` for the language server only. Empty string falls back to `#phel.executablePath#`. Relative paths resolve against the workspace folder."
+                    "markdownDescription": "Override `#phel.executablePath#` for the language server only. Empty string falls back to `#phel.executablePath#`. Relative paths resolve against the workspace folder. Changing this restarts a running server automatically."
                 },
                 "phel.lsp.args": {
                     "type": "array",
@@ -434,7 +434,7 @@
                     "default": [
                         "lsp"
                     ],
-                    "description": "Arguments passed to the Phel CLI when starting the language server."
+                    "description": "Arguments passed to the Phel CLI when starting the language server. Changing this restarts a running server automatically."
                 },
                 "phel.cacheDirectory": {
                     "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,9 +34,12 @@ import { PhelStatusBar } from './phelStatusBar';
 import { PhelTestController } from './phelTestController';
 import {
     isLanguageServerEnabled,
+    isLanguageServerRunning,
+    restartLanguageClient,
     startLanguageClient,
     stopLanguageClient,
 } from './phelLanguageClient';
+import { affectsPhelExecutable } from './phelExecutable';
 
 let sourceMapManager: SourceMapManager;
 
@@ -132,6 +135,21 @@ export function activate(context: vscode.ExtensionContext) {
                 if (cacheDir) {
                     sourceMapManager.addCacheDirectory(cacheDir);
                 }
+            }
+
+            // Toggling the server on/off swaps the entire provider stack, which
+            // can't be done safely in place — ask for a reload.
+            if (e.affectsConfiguration('phel.lsp.enabled')) {
+                void promptReloadForLspToggle();
+            } else if (
+                isLanguageServerRunning() &&
+                (e.affectsConfiguration('phel.lsp.command') ||
+                    e.affectsConfiguration('phel.lsp.args') ||
+                    affectsPhelExecutable(e))
+            ) {
+                // Path/args changed while the server is up — restart it so the
+                // change takes effect without a reload.
+                void restartLanguageClient(context);
             }
         })
     );
@@ -234,6 +252,20 @@ export function activate(context: vscode.ExtensionContext) {
 
 export function deactivate(): Thenable<void> | undefined {
     return stopLanguageClient();
+}
+
+/**
+ * `phel.lsp.enabled` switches between the language server and the bundled
+ * providers; swapping the whole stack live is error-prone, so offer a reload.
+ */
+async function promptReloadForLspToggle(): Promise<void> {
+    const choice = await vscode.window.showInformationMessage(
+        'Phel: the language-server setting changed. Reload the window to apply it.',
+        'Reload Window'
+    );
+    if (choice === 'Reload Window') {
+        await vscode.commands.executeCommand('workbench.action.reloadWindow');
+    }
 }
 
 /**
@@ -366,7 +398,10 @@ function runPhelTests(uri?: vscode.Uri, testName?: string): void {
     const filePath = path.relative(cwd, target.fsPath) || target.fsPath;
     const args = ['test'];
     if (testName) {
-        args.push('--filter', testName);
+        // `--filter` is a regex; anchor and escape so "foo" doesn't also match
+        // "foobar" (matches the Test Explorer's exact-name behavior).
+        const escaped = testName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        args.push('--filter', `^${escaped}$`);
     }
     args.push(filePath);
     runInTerminal('Phel Tests', command, args, cwd);

--- a/src/junitParser.ts
+++ b/src/junitParser.ts
@@ -55,17 +55,13 @@ export function parseJUnit(xml: string): JUnitTestCase[] {
 }
 
 function collectCases(scope: string, suiteName: string, out: JUnitTestCase[]): void {
-    // Self-closing testcases (no failure/error child).
-    const selfClosingRe = /<testcase\b([^>]*?)\/>/g;
-    // Testcases with a body (may contain failure/error children).
-    const bodyRe = /<testcase\b([^>]*?)>([\s\S]*?)<\/testcase>/g;
-
+    // Match self-closing (`<testcase .../>`) and body (`<testcase ...>...</testcase>`)
+    // forms in a single left-to-right pass so document order is preserved and a
+    // self-closing element can't be swallowed by a following element's body.
+    const re = /<testcase\b([^>]*?)(?:\/>|>([\s\S]*?)<\/testcase>)/g;
     let m: RegExpExecArray | null;
-    while ((m = bodyRe.exec(scope)) !== null) {
-        out.push(buildCase(m[1], m[2], suiteName));
-    }
-    while ((m = selfClosingRe.exec(scope)) !== null) {
-        out.push(buildCase(m[1], '', suiteName));
+    while ((m = re.exec(scope)) !== null) {
+        out.push(buildCase(m[1], m[2] ?? '', suiteName));
     }
 }
 

--- a/src/phelCliCommands.ts
+++ b/src/phelCliCommands.ts
@@ -1,10 +1,5 @@
 // Pure helpers for the Phel CLI command wrappers (template parsing, build
-// args, shell quoting). Kept free of `vscode` so they can be unit-tested.
-
-/** POSIX-quote a single argument so paths/names with spaces survive the shell. */
-export function shellQuote(arg: string): string {
-    return /[\s"'$`\\]/.test(arg) ? `'${arg.replace(/'/g, "'\\''")}'` : arg;
-}
+// args). Kept free of `vscode` so they can be unit-tested.
 
 export interface PhelTemplate {
     name: string;

--- a/src/phelDoctorProvider.ts
+++ b/src/phelDoctorProvider.ts
@@ -113,6 +113,7 @@ function prettyJson(raw: string): string | null {
 
 export function registerDoctorCommands(context: vscode.ExtensionContext): void {
     context.subscriptions.push(
+        channel(),
         vscode.commands.registerCommand('phel.doctor', runDoctor),
         vscode.commands.registerCommand('phel.showConfig', showConfig)
     );

--- a/src/phelLanguageClient.ts
+++ b/src/phelLanguageClient.ts
@@ -82,7 +82,10 @@ export async function startLanguageClient(context: vscode.ExtensionContext): Pro
         return false;
     }
 
-    outputChannel ??= vscode.window.createOutputChannel(OUTPUT_CHANNEL_NAME);
+    if (!outputChannel) {
+        outputChannel = vscode.window.createOutputChannel(OUTPUT_CHANNEL_NAME);
+        context.subscriptions.push(outputChannel);
+    }
 
     const serverOptions: ServerOptions = {
         run: { command, args, transport: TransportKind.stdio },
@@ -131,6 +134,20 @@ export async function stopLanguageClient(): Promise<void> {
     } catch {
         // ignore: the server may already be gone
     }
+}
+
+/**
+ * Restart the running language client (e.g. after the executable path or args
+ * change). No-op when no client is currently running so it can't accidentally
+ * start the server when the fallback providers are in use.
+ */
+export async function restartLanguageClient(context: vscode.ExtensionContext): Promise<void> {
+    if (!client) {
+        return;
+    }
+    log('Restarting Phel language server (configuration changed).');
+    await stopLanguageClient();
+    await startLanguageClient(context);
 }
 
 function log(message: string): void {

--- a/src/phelNreplClient.ts
+++ b/src/phelNreplClient.ts
@@ -98,6 +98,7 @@ export class PhelNreplConnection {
                     reject(new Error('Timed out waiting for the nREPL server to start.'));
                 }
             }, STARTUP_TIMEOUT_MS);
+            timer.unref(); // a pending timeout must not keep the host process alive
 
             const onData = (chunk: Buffer): void => {
                 const text = chunk.toString();
@@ -240,6 +241,7 @@ export class PhelNreplConnection {
                 this.pending.delete(id);
                 reject(new Error(`nREPL op "${asString(op['op'])}" timed out.`));
             }, OP_TIMEOUT_MS);
+            timer.unref(); // a pending timeout must not keep the host process alive
             const pending: PendingOp = {
                 resolve,
                 reject,
@@ -260,15 +262,18 @@ export class PhelNreplConnection {
     }
 
     eval(code: string, ns?: string): Promise<OpResult> {
-        const op: { [key: string]: BencodeValue } = { op: 'eval', code };
-        if (ns) {
-            op['ns'] = ns;
-        }
-        return this.send(op);
+        // The server evaluates in the session's current namespace and has no
+        // `ns` op param, so switch the session first with an in-ns form when a
+        // namespace is requested. (`*ns*` tracking across evals lives in the
+        // session, so this persists for follow-up evals in the same file.)
+        const source = ns ? `(in-ns '${ns})\n${code}` : code;
+        return this.send({ op: 'eval', code: source });
     }
 
     loadFile(content: string, filePath: string): Promise<OpResult> {
-        return this.send({ op: 'load-file', file: content, 'file-path': filePath });
+        // The server reads the source name from `file-name` (used in compile
+        // error locations); `file` carries the contents.
+        return this.send({ op: 'load-file', file: content, 'file-name': filePath });
     }
 
     reload(all = false): Promise<OpResult> {

--- a/src/phelNreplProvider.ts
+++ b/src/phelNreplProvider.ts
@@ -42,6 +42,11 @@ async function getConnection(
     if (existing && existing.connected) {
         return existing;
     }
+    if (existing) {
+        // A stale (closed) connection lingered; drop it before reconnecting.
+        existing.dispose();
+        connections.delete(key);
+    }
     if (!create) {
         return undefined;
     }
@@ -107,11 +112,14 @@ function reportResult(label: string, result: OpResult): void {
     for (const value of result.values) {
         ch.appendLine(`=> ${value}`);
     }
-    const failed = result.status.includes('error') || result.status.includes('eval-error');
+    const hasError =
+        result.status.includes('error') ||
+        result.status.includes('eval-error') ||
+        result.err.trim() !== '';
     if (result.err.trim()) {
         ch.appendLine(result.err.trim());
     }
-    if (failed) {
+    if (hasError) {
         ch.show(true);
     }
 }
@@ -260,6 +268,7 @@ function disposeAll(): void {
 
 export function registerNreplCommands(context: vscode.ExtensionContext): void {
     context.subscriptions.push(
+        channel(),
         vscode.commands.registerCommand('phel.nrepl.connect', connect),
         vscode.commands.registerCommand('phel.nrepl.disconnect', disconnect),
         vscode.commands.registerCommand('phel.nrepl.eval', evalForm),

--- a/src/phelTerminal.ts
+++ b/src/phelTerminal.ts
@@ -1,18 +1,29 @@
-// Shared helpers for running a Phel CLI command in an integrated terminal
-// (used for interactive / long-running commands: REPL, test runs, watch,
+// Shared helper for running a Phel CLI command in a dedicated integrated
+// terminal (used for one-shot / long-running commands: test runs, watch,
 // build, init).
 
 import * as vscode from 'vscode';
-import { shellQuote } from './phelCliCommands';
 
-/** Open (or reuse a freshly created) terminal and run `command args` in `cwd`. */
+/**
+ * Open a terminal that runs `command args` directly as its shell process and
+ * exits when the command does.
+ *
+ * Passing the command via `shellPath`/`shellArgs` makes VS Code spawn the
+ * process itself (argv array, no intermediate shell), so arguments with spaces
+ * or shell metacharacters are passed verbatim and the behaviour is identical on
+ * POSIX and Windows. (This is the same mechanism the REPL terminal uses.)
+ */
 export function runInTerminal(
     name: string,
     command: string,
     args: readonly string[],
     cwd: string
 ): void {
-    const terminal = vscode.window.createTerminal({ name, cwd });
+    const terminal = vscode.window.createTerminal({
+        name,
+        cwd,
+        shellPath: command,
+        shellArgs: [...args],
+    });
     terminal.show(true);
-    terminal.sendText([command, ...args].map(shellQuote).join(' '));
 }

--- a/src/phelTestController.ts
+++ b/src/phelTestController.ts
@@ -217,25 +217,41 @@ function messageFor(aggregated: AggregatedCase): vscode.TestMessage[] {
     });
 }
 
-/** Build a FileCoverage (+ cache its per-line detail) from a Clover file entry. */
-function toFileCoverage(
-    entry: CloverFile,
+/**
+ * Build one FileCoverage (and cache its per-line detail) for a source file
+ * from all Clover entries that referenced it during the run. A line is covered
+ * if it was executed in any entry; the summary counts come from the merged set.
+ */
+function mergeCoverage(
+    entries: readonly CloverFile[],
     detailStore: Map<string, vscode.StatementCoverage[]>
 ): vscode.FileCoverage {
-    const uri = vscode.Uri.file(entry.file);
-    const details = entry.lines.map(
-        (l) =>
+    const uri = vscode.Uri.file(entries[0].file);
+
+    const coveredByLine = new Map<number, boolean>();
+    for (const entry of entries) {
+        for (const l of entry.lines) {
+            coveredByLine.set(l.line, (coveredByLine.get(l.line) ?? false) || l.covered);
+        }
+    }
+
+    const details: vscode.StatementCoverage[] = [];
+    let covered = 0;
+    for (const [line, isCovered] of coveredByLine) {
+        details.push(
             new vscode.StatementCoverage(
-                l.covered,
+                isCovered,
                 // Clover line numbers are 1-based; VS Code positions are 0-based.
-                new vscode.Position(Math.max(0, l.line - 1), 0)
+                new vscode.Position(Math.max(0, line - 1), 0)
             )
-    );
+        );
+        if (isCovered) {
+            covered += 1;
+        }
+    }
+
     detailStore.set(uri.toString(), details);
-    return new vscode.FileCoverage(
-        uri,
-        new vscode.TestCoverageCount(entry.coveredStatements, entry.statements)
-    );
+    return new vscode.FileCoverage(uri, new vscode.TestCoverageCount(covered, coveredByLine.size));
 }
 
 export class PhelTestController implements vscode.Disposable {
@@ -250,11 +266,13 @@ export class PhelTestController implements vscode.Disposable {
         this.controller.resolveHandler = async () => {
             await loadAllTests(this.controller);
         };
-        this.controller.createRunProfile(
-            'Run',
-            vscode.TestRunProfileKind.Run,
-            (request, token) => this.run(request, token, false),
-            true
+        this.disposables.push(
+            this.controller.createRunProfile(
+                'Run',
+                vscode.TestRunProfileKind.Run,
+                (request, token) => this.run(request, token, false),
+                true
+            )
         );
         if (COVERAGE_API_AVAILABLE) {
             const coverageProfile = this.controller.createRunProfile(
@@ -265,6 +283,7 @@ export class PhelTestController implements vscode.Disposable {
             );
             coverageProfile.loadDetailedCoverage = (_run, fileCoverage) =>
                 Promise.resolve(this.coverageDetails.get(fileCoverage.uri.toString()) ?? []);
+            this.disposables.push(coverageProfile);
         }
         this.disposables.push(
             vscode.workspace.onDidSaveTextDocument(async (doc) => {
@@ -292,61 +311,85 @@ export class PhelTestController implements vscode.Disposable {
         if (withCoverage) {
             this.coverageDetails = new Map();
         }
+        // Accumulate coverage across files so a source executed by several test
+        // files yields one merged FileCoverage rather than duplicate entries.
+        const coverageByUri = new Map<string, CloverFile[]>();
         let warnedNoDriver = false;
 
-        for (const [fileItem, leaves] of byFile) {
-            if (token.isCancellationRequested) {
-                break;
-            }
-            const folder = fileItem.uri
-                ? vscode.workspace.getWorkspaceFolder(fileItem.uri)
-                : undefined;
-            if (!folder || !fileItem.uri) {
-                leaves.forEach((l) => run.skipped(l));
-                continue;
-            }
-            leaves.forEach((l) => run.started(l));
-
-            const outcome = await runPhelTestFile(folder, fileItem.uri, token, withCoverage);
-
-            if (withCoverage) {
-                for (const entry of outcome.coverage) {
-                    run.addCoverage(toFileCoverage(entry, this.coverageDetails));
-                }
-                if (outcome.coverageDriverMissing && !warnedNoDriver) {
-                    warnedNoDriver = true;
-                    vscode.window.showWarningMessage(
-                        'Phel coverage needs the pcov or xdebug PHP extension; tests ran without coverage.'
-                    );
-                }
-            }
-
-            for (const leaf of leaves) {
-                const name = nameForLeaf(leaf);
-                // A leaf only knows the deftest name, not its namespace, so we
-                // match by name (test names are unique within a file).
-                const result = findByName(outcome.byName, name);
-                if (!result) {
-                    if (outcome.parsed) {
-                        run.skipped(leaf);
-                    } else {
-                        run.errored(
-                            leaf,
-                            new vscode.TestMessage(
-                                outcome.output.trim() || `phel test exited ${outcome.code}`
-                            )
-                        );
-                    }
+        try {
+            for (const [fileItem, leaves] of byFile) {
+                if (token.isCancellationRequested) {
+                    // VS Code expects every started item to reach a terminal
+                    // state; mark the rest skipped instead of leaving them spinning.
+                    leaves.forEach((l) => run.skipped(l));
                     continue;
                 }
-                if (result.passed) {
-                    run.passed(leaf);
-                } else {
-                    run.failed(leaf, messageFor(result));
+                const folder = fileItem.uri
+                    ? vscode.workspace.getWorkspaceFolder(fileItem.uri)
+                    : undefined;
+                if (!folder || !fileItem.uri) {
+                    leaves.forEach((l) => run.skipped(l));
+                    continue;
+                }
+                leaves.forEach((l) => run.started(l));
+
+                const outcome = await runPhelTestFile(folder, fileItem.uri, token, withCoverage);
+
+                if (token.isCancellationRequested) {
+                    leaves.forEach((l) => run.skipped(l));
+                    continue;
+                }
+
+                if (withCoverage) {
+                    for (const entry of outcome.coverage) {
+                        const list = coverageByUri.get(entry.file) ?? [];
+                        list.push(entry);
+                        coverageByUri.set(entry.file, list);
+                    }
+                    if (outcome.coverageDriverMissing && !warnedNoDriver) {
+                        warnedNoDriver = true;
+                        vscode.window.showWarningMessage(
+                            'Phel coverage needs the pcov or xdebug PHP extension; tests ran without coverage.'
+                        );
+                    }
+                }
+
+                for (const leaf of leaves) {
+                    const name = nameForLeaf(leaf);
+                    // A leaf only knows the deftest name, not its namespace, so we
+                    // match by name. Tests run one file per subprocess, so the
+                    // report only contains this file's tests — names are unique
+                    // within a file.
+                    const result = findByName(outcome.byName, name);
+                    if (!result) {
+                        if (outcome.parsed) {
+                            run.skipped(leaf);
+                        } else {
+                            run.errored(
+                                leaf,
+                                new vscode.TestMessage(
+                                    outcome.output.trim() || `phel test exited ${outcome.code}`
+                                )
+                            );
+                        }
+                        continue;
+                    }
+                    if (result.passed) {
+                        run.passed(leaf);
+                    } else {
+                        run.failed(leaf, messageFor(result));
+                    }
                 }
             }
+
+            if (withCoverage) {
+                for (const [, entries] of coverageByUri) {
+                    run.addCoverage(mergeCoverage(entries, this.coverageDetails));
+                }
+            }
+        } finally {
+            run.end();
         }
-        run.end();
     }
 
     dispose(): void {

--- a/src/phelTestScanner.ts
+++ b/src/phelTestScanner.ts
@@ -15,7 +15,9 @@ export interface PhelTestRef {
     nameCol: number;
 }
 
-const DEFTEST_RE = /^[ \t]*\((deftest)\s+(?:\^:[^\s()[\]{}]+\s+)?([^\s()[\]{}]+)/gm;
+// Optional metadata before the test name takes either the keyword-shorthand
+// form (`^:slow`) or the map form (`^{:slow true}`); both are skipped.
+const DEFTEST_RE = /^[ \t]*\((deftest)\s+(?:\^(?::[^\s()[\]{}]+|\{[^}]*\})\s+)?([^\s()[\]{}]+)/gm;
 
 export function findDeftests(source: string): PhelTestRef[] {
     const out: PhelTestRef[] = [];

--- a/src/phelWorkspaceIndexProvider.ts
+++ b/src/phelWorkspaceIndexProvider.ts
@@ -18,7 +18,8 @@ const NAMESPACE_RE = /\((?:ns|in-ns)\s+([A-Za-z][\w.-]*)/;
 
 export class PhelWorkspaceIndexer implements vscode.Disposable {
     readonly index = new PhelWorkspaceIndex();
-    private readonly watchers: vscode.FileSystemWatcher[] = [];
+    /** One watcher (plus its event subscriptions) per workspace folder, by URI. */
+    private readonly watchers = new Map<string, vscode.Disposable>();
     private readonly disposables: vscode.Disposable[] = [];
     private readonly _onDidChange = new vscode.EventEmitter<void>();
     readonly onDidChange = this._onDidChange.event;
@@ -51,9 +52,10 @@ export class PhelWorkspaceIndexer implements vscode.Disposable {
         for (const d of this.disposables) {
             d.dispose();
         }
-        for (const w of this.watchers) {
+        for (const w of this.watchers.values()) {
             w.dispose();
         }
+        this.watchers.clear();
         this._onDidChange.dispose();
     }
 
@@ -63,20 +65,29 @@ export class PhelWorkspaceIndexer implements vscode.Disposable {
         await Promise.all(files.map((uri) => this.indexFile(uri.fsPath)));
 
         const watcher = vscode.workspace.createFileSystemWatcher(pattern);
-        watcher.onDidCreate((uri) =>
-            this.indexFile(uri.fsPath).then(() => this._onDidChange.fire())
+        // Bundle the watcher with its event subscriptions so dropping a folder
+        // disposes all of them together (no leak on workspace-folder churn).
+        const subscription = vscode.Disposable.from(
+            watcher,
+            watcher.onDidCreate((uri) =>
+                this.indexFile(uri.fsPath).then(() => this._onDidChange.fire())
+            ),
+            watcher.onDidChange((uri) =>
+                this.indexFile(uri.fsPath).then(() => this._onDidChange.fire())
+            ),
+            watcher.onDidDelete((uri) => {
+                this.index.removeFile(uri.fsPath);
+                this._onDidChange.fire();
+            })
         );
-        watcher.onDidChange((uri) =>
-            this.indexFile(uri.fsPath).then(() => this._onDidChange.fire())
-        );
-        watcher.onDidDelete((uri) => {
-            this.index.removeFile(uri.fsPath);
-            this._onDidChange.fire();
-        });
-        this.watchers.push(watcher);
+        this.watchers.get(folder.uri.toString())?.dispose();
+        this.watchers.set(folder.uri.toString(), subscription);
     }
 
     private dropFolder(folder: vscode.WorkspaceFolder): void {
+        this.watchers.get(folder.uri.toString())?.dispose();
+        this.watchers.delete(folder.uri.toString());
+
         const prefix = folder.uri.fsPath + path.sep;
         for (const file of [...this.indexedFiles()]) {
             if (file.startsWith(prefix)) {

--- a/src/test/junitParser.test.ts
+++ b/src/test/junitParser.test.ts
@@ -96,6 +96,25 @@ describe('junitParser.parseJUnit', () => {
         assert.deepEqual(cases[0].failures, []);
     });
 
+    it('keeps order and attribution when a self-closing case precedes a body case', () => {
+        // A single left-to-right pass must not let the body case swallow the
+        // self-closing one, nor misattribute the failure.
+        const xml =
+            '<testsuites><testsuite name="ns">' +
+            '<testcase name="self" file="/f.phel" line="1"/>' +
+            '<testcase name="body" file="/f.phel" line="2">' +
+            '<failure message="boom" type="T">(x)</failure></testcase>' +
+            '</testsuite></testsuites>';
+        const cases = parseJUnit(xml);
+        assert.deepEqual(
+            cases.map((c) => c.name),
+            ['self', 'body']
+        );
+        assert.deepEqual(cases[0].failures, []);
+        assert.equal(cases[1].failures.length, 1);
+        assert.equal(cases[1].failures[0].message, 'boom');
+    });
+
     it('returns an empty array for empty or malformed input', () => {
         assert.deepEqual(parseJUnit(''), []);
         assert.deepEqual(parseJUnit('not xml'), []);

--- a/src/test/phelCliCommands.test.ts
+++ b/src/test/phelCliCommands.test.ts
@@ -1,29 +1,5 @@
 import * as assert from 'node:assert/strict';
-import { buildArgs, parseTemplates, shellQuote } from '../phelCliCommands';
-
-describe('phelCliCommands.shellQuote', () => {
-    it('leaves simple tokens unquoted', () => {
-        assert.equal(shellQuote('test'), 'test');
-        assert.equal(shellQuote('vendor/bin/phel'), 'vendor/bin/phel');
-        assert.equal(shellQuote('--filter'), '--filter');
-    });
-
-    it('quotes arguments containing spaces', () => {
-        assert.equal(shellQuote('my test'), "'my test'");
-        assert.equal(shellQuote('/path with spaces/phel'), "'/path with spaces/phel'");
-    });
-
-    it('quotes shell-significant characters', () => {
-        assert.equal(shellQuote('a$b'), "'a$b'");
-        assert.equal(shellQuote('a`b'), "'a`b'");
-        assert.equal(shellQuote('a"b'), "'a\"b'");
-        assert.equal(shellQuote('a\\b'), "'a\\b'");
-    });
-
-    it('escapes embedded single quotes', () => {
-        assert.equal(shellQuote("it's"), "'it'\\''s'");
-    });
-});
+import { buildArgs, parseTemplates } from '../phelCliCommands';
 
 // Captured verbatim from `phel init --list-templates`.
 const LIST_OUTPUT = [

--- a/src/test/phelTestScanner.test.ts
+++ b/src/test/phelTestScanner.test.ts
@@ -30,6 +30,14 @@ describe('findDeftests', function () {
         assert.strictEqual(refs[0].nameCol, 16);
     });
 
+    it('skips map-form metadata before the test name', function () {
+        const source = '(deftest ^{:slow true} my-test\n  (is true))\n';
+        const refs = findDeftests(source);
+        assert.strictEqual(refs.length, 1);
+        assert.strictEqual(refs[0].name, 'my-test');
+        assert.strictEqual(refs[0].nameCol, 23);
+    });
+
     it('reports the column relative to the line, not the file', function () {
         const source = 'leading line\n  (deftest indented-test [] (is true))\n';
         const [ref] = findDeftests(source);


### PR DESCRIPTION
A focused quality pass driven by three independent deep reviews of the feature + refactor code. Fixes real bugs (two verified against the live phel server source) and tightens robustness/lifecycle to a 10/10 bar.

## User-facing fixes

- **Windows terminal commands** — `phel.test.watch` / `phel.build` / `phel.init` (and the CodeLens test run) built a POSIX-shell-quoted command line and `sendText` it to the integrated terminal. On Windows that shell is PowerShell/cmd, so a path like `C:\…\vendor\bin\phel` was mangled. Now they launch the CLI as the terminal's own process via `shellPath`/`shellArgs` (argv array, no shell, no quoting) — correct on every OS, and the same mechanism the REPL already uses. `shellQuote` is removed.
- **nREPL eval namespace** — `eval` claimed to run in the document's namespace but the server (`EvalOp.php`) reads only `code` and has no `ns` param. Eval now prepends `(in-ns 'NS)` so it runs in the open file's namespace (the session tracks `*ns*` for follow-ups).
- **nREPL load-file error locations** — the client sent `file-path`, but the server (`LoadFileOp.php:29`) reads `file-name`, so compile errors always reported `NO_SOURCE_FILE`. **Verified against the live server**: errors now read e.g. `UnfinishedParserException (/proj/src/myapp/core.phel): …`.
- **LSP config changes** — a running server now restarts automatically when `phel.lsp.command`, `phel.lsp.args`, or `phel.executablePath` changes; toggling `phel.lsp.enabled` offers a window reload (swapping the whole provider stack live is unsafe).
- **Coverage + cancellation** — coverage from several test files now merges into one `FileCoverage` per source (was a duplicate-URI risk); cancelling a run marks every *started* test skipped (no spinning items) and `run.end()` runs in a `finally`.

## Robustness / lifecycle

- nREPL: `unref()` pending timers; reap a stale (closed) connection before reconnecting; reveal output whenever stderr is non-empty (not only on an error status).
- `junitParser`: scan testcases in a single ordered pass so a self-closing `<testcase/>` can't be swallowed by a following body element (latent, but now correct + tested).
- Test scanner: skip map-form metadata `^{…}`, not just `^:keyword`.
- Disposal: output channels (nREPL/LSP/doctor), both test run profiles, and per-folder file watchers are now disposed (the indexer leaked watchers on workspace-folder churn).

## Verification

- **Live E2E**: re-ran the nREPL smoke (clone/eval/eval-error/completions), the F1 load-file filename check, and the JUnit pass/fail mapping against the real `phel` — all pass.
- **326** tests pass (added JUnit-ordering and map-metadata cases; removed the obsolete `shellQuote` suite). `tsc --noEmit` clean, `eslint` clean, prod bundle + `vsce package` succeed.

## Reviewer notes

Three reviewers cross-checked against the phel-lang server source. Items verified *correct* and intentionally left alone: the `getConnection` connect race (sound single-funnel memoization), bencode UTF-8 handling across TCP chunk boundaries (byte-offset correct), the LSP-vs-fallback mutual exclusivity, and idempotent client double-dispose. One low-severity item (a multi-second "providers warming up" window during cold LSP start) is inherent to async LSP init — requests are queued by the client, not dropped — and is left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)