### PR TITLE
fix(qa): full regression QA — resilient LSP, debug toggle, short-fn highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
 - Terminal commands (test / watch / build / init) now launch the CLI as the terminal's process instead of a shell-quoted command line, so they work on Windows (PowerShell/cmd) and with paths containing spaces.
 - nREPL eval now runs in the open file's namespace, and nREPL "load file" reports compile-error locations with the real file path instead of `NO_SOURCE_FILE`.
 - The language server now restarts automatically when `phel.lsp.command`, `phel.lsp.args`, or `phel.executablePath` changes (toggling `phel.lsp.enabled` offers a reload); coverage from several test files merges into one report per source; cancelling a test run resolves every started test.
+- The language client now restarts the server if its connection drops, and falls back to the bundled providers (instead of looping) if the server proves unusable, so language features keep working.
+- `phel.debug.enabled` now actually gates the debug adapter (it was declared but ignored).
+- Highlight the `#(... %&)` / `#(... $&)` rest-arg marker as a parameter (the `&` was previously left unscoped).
 
 ### Internal
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,6 +42,8 @@ import {
 import { affectsPhelExecutable } from './phelExecutable';
 
 let sourceMapManager: SourceMapManager;
+/** Guards against registering the bundled providers twice (startup + later fallback). */
+let languageProvidersRegistered = false;
 
 export function activate(context: vscode.ExtensionContext) {
     console.log('Phel extension activated');
@@ -56,15 +58,18 @@ export function activate(context: vscode.ExtensionContext) {
         }
     }
 
-    // Register the debug adapter factory
-    const factory = new PhelDebugAdapterFactory();
-    context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('phel', factory));
+    // Register the debug adapter (honoring the `phel.debug.enabled` toggle).
+    if (vscode.workspace.getConfiguration('phel').get<boolean>('debug.enabled', true)) {
+        const factory = new PhelDebugAdapterFactory();
+        context.subscriptions.push(
+            vscode.debug.registerDebugAdapterDescriptorFactory('phel', factory)
+        );
 
-    // Register debug configuration provider
-    const configProvider = new PhelDebugConfigurationProvider();
-    context.subscriptions.push(
-        vscode.debug.registerDebugConfigurationProvider('phel', configProvider)
-    );
+        const configProvider = new PhelDebugConfigurationProvider();
+        context.subscriptions.push(
+            vscode.debug.registerDebugConfigurationProvider('phel', configProvider)
+        );
+    }
 
     // Register command: Show compiled PHP location
     context.subscriptions.push(
@@ -167,12 +172,15 @@ export function activate(context: vscode.ExtensionContext) {
     // bundled TypeScript providers as a fallback. We never run both, to avoid
     // duplicate completions and conflicting results.
     if (isLanguageServerEnabled()) {
-        void startLanguageClient(context).then((started) => {
+        // The fallback can be triggered either at startup (server can't launch)
+        // or later (server proves unusable); register the providers at most once.
+        const fallBack = (): void => registerLanguageProviders(context);
+        void startLanguageClient(context, { onUnrecoverable: fallBack }).then((started) => {
             if (!started) {
                 console.warn(
                     'Phel language server could not start; using bundled language providers.'
                 );
-                registerLanguageProviders(context);
+                fallBack();
             }
         });
     } else {
@@ -274,6 +282,11 @@ async function promptReloadForLspToggle(): Promise<void> {
  * serves these features (with PHP-interop intelligence the TS providers lack).
  */
 function registerLanguageProviders(context: vscode.ExtensionContext): void {
+    if (languageProvidersRegistered) {
+        return;
+    }
+    languageProvidersRegistered = true;
+
     const workspaceIndexer = new PhelWorkspaceIndexer();
     context.subscriptions.push(workspaceIndexer);
     void workspaceIndexer.start();

--- a/src/lspRestartBudget.ts
+++ b/src/lspRestartBudget.ts
@@ -1,0 +1,39 @@
+// Pure restart-budget tracker for the language client's close handler. Kept
+// free of `vscode` so the decision logic can be unit-tested.
+//
+// The Phel server can exit between requests, so we restart it — but a server
+// that exits immediately and repeatedly would otherwise respawn in a tight
+// loop. This caps restarts within a sliding time window; once exceeded, the
+// caller gives up and falls back to the bundled providers.
+
+export class LspRestartBudget {
+    private restarts = 0;
+    private windowStart: number;
+
+    constructor(
+        private readonly maxRestarts: number,
+        private readonly windowMs: number,
+        private readonly now: () => number = Date.now
+    ) {
+        this.windowStart = this.now();
+    }
+
+    /**
+     * Record a close and decide whether to restart. Returns `true` to restart,
+     * `false` once the budget is exhausted within the current window.
+     */
+    shouldRestart(): boolean {
+        const now = this.now();
+        if (now - this.windowStart > this.windowMs) {
+            this.windowStart = now;
+            this.restarts = 0;
+        }
+        this.restarts += 1;
+        return this.restarts <= this.maxRestarts;
+    }
+
+    /** Number of restarts recorded in the current window (for logging). */
+    get count(): number {
+        return this.restarts;
+    }
+}

--- a/src/phelLanguageClient.ts
+++ b/src/phelLanguageClient.ts
@@ -17,18 +17,36 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import {
+    CloseAction,
+    type CloseHandlerResult,
+    ErrorAction,
+    type ErrorHandler,
+    type ErrorHandlerResult,
     LanguageClient,
     type LanguageClientOptions,
+    type Message,
     type ServerOptions,
     State,
     TransportKind,
 } from 'vscode-languageclient/node';
 import { resolvePhelExecutable } from './phelExecutable';
+import { LspRestartBudget } from './lspRestartBudget';
 
 const OUTPUT_CHANNEL_NAME = 'Phel Language Server';
 
+// The Phel server is a short-lived stdio process: it can exit between requests
+// (e.g. it returns 0 on an idle read). Transparently restart it a bounded
+// number of times so language features keep working without a reload, while
+// still giving up on a genuinely broken (or chronically idle-exiting) server
+// to avoid a spawn loop — at which point we hand off to the bundled providers.
+const MAX_SERVER_RESTARTS = 5;
+const RESTART_WINDOW_MS = 60_000;
+
 let client: LanguageClient | undefined;
 let outputChannel: vscode.OutputChannel | undefined;
+/** Invoked once when the server proves unusable, so the caller can fall back. */
+let onUnrecoverable: (() => void) | undefined;
+let gaveUp = false;
 
 export function isLanguageServerEnabled(): boolean {
     return vscode.workspace.getConfiguration('phel').get<boolean>('lsp.enabled', true);
@@ -66,8 +84,18 @@ function resolveServerCommand(folder: vscode.WorkspaceFolder | undefined): {
  * Start the language client. Returns true when the server was launched and
  * reached the running state, false when it could not be started (so the
  * caller can fall back to the bundled providers).
+ *
+ * `options.onUnrecoverable` is invoked at most once if the server later proves
+ * unusable (repeated crashes / idle-exits), so the caller can register the
+ * bundled providers as a permanent fallback for the session.
  */
-export async function startLanguageClient(context: vscode.ExtensionContext): Promise<boolean> {
+export async function startLanguageClient(
+    context: vscode.ExtensionContext,
+    options: { onUnrecoverable?: () => void } = {}
+): Promise<boolean> {
+    if (options.onUnrecoverable) {
+        onUnrecoverable = options.onUnrecoverable;
+    }
     if (client) {
         return isLanguageServerRunning();
     }
@@ -101,6 +129,7 @@ export async function startLanguageClient(context: vscode.ExtensionContext): Pro
         // Phel diagnostics already flow through the server's publishDiagnostics;
         // don't also reveal the output on every error.
         revealOutputChannelOn: 4, // RevealOutputChannelOn.Never
+        errorHandler: createErrorHandler(),
     };
 
     client = new LanguageClient('phel', 'Phel Language Server', serverOptions, clientOptions);
@@ -148,6 +177,69 @@ export async function restartLanguageClient(context: vscode.ExtensionContext): P
     log('Restarting Phel language server (configuration changed).');
     await stopLanguageClient();
     await startLanguageClient(context);
+}
+
+/**
+ * Restart the server when its connection closes (it may exit between requests),
+ * capped within a sliding window so a genuinely broken binary can't spin
+ * forever. Read/write errors are tolerated briefly, then the connection is
+ * shut down (which triggers `closed()` and the restart path).
+ */
+function createErrorHandler(): ErrorHandler {
+    const budget = new LspRestartBudget(MAX_SERVER_RESTARTS, RESTART_WINDOW_MS);
+
+    return {
+        error(
+            _error: Error,
+            _message: Message | undefined,
+            count: number | undefined
+        ): ErrorHandlerResult {
+            // Tolerate a few transient transport errors before tearing down.
+            return {
+                action:
+                    count !== undefined && count <= 3 ? ErrorAction.Continue : ErrorAction.Shutdown,
+            };
+        },
+        closed(): CloseHandlerResult {
+            if (!budget.shouldRestart()) {
+                log(
+                    `Phel language server exited ${budget.count} times within ` +
+                        `${Math.round(RESTART_WINDOW_MS / 1000)}s; not restarting it again. ` +
+                        'Falling back to the bundled language providers.'
+                );
+                giveUpAndFallBack();
+                return {
+                    action: CloseAction.DoNotRestart,
+                    message:
+                        'Phel language server is unavailable; using the bundled language providers.',
+                    handled: true,
+                };
+            }
+            log(
+                `Phel language server connection closed; restarting (${budget.count}/${MAX_SERVER_RESTARTS}).`
+            );
+            return { action: CloseAction.Restart, handled: true };
+        },
+    };
+}
+
+/**
+ * The server proved unusable. Hand off to the bundled providers exactly once
+ * for the rest of the session. The library tears the client down itself when
+ * we return `DoNotRestart`, so we only clear our reference and fire the
+ * fallback (deferred, so it runs after the library finishes its cleanup).
+ */
+function giveUpAndFallBack(): void {
+    if (gaveUp) {
+        return;
+    }
+    gaveUp = true;
+    client = undefined;
+    const fallback = onUnrecoverable;
+    onUnrecoverable = undefined;
+    if (fallback) {
+        setImmediate(fallback);
+    }
 }
 
 function log(message: string): void {

--- a/src/test/lspRestartBudget.test.ts
+++ b/src/test/lspRestartBudget.test.ts
@@ -1,0 +1,34 @@
+import * as assert from 'node:assert/strict';
+import { LspRestartBudget } from '../lspRestartBudget';
+
+describe('LspRestartBudget', () => {
+    it('allows up to maxRestarts within the window, then refuses', () => {
+        let now = 1000;
+        const budget = new LspRestartBudget(3, 60_000, () => now);
+        assert.equal(budget.shouldRestart(), true, '1st');
+        assert.equal(budget.shouldRestart(), true, '2nd');
+        assert.equal(budget.shouldRestart(), true, '3rd');
+        assert.equal(budget.shouldRestart(), false, '4th exceeds budget');
+        assert.equal(budget.shouldRestart(), false, 'stays refused');
+        assert.equal(budget.count, 5);
+    });
+
+    it('resets the counter once the window elapses', () => {
+        let now = 0;
+        const budget = new LspRestartBudget(2, 1000, () => now);
+        assert.equal(budget.shouldRestart(), true);
+        assert.equal(budget.shouldRestart(), true);
+        assert.equal(budget.shouldRestart(), false); // budget used up
+        now += 1001; // window elapses
+        assert.equal(budget.shouldRestart(), true, 'budget refreshed after window');
+        assert.equal(budget.count, 1);
+    });
+
+    it('does not reset while still inside the window', () => {
+        let now = 0;
+        const budget = new LspRestartBudget(1, 1000, () => now);
+        assert.equal(budget.shouldRestart(), true);
+        now += 999;
+        assert.equal(budget.shouldRestart(), false, 'still within window, budget exhausted');
+    });
+});

--- a/src/test/lspRestartBudget.test.ts
+++ b/src/test/lspRestartBudget.test.ts
@@ -3,7 +3,7 @@ import { LspRestartBudget } from '../lspRestartBudget';
 
 describe('LspRestartBudget', () => {
     it('allows up to maxRestarts within the window, then refuses', () => {
-        let now = 1000;
+        const now = 1000;
         const budget = new LspRestartBudget(3, 60_000, () => now);
         assert.equal(budget.shouldRestart(), true, '1st');
         assert.equal(budget.shouldRestart(), true, '2nd');

--- a/syntaxes/phel.tmLanguage.json
+++ b/syntaxes/phel.tmLanguage.json
@@ -156,7 +156,7 @@
 			"patterns": [
 				{
 					"name": "variable.parameter.positional.phel",
-					"match": "%[0-9]*|%&|\\$[0-9]*|\\$&"
+					"match": "%&|%[0-9]*|\\$&|\\$[0-9]*"
 				},
 				{
 					"include": "#all"


### PR DESCRIPTION
Full regression QA of **all Unreleased changes**, exercising each feature against the live `phel` toolchain (not just static review). Three findings fixed; everything else verified green.

## Finding 1 (critical) — LSP server exits on idle → client made resilient

Driving a real JSON-RPC client against `phel lsp` (v0.45.1-beta) revealed the server **exits ~200ms after an idle read**: its `MessageReader` sets a 200ms `fgets` timeout and misreads the timeout as EOF (`src/php/Lsp/Application/Rpc/MessageReader.php` in phel-lang), so `LspServer` returns 0. A persistent stdio client (what `vscode-languageclient` is) would lose the server between keystrokes.

**This is an upstream phel-lang bug** — verified the server works perfectly when messages arrive back-to-back (completion → `greet`, hover → `**app/greet** _(defn)_`, definition/rename/symbols/formatting/diagnostics all correct). The fix here makes the *extension* resilient:

- Restart the server on connection close, **capped at 5 restarts / 60s** via a pure, unit-tested `LspRestartBudget`.
- When the budget is exhausted (chronically-exiting or broken server), **stop restarting and register the bundled providers** as the session fallback — no spin loop, and the user always has working language features. Bundled-provider registration is now idempotent so the startup-failure and later-fallback paths can't double-register (which would duplicate completions).

After the upstream timeout is fixed, the LSP works fully with no extension change.

## Finding 2 — `phel.debug.enabled` was a dead setting

Declared in `package.json` but never read; the debug adapter registered unconditionally. Now the setting gates the debug-adapter + config-provider registration as documented.

## Finding 3 — short-fn rest-arg marker mis-highlighted

`#(... %&)` / `#(... $&)`: the positional regex `%[0-9]*|%&|…` let `%[0-9]*` (zero digits) match the bare `%`, leaving `&` unscoped. Reordered to `%&|%[0-9]*|\$&|\$[0-9]*`; verified via the tokenizer that `%&` is now a single `variable.parameter.positional.phel` token.

## QA coverage (all re-verified against the real CLI/server)

| Area | Result |
|---|---|
| LSP handshake + every advertised capability | PASS (and the idle-exit caught) |
| LSP completion / hover / definition / rename / symbols / formatting | PASS when server alive |
| nREPL clone / eval / eval-error / completions | PASS |
| nREPL `file-name` (load-file) + `in-ns` (eval namespace) fixes | PASS |
| Test Explorer JUnit pass/fail + failure message mapping | PASS |
| Coverage driver-missing path (regex matches phel's message) | PASS |
| `config --format=json` parses | PASS |
| `init --list-templates` → 3 templates | PASS |
| `build -O` / `--report`, `test --watch` flags | PASS |
| package.json command/setting symmetry (35 cmds = 35 registered) | PASS |
| Grammar: tagged literals, reader conditionals, anon-fn, defenum/defonce, php/* | PASS |

## Verification

- **329** tests pass (+3 `LspRestartBudget`). `tsc --noEmit` clean, `eslint` clean, prod bundle + `vsce package` succeed.

## Follow-up (not in this repo)

Report the `phel lsp` idle-exit to phel-lang: in `MessageReader::readHeaders`, an `fgets` returning `false` under the 200ms `stream_set_timeout` should be treated as "no data yet" (retry while `!feof`), not as stream-closed. That one change makes the LSP a stable long-lived server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)