### PR TITLE
fix(lsp): default phel.lsp.enabled to off (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Language server
 
-- Delegate language intelligence (completion, hover, signature help, go-to-definition, references, rename, symbols, formatting, diagnostics) to the Phel language server (`phel lsp`) when available, gaining PHP-interop intelligence (`php/->`, `php/::`, `php/new`) and scoped rename/references. Falls back to the bundled providers when disabled or unavailable. Settings: `phel.lsp.enabled` (default `true`), `phel.lsp.command`, `phel.lsp.args`.
+- Optional Phel language-server integration via `phel lsp` (`phel.lsp.enabled`, **default off**): when enabled and the server is healthy, delegates completion, hover, signature help, go-to-definition, references, rename, symbols, formatting, and diagnostics to the Phel-compiler-backed server, gaining PHP-interop intelligence (`php/->`, `php/::`, `php/new`) and scoped rename/references. Best-effort: it falls back to the bundled providers when off, unavailable, or unstable — some current `phel lsp` builds exit on idle, so it ships opt-in. Settings: `phel.lsp.command`, `phel.lsp.args`. Note: the LSP path does not yet replace the bundled providers (no auto-import or call-site snippets over LSP), and both ship together.
 
 ### REPL & runtime
 
@@ -38,6 +38,7 @@
 ### Internal
 
 - Deduplicate shared logic into focused modules: `xml` (attribute/entity/int parsing used by the JUnit and Clover parsers), `phelCli` (one-shot CLI spawn + output collection), `phelWorkspace` (active-folder resolution), and `phelTerminal` (terminal launch). Harden the nREPL reader against malformed frames, unref pending timers, and reap the server process on socket close; dispose output channels, run profiles, and per-folder file watchers; read test files concurrently when populating the Test Explorer.
+- The language client (`vscode-languageclient`) ships alongside the existing bundled providers and symbol corpus rather than replacing them, so the packaged extension is larger than 0.8.0 (~265 KB vsix, `extension.js` ~98 KB → ~463 KB).
 
 ## [0.8.0] - 2026-06-05
 

--- a/package.json
+++ b/package.json
@@ -418,8 +418,8 @@
             "properties": {
                 "phel.lsp.enabled": {
                     "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Use the Phel language server (`phel lsp`) for completion, hover, signature help, go-to-definition, find references, rename, symbols, formatting, and diagnostics. The server is backed by the Phel compiler and understands PHP interop (`php/->`, `php/::`, `php/new`). When disabled (or when the installed Phel is too old to provide `phel lsp`), the extension falls back to its bundled providers. Requires a reload to take effect."
+                    "default": false,
+                    "markdownDescription": "Opt-in (default off): use the Phel language server (`phel lsp`) for completion, hover, signature help, go-to-definition, find references, rename, symbols, formatting, and diagnostics, backed by the Phel compiler with PHP-interop awareness (`php/->`, `php/::`, `php/new`). Best-effort today: some Phel releases ship a `phel lsp` that exits on idle, in which case the extension restarts it a few times and then falls back to its bundled providers. Enable once your Phel provides a stable server. Requires a reload to take effect."
                 },
                 "phel.lsp.command": {
                     "type": "string",

--- a/src/phelLanguageClient.ts
+++ b/src/phelLanguageClient.ts
@@ -49,7 +49,8 @@ let onUnrecoverable: (() => void) | undefined;
 let gaveUp = false;
 
 export function isLanguageServerEnabled(): boolean {
-    return vscode.workspace.getConfiguration('phel').get<boolean>('lsp.enabled', true);
+    // Opt-in: current `phel lsp` builds can exit on idle, so default off until upstream is stable.
+    return vscode.workspace.getConfiguration('phel').get<boolean>('lsp.enabled', false);
 }
 
 export function isLanguageServerRunning(): boolean {


### PR DESCRIPTION
## What

Make the `phel lsp` language-server integration **opt-in** (`phel.lsp.enabled` default `true` → `false`), and make the CHANGELOG/setting copy honest about the current limitations.

## Why

Regression QA against the real `phel lsp` (v0.45.x) found the server exits ~200ms after an idle read — an upstream phel-lang `MessageReader` bug (it treats an `fgets` timeout as EOF). A persistent stdio client loses the server between keystrokes; the extension restarts it a few times and then falls back to the bundled providers. So today the LSP path is best-effort and silently degrades. Shipping it **on** by default would advertise "delegates to the language server" while most users actually run on the fallback.

Also documented (no behavior change): the LSP does **not** replace the bundled providers — it loses auto-import and call-site snippets over LSP, and both implementations ship, so the vsix is larger than 0.8.0.

## Changes
- `package.json`: `phel.lsp.enabled` default `false`; description rewritten as opt-in + best-effort caveat.
- `phelLanguageClient.ts`: code fallback default `false` (matches the manifest) with a one-line WHY.
- `CHANGELOG.md`: LSP bullet reflects opt-in/fallback; Internal note on bundle growth.

## Not included (your call)
The `engines.vscode` 1.75→1.88 bump is **not** touched here — lowering it cleanly is not free (the coverage code uses 1.88-only typings), see the discussion. Happy to follow up either way.

## Verification
typecheck ✅ · eslint ✅ · 329 tests ✅ · changelog check ✅ · `vsce package` ✅ (266 KB)