### PR TITLE
docs(lsp): correct language-server default/behavior wording for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Language server
 
-- Optional Phel language-server integration via `phel lsp` (`phel.lsp.enabled`, **default off**): when enabled and the server is healthy, delegates completion, hover, signature help, go-to-definition, references, rename, symbols, formatting, and diagnostics to the Phel-compiler-backed server, gaining PHP-interop intelligence (`php/->`, `php/::`, `php/new`) and scoped rename/references. Best-effort: it falls back to the bundled providers when off, unavailable, or unstable — some current `phel lsp` builds exit on idle, so it ships opt-in. Settings: `phel.lsp.command`, `phel.lsp.args`. Note: the LSP path does not yet replace the bundled providers (no auto-import or call-site snippets over LSP), and both ship together.
+- Optional Phel language-server integration via `phel lsp` (`phel.lsp.enabled`, **default off**): when enabled and the server is healthy, delegates completion, hover, signature help, go-to-definition, references, rename, symbols, formatting, and diagnostics to the Phel-compiler-backed server, gaining PHP-interop intelligence (`php/->`, `php/::`, `php/new`) and scoped rename/references. Best-effort: it falls back to the bundled providers when off, unavailable, or unstable — some current `phel lsp` builds exit on idle, so it ships opt-in. Settings: `phel.lsp.command`, `phel.lsp.args`. The server and the bundled providers are mutually exclusive at runtime (never both, to avoid duplicate results); note the LSP path does not provide the bundled providers' auto-import-on-accept or call-site snippets.
 
 ### REPL & runtime
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ VS Code support for [Phel](https://phel-lang.org/), a functional Lisp that compi
 ## Features
 
 - **Highlighting** for forms, macros, reader macros, tagged literals, and reader conditionals.
-- **Language server** (`phel lsp`, on by default): completion, hover, signature help, go-to-definition, find references, rename, symbols, formatting, and diagnostics straight from the Phel compiler — including PHP-interop intelligence for `php/->`, `php/::`, and `php/new`. Falls back to bundled providers when disabled or unavailable.
+- **Language server** (`phel lsp`, opt-in via `phel.lsp.enabled`): completion, hover, signature help, go-to-definition, find references, rename, symbols, formatting, and diagnostics straight from the Phel compiler — including PHP-interop intelligence for `php/->`, `php/::`, and `php/new`. Off by default; enable it once your Phel ships a stable server (older `phel lsp` builds exit on idle, in which case the extension falls back to its bundled providers).
 - **Go to / Find / Rename** (`F12`, `shift+F12`, `F2`, `cmd+T`).
 - **Diagnostics** and **format** on save.
 - **REPL** in an integrated terminal with `(in-ns)` follow and history.

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -10,9 +10,11 @@ The extension ships a static `CompletionItemProvider` for the `phel` language. I
 
 The provider respects the word range so `defn|` completes correctly without duplicating the prefix.
 
-### Why not a language server?
+### Bundled providers vs. the language server
 
-A real LSP (hover docs, go-to-def, namespace-aware suggestions) is the long-term answer and is on the roadmap. The static list covers ~80% of the daily friction with zero runtime cost - works offline, no extra processes, no warmup latency.
+These bundled providers are the zero-config default: they work offline, with no extra process or warmup, and cover ~80% of the daily friction.
+
+For deeper, compiler-backed intelligence (namespace-aware completion, PHP-interop hover/signature help for `php/->` / `php/::` / `php/new`, and scoped rename/references) the extension can delegate to Phel's own language server, `phel lsp`. It is **opt-in** via `phel.lsp.enabled` (off by default): when enabled and the server is healthy the LSP serves these features; otherwise the bundled providers above are used. See the language-server bullet in the README.
 
 ### Why isn't symbol X suggested?
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,9 +168,9 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Language intelligence (completion / hover / signature help / definition /
     // references / rename / symbols / diagnostics / formatting) is provided
-    // either by the Phel language server (`phel lsp`, the default) or by the
-    // bundled TypeScript providers as a fallback. We never run both, to avoid
-    // duplicate completions and conflicting results.
+    // either by the Phel language server (`phel lsp`, opt-in) or by the bundled
+    // TypeScript providers (the default). We never run both, to avoid duplicate
+    // completions and conflicting results.
     if (isLanguageServerEnabled()) {
         // The fallback can be triggered either at startup (server can't launch)
         // or later (server proves unusable); register the providers at most once.


### PR DESCRIPTION
Release-prep accuracy pass. The phel-lang LSP idle-exit + empty-documentSymbol bugs are now fixed upstream (phel-lang #2617, merged), so `phel lsp` works fully end-to-end — verified **19/19 capabilities** over stdio *with realistic idle gaps* (completion, hover, definition, references, documentSymbol, formatting, rename, clean shutdown).

That fix ships in the **next** phel release, and the extension's LSP integration is (correctly) **opt-in** (`phel.lsp.enabled` defaults to `false`) until a stable server is widely available. But the docs had drifted out of sync with that default and with the runtime behavior:

- **README** said the language server is *"on by default"* — it is **opt-in / off by default**. Corrected, with guidance to enable it once the installed Phel ships a stable server (older `phel lsp` builds exit on idle → graceful fallback).
- **docs/completion.md** had a *"Why not a language server? … on the roadmap"* section — the LSP exists and is integrated. Rewrote it to describe the bundled-providers (zero-config default) vs. opt-in LSP split.
- **CHANGELOG** implied the LSP and bundled providers *"both ship together"* (read as: both run) — they are **mutually exclusive at runtime**. Clarified, keeping the real caveat (no auto-import / call-site snippets over LSP).
- **`activate()` comment** updated to match (opt-in, not default).

No behavior change (the only code edit is a comment). Bundle + `vsce package` clean; 329 tests green; changelog check passes.

## Release-readiness note

With this, the extension is internally consistent and honest about the LSP. Suggested sequencing: ship now with the LSP **opt-in**; once a phel release containing #2617 is out, a follow-up extension release can flip `phel.lsp.enabled` to default-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)