### PR TITLE
feat(nav): scope-aware go-to-def, references, rename, completion for locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Language support
+
+- **Scope-aware navigation for locals.** Go-to-definition, find-references, rename, and document-highlight now understand lexical scope: `fn` / `defn` parameters, `let` / `loop` / `binding` / `with-open` bindings, `if-let` / `when-let`, `for` / `doseq` / `dofor` loop vars, `foreach` key/value vars, `catch` exception vars, and vector / `:keys` / `:as` destructuring. A local now resolves to its binding site and renames **only within its own scope** — same-named globals and bindings shadowed in other scopes are left untouched (previously every matching token in the file was rewritten). Go-to-definition on a parameter jumps to the parameter, not to an unrelated global of the same name.
+- **In-scope locals in completion.** While writing a body, completion surfaces the bindings visible at the cursor (parameters, `let` names, loop vars, …) ranked above core and workspace symbols, plus the current file's own private (`defn-`) definitions.
+
+### Docs
+
+- Bump corpus / extension version references in `CONTRIBUTING.md` (regen example → v0.49.0) and `docs/installation.md` (dev symlink → 0.9.0).
+
 ## [0.9.0] - 2026-07-24
 
 ### Language server

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ That uses the same `vscode-textmate` + `vscode-oniguruma` engine VS Code ships w
 To regenerate after bumping phel-lang:
 
 ```bash
-npm run regen-docs -- /path/to/phel-lang --phel-version v0.45.1
+npm run regen-docs -- /path/to/phel-lang --phel-version v0.49.0
 ```
 
 The script walks `src/phel/**/*.phel`, detects each file's namespace from its `(ns ...)` or `(in-ns ...)` form, runs the parser in `src/phelDocs.ts`, and writes the JSON corpus. `--phel-version` (default `main`) is the git ref used to build `View source` links.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,7 +39,7 @@ Iterate on grammar / TypeScript without rebuilding the `.vsix` each time. Pair t
 **macOS / Linux**
 ```bash
 cd ~/.vscode/extensions
-ln -s /absolute/path/to/phel-vs-code-extension phel-lang.phel-lang-0.5.0
+ln -s /absolute/path/to/phel-vs-code-extension phel-lang.phel-lang-0.9.0
 ```
 
 **Windows** (PowerShell, Administrator)
@@ -47,7 +47,7 @@ ln -s /absolute/path/to/phel-vs-code-extension phel-lang.phel-lang-0.5.0
 cd $env:USERPROFILE\.vscode\extensions
 New-Item -ItemType SymbolicLink `
     -Target "C:\absolute\path\to\phel-vs-code-extension" `
-    -Path "phel-lang.phel-lang-0.5.0"
+    -Path "phel-lang.phel-lang-0.9.0"
 ```
 
 Restart VS Code (or run **Developer: Reload Window**) and changes to `syntaxes/`, `snippets/`, and the compiled `out/` directory pick up immediately.

--- a/src/phelCompletionProvider.ts
+++ b/src/phelCompletionProvider.ts
@@ -5,6 +5,7 @@ import { buildCallSnippet, isCalleePosition } from './phelCallSnippet';
 import { lookupSymbol, renderDocMarkdown } from './phelDocsLookup';
 import { buildRequireEdit, parseNsForm, type NsForm } from './phelNsAnalyzer';
 import { combineDocs } from './phelWorkspaceIndex';
+import { localsInScopeAt } from './phelScope';
 import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
 
 const SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;
@@ -40,6 +41,31 @@ function buildBaseSpecs(): ItemSpec[] {
             label: name,
             kind: vscode.CompletionItemKind.Function,
             detail: 'Phel core function',
+        });
+    }
+    return specs;
+}
+
+/** Private defs from the current file — offerable unqualified inside their own file. */
+function privateFileSpecs(
+    indexer: PhelWorkspaceIndexer | undefined,
+    document: vscode.TextDocument
+): ItemSpec[] {
+    if (!indexer) {
+        return [];
+    }
+    const specs: ItemSpec[] = [];
+    for (const doc of indexer.index.docsForFile(document.uri.fsPath)) {
+        if (!doc.private) {
+            continue; // publics are already covered by workspaceSpecs
+        }
+        specs.push({
+            label: doc.name,
+            kind:
+                doc.kind === 'macro'
+                    ? vscode.CompletionItemKind.Keyword
+                    : vscode.CompletionItemKind.Function,
+            detail: `${doc.ns} (private)`,
         });
     }
     return specs;
@@ -133,13 +159,31 @@ export class PhelCompletionProvider implements vscode.CompletionItemProvider {
         position: vscode.Position
     ): vscode.ProviderResult<vscode.CompletionItem[]> {
         const range = document.getWordRangeAtPosition(position, SYMBOL_RE);
+        const src = document.getText();
         const merged = this.indexer
             ? combineDocs(this.indexer.index.allDocs(), PHEL_DOCS)
             : [...PHEL_DOCS];
-        const specs = [...this.baseSpecs, ...workspaceSpecs(this.indexer)];
-        const nsForm = parseNsForm(document.getText());
+        const specs = [
+            ...this.baseSpecs,
+            ...workspaceSpecs(this.indexer),
+            ...privateFileSpecs(this.indexer, document),
+        ];
+        const nsForm = parseNsForm(src);
         const linePrefix = document.lineAt(position.line).text.slice(0, position.character);
         const callee = isCalleePosition(linePrefix);
-        return specs.map((spec) => buildItem(spec, range, merged, document, nsForm, callee));
+        const items = specs.map((spec) => buildItem(spec, range, merged, document, nsForm, callee));
+
+        // In-scope locals (params, let/loop names, …) are the most relevant
+        // suggestions while writing a body, so surface them first.
+        for (const name of localsInScopeAt(src, document.offsetAt(position))) {
+            const item = new vscode.CompletionItem(name, vscode.CompletionItemKind.Variable);
+            item.detail = 'local binding';
+            item.sortText = `0_${name}`;
+            if (range) {
+                item.range = range;
+            }
+            items.push(item);
+        }
+        return items;
     }
 }

--- a/src/phelDefinitionProvider.ts
+++ b/src/phelDefinitionProvider.ts
@@ -4,6 +4,7 @@ import { aliasMapFromSource } from './phelNsAnalyzer';
 import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
 import { combineDocs } from './phelWorkspaceIndex';
 import { PHEL_DOCS } from './phelCoreDocs';
+import { resolveLocalAt } from './phelScope';
 
 const SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;
 
@@ -19,6 +20,20 @@ export class PhelDefinitionProvider implements vscode.DefinitionProvider {
             return null;
         }
         const word = document.getText(range);
+
+        // A locally-bound symbol (fn/let/loop param, catch var, …) resolves to
+        // its binding site in this document, never to a same-named global.
+        const src = document.getText();
+        const local = resolveLocalAt(src, document.offsetAt(range.start));
+        if (local) {
+            return new vscode.Location(
+                document.uri,
+                new vscode.Range(
+                    document.positionAt(local.declStart),
+                    document.positionAt(local.declEnd)
+                )
+            );
+        }
 
         const merged = combineDocs(this.indexer.index.allDocs(), PHEL_DOCS);
         const aliases = aliasMapFromSource(document.getText());

--- a/src/phelDocumentHighlight.ts
+++ b/src/phelDocumentHighlight.ts
@@ -4,6 +4,7 @@
 
 import * as vscode from 'vscode';
 import { findOccurrences } from './phelReferences';
+import { resolveLocalAt, localOccurrences } from './phelScope';
 
 const SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;
 
@@ -16,8 +17,27 @@ export class PhelDocumentHighlightProvider implements vscode.DocumentHighlightPr
         if (!range) {
             return null;
         }
-        const word = document.getText(range);
         const text = document.getText();
+
+        // For a local, highlight only its scoped occurrences and flag the
+        // binding site as a write.
+        const local = resolveLocalAt(text, document.offsetAt(range.start));
+        if (local) {
+            return localOccurrences(text, local).map(
+                (occ) =>
+                    new vscode.DocumentHighlight(
+                        new vscode.Range(
+                            document.positionAt(occ.start),
+                            document.positionAt(occ.end)
+                        ),
+                        occ.start === local.declStart
+                            ? vscode.DocumentHighlightKind.Write
+                            : vscode.DocumentHighlightKind.Read
+                    )
+            );
+        }
+
+        const word = document.getText(range);
         return findOccurrences(text, word).map(
             (occ) =>
                 new vscode.DocumentHighlight(

--- a/src/phelReferenceProvider.ts
+++ b/src/phelReferenceProvider.ts
@@ -5,6 +5,7 @@
 import * as fs from 'node:fs/promises';
 import * as vscode from 'vscode';
 import { findOccurrences } from './phelReferences';
+import { resolveLocalAt, localOccurrences } from './phelScope';
 import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
 
 const SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;
@@ -19,6 +20,21 @@ export class PhelReferenceProvider implements vscode.ReferenceProvider {
         const range = document.getWordRangeAtPosition(position, SYMBOL_RE);
         if (!range) {
             return [];
+        }
+        // A local binding's references stay within this document and its scope.
+        const src = document.getText();
+        const local = resolveLocalAt(src, document.offsetAt(range.start));
+        if (local) {
+            return localOccurrences(src, local).map(
+                (occ) =>
+                    new vscode.Location(
+                        document.uri,
+                        new vscode.Range(
+                            document.positionAt(occ.start),
+                            document.positionAt(occ.end)
+                        )
+                    )
+            );
         }
         const word = document.getText(range);
         return findReferenceLocations(word, document, this.indexer);

--- a/src/phelRenameProvider.ts
+++ b/src/phelRenameProvider.ts
@@ -54,10 +54,7 @@ export class PhelRenameProvider implements vscode.RenameProvider {
             for (const occ of localOccurrences(src, local)) {
                 edit.replace(
                     document.uri,
-                    new vscode.Range(
-                        document.positionAt(occ.start),
-                        document.positionAt(occ.end)
-                    ),
+                    new vscode.Range(document.positionAt(occ.start), document.positionAt(occ.end)),
                     newName
                 );
             }

--- a/src/phelRenameProvider.ts
+++ b/src/phelRenameProvider.ts
@@ -8,6 +8,7 @@
 import * as vscode from 'vscode';
 import { findReferenceLocations } from './phelReferenceProvider';
 import { isValidSymbolName } from './phelReferences';
+import { resolveLocalAt, localOccurrences } from './phelScope';
 import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
 
 const SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;
@@ -43,8 +44,27 @@ export class PhelRenameProvider implements vscode.RenameProvider {
             return undefined;
         }
 
-        const locations = await findReferenceLocations(oldName, document, this.indexer);
         const edit = new vscode.WorkspaceEdit();
+
+        // A local binding renames only within its lexical scope in this file,
+        // leaving same-named globals and other-scope locals untouched.
+        const src = document.getText();
+        const local = resolveLocalAt(src, document.offsetAt(range.start));
+        if (local) {
+            for (const occ of localOccurrences(src, local)) {
+                edit.replace(
+                    document.uri,
+                    new vscode.Range(
+                        document.positionAt(occ.start),
+                        document.positionAt(occ.end)
+                    ),
+                    newName
+                );
+            }
+            return edit;
+        }
+
+        const locations = await findReferenceLocations(oldName, document, this.indexer);
         for (const loc of locations) {
             edit.replace(loc.uri, loc.range, newName);
         }

--- a/src/phelScope.ts
+++ b/src/phelScope.ts
@@ -1,0 +1,415 @@
+// Lexical-scope analysis for `.phel` source. Built on the structural reader in
+// `phelParedit` (`parseAll` / `pathAt`), it answers two questions the
+// navigation providers need:
+//
+//   1. Is the symbol token at a given offset a *local* binding (a fn/defn
+//      parameter, a `let`/`loop`/`binding` name, a `catch` var, an iteration
+//      var, …) rather than a global `def`/core symbol?
+//   2. If so, what is its declaring occurrence and lexical scope, so that
+//      go-to-definition, find-references, rename, and highlight can be scoped
+//      to *that* binding instead of every same-named token in the file.
+//
+// Design stance: only forms whose binding shape is unambiguous produce locals.
+// Anything unrecognised yields no binding, so callers fall back to the existing
+// global/workspace behaviour — the analyzer never makes rename *worse*, it only
+// narrows it when it is certain a symbol is local.
+//
+// No `vscode` imports: pure and unit-testable.
+
+import { parseAll, pathAt, type Form } from './phelParedit';
+import { findOccurrences, type Occurrence } from './phelReferences';
+
+export interface LocalBinding {
+    /** The bound symbol name. */
+    name: string;
+    /** Offset of the declaring occurrence (start of the binding symbol). */
+    declStart: number;
+    /** Offset just past the declaring occurrence. */
+    declEnd: number;
+    /** Start of the region where the binding is visible (inclusive). */
+    scopeStart: number;
+    /** End of the region where the binding is visible (exclusive). */
+    scopeEnd: number;
+}
+
+/** `let`-shaped forms: `(head [name init name init …] body…)`. */
+const PAIR_BINDING_HEADS = new Set(['let', 'loop', 'binding', 'with-open']);
+/** Single-pair conditional binding forms: `(head [name test] …)`. */
+const ONE_PAIR_HEADS = new Set(['if-let', 'when-let', 'if-some', 'when-some']);
+/** `fn`-shaped forms whose parameter vector(s) introduce locals. */
+const FN_HEADS = new Set(['fn', 'defn', 'defn-', 'defmacro', 'defmacro-']);
+/** Sequential-iteration forms: `(head [var … coll] body…)`. */
+const SEQ_HEADS = new Set(['for', 'doseq', 'dofor']);
+
+function atomText(src: string, form: Form): string {
+    return src.slice(form.bodyStart, form.bodyEnd);
+}
+
+function isAtom(form: Form | undefined): form is Form {
+    return !!form && form.kind === 'atom';
+}
+
+/** A plain, bindable symbol — not a keyword, rest-marker, ignore, or qualified. */
+function isBindableName(name: string): boolean {
+    if (!name || name === '&' || name === '_') {
+        return false;
+    }
+    const c = name[0];
+    if (c === ':' || c === '#' || c === '"' || c === '\\') {
+        return false;
+    }
+    if (name.includes('/')) {
+        return false; // qualified symbol => not a local
+    }
+    if (/^[-+]?\d/.test(name)) {
+        return false; // number
+    }
+    return true;
+}
+
+/**
+ * Collect the symbol names introduced by a binding *target* form, descending
+ * through vector and map destructuring. Returns each name with the offset of
+ * its declaring atom.
+ */
+function collectTargets(src: string, target: Form): { name: string; start: number; end: number }[] {
+    const out: { name: string; start: number; end: number }[] = [];
+    const visit = (f: Form): void => {
+        if (f.kind === 'atom') {
+            const name = atomText(src, f);
+            if (isBindableName(name)) {
+                out.push({ name, start: f.bodyStart, end: f.bodyEnd });
+            }
+            return;
+        }
+        if (f.kind === 'vector') {
+            for (const child of f.children) {
+                visit(child);
+            }
+            return;
+        }
+        if (f.kind === 'map') {
+            // Associative destructuring: {:keys [a b]}, {:as z}, {sym :key}, {:or {…}}.
+            const kids = f.children;
+            for (let i = 0; i + 1 < kids.length; i += 2) {
+                const key = kids[i];
+                const val = kids[i + 1];
+                const keyText = key.kind === 'atom' ? atomText(src, key) : '';
+                if (keyText === ':keys' || keyText === ':syms' || keyText === ':strs') {
+                    if (val.kind === 'vector') {
+                        for (const child of val.children) {
+                            visit(child);
+                        }
+                    }
+                } else if (keyText === ':as') {
+                    visit(val);
+                } else if (keyText === ':or') {
+                    // defaults — the keys are already bound via :keys/local pairs
+                } else if (key.kind === 'atom') {
+                    // {local-sym :some-key}
+                    visit(key);
+                }
+            }
+        }
+    };
+    visit(target);
+    return out;
+}
+
+/** The binding vector of a form, i.e. `children[1]` when it is a `[...]`. */
+function bindingVec(form: Form): Form | null {
+    const vec = form.children[1];
+    return vec && vec.kind === 'vector' ? vec : null;
+}
+
+/**
+ * Extract every local binding a single form introduces, each paired with the
+ * scope region in which it is visible. Unrecognised heads yield `[]`.
+ */
+function bindingsOf(src: string, form: Form): LocalBinding[] {
+    if (form.kind !== 'list' || form.children.length === 0) {
+        return [];
+    }
+    const head = form.children[0];
+    if (!isAtom(head)) {
+        return [];
+    }
+    const name = atomText(src, head);
+    const bodyEnd = form.innerEnd;
+
+    if (PAIR_BINDING_HEADS.has(name)) {
+        const vec = bindingVec(form);
+        if (!vec) {
+            return [];
+        }
+        const out: LocalBinding[] = [];
+        const pairs = vec.children;
+        for (let i = 0; i + 1 < pairs.length; i += 2) {
+            const target = pairs[i];
+            const init = pairs[i + 1];
+            // Sequential scope: a binding is visible from the end of its init
+            // through the rest of the form body (later inits + body).
+            const scopeStart = init.end;
+            for (const t of collectTargets(src, target)) {
+                out.push({
+                    name: t.name,
+                    declStart: t.start,
+                    declEnd: t.end,
+                    scopeStart,
+                    scopeEnd: bodyEnd,
+                });
+            }
+        }
+        return out;
+    }
+
+    if (ONE_PAIR_HEADS.has(name)) {
+        const vec = bindingVec(form);
+        if (!vec || vec.children.length < 2) {
+            return [];
+        }
+        const target = vec.children[0];
+        const init = vec.children[1];
+        return collectTargets(src, target).map((t) => ({
+            name: t.name,
+            declStart: t.start,
+            declEnd: t.end,
+            scopeStart: init.end,
+            scopeEnd: bodyEnd,
+        }));
+    }
+
+    if (name === 'catch') {
+        // (catch Type e body…) — the third child binds the exception.
+        const binding = form.children[2];
+        if (!isAtom(binding)) {
+            return [];
+        }
+        const bname = atomText(src, binding);
+        if (!isBindableName(bname)) {
+            return [];
+        }
+        return [
+            {
+                name: bname,
+                declStart: binding.bodyStart,
+                declEnd: binding.bodyEnd,
+                scopeStart: binding.bodyEnd,
+                scopeEnd: bodyEnd,
+            },
+        ];
+    }
+
+    if (name === 'foreach') {
+        // (foreach [k v coll] body…) or (foreach [v coll] body…): every element
+        // but the trailing collection expression is a binding target.
+        const vec = bindingVec(form);
+        if (!vec || vec.children.length < 2) {
+            return [];
+        }
+        const targets = vec.children.slice(0, -1);
+        const out: LocalBinding[] = [];
+        for (const target of targets) {
+            for (const t of collectTargets(src, target)) {
+                out.push({
+                    name: t.name,
+                    declStart: t.start,
+                    declEnd: t.end,
+                    scopeStart: vec.end,
+                    scopeEnd: bodyEnd,
+                });
+            }
+        }
+        return out;
+    }
+
+    if (SEQ_HEADS.has(name)) {
+        // (for [x :in coll … :let [y (f x)] …] body): the leading element is the
+        // primary loop var; `:let [pairs]` sub-vectors add more. Visible through
+        // the remaining binding clauses and the body.
+        const vec = bindingVec(form);
+        if (!vec || vec.children.length === 0) {
+            return [];
+        }
+        const out: LocalBinding[] = [];
+        const first = vec.children[0];
+        for (const t of collectTargets(src, first)) {
+            out.push({
+                name: t.name,
+                declStart: t.start,
+                declEnd: t.end,
+                scopeStart: first.end,
+                scopeEnd: bodyEnd,
+            });
+        }
+        const kids = vec.children;
+        for (let i = 0; i + 1 < kids.length; i++) {
+            const k = kids[i];
+            if (k.kind === 'atom' && atomText(src, k) === ':let') {
+                const letVec = kids[i + 1];
+                if (letVec.kind === 'vector') {
+                    for (let j = 0; j + 1 < letVec.children.length; j += 2) {
+                        const target = letVec.children[j];
+                        const init = letVec.children[j + 1];
+                        for (const t of collectTargets(src, target)) {
+                            out.push({
+                                name: t.name,
+                                declStart: t.start,
+                                declEnd: t.end,
+                                scopeStart: init.end,
+                                scopeEnd: bodyEnd,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        return out;
+    }
+
+    if (FN_HEADS.has(name)) {
+        return fnBindings(src, form, name);
+    }
+
+    return [];
+}
+
+/** Parameter (and self-name) bindings for `fn` / `defn` shaped forms. */
+function fnBindings(src: string, form: Form, head: string): LocalBinding[] {
+    const out: LocalBinding[] = [];
+    const kids = form.children;
+    // `defn`/`defmacro` name their def; the name is a global, not a local, so we
+    // skip it. `fn` may carry an optional *self* name, which IS a local.
+    let i = 1;
+    if (head === 'fn' && isAtom(kids[i]) && isBindableName(atomText(src, kids[i]))) {
+        const self = kids[i];
+        out.push({
+            name: atomText(src, self),
+            declStart: self.bodyStart,
+            declEnd: self.bodyEnd,
+            scopeStart: self.bodyEnd,
+            scopeEnd: form.innerEnd,
+        });
+        i++;
+    } else if (head !== 'fn') {
+        i++; // skip the def name
+    }
+
+    const addArity = (paramVec: Form, scopeEnd: number): void => {
+        for (const t of collectTargets(src, paramVec)) {
+            out.push({
+                name: t.name,
+                declStart: t.start,
+                declEnd: t.end,
+                scopeStart: paramVec.end,
+                scopeEnd,
+            });
+        }
+    };
+
+    // Single-arity: the first vector child is the parameter list.
+    const directVec = kids.slice(i).find((c) => c.kind === 'vector');
+    if (directVec) {
+        addArity(directVec, form.innerEnd);
+        return out;
+    }
+    // Multi-arity: each `([params] body…)` list is its own scope.
+    for (const arity of kids.slice(i)) {
+        if (arity.kind === 'list' && arity.children[0]?.kind === 'vector') {
+            addArity(arity.children[0], arity.innerEnd);
+        }
+    }
+    return out;
+}
+
+/** Every binding introduced by any list form on `path`, innermost first. */
+function bindingsOnPath(src: string, path: readonly Form[]): LocalBinding[] {
+    const out: LocalBinding[] = [];
+    for (let i = path.length - 1; i >= 0; i--) {
+        for (const b of bindingsOf(src, path[i])) {
+            out.push(b);
+        }
+    }
+    return out;
+}
+
+/**
+ * Resolve the local binding that governs the symbol token at `offset`, or null
+ * when the token is not a locally-bound symbol (caller should treat it as a
+ * global / core symbol).
+ */
+export function resolveLocalAt(src: string, offset: number): LocalBinding | null {
+    const forms = parseAll(src);
+    const path = pathAt(forms, offset);
+    const last = path[path.length - 1];
+    if (!last || last.kind !== 'atom') {
+        return null;
+    }
+    const name = atomText(src, last);
+    if (!isBindableName(name)) {
+        return null;
+    }
+    const pos = last.bodyStart;
+
+    // Case 1: the cursor is *on a declaration* — return that binding directly so
+    // rename/refs include the decl and shadowing resolves correctly.
+    const bindings = bindingsOnPath(src, path);
+    for (const b of bindings) {
+        if (b.declStart === pos && b.name === name) {
+            return b;
+        }
+    }
+    // Case 2: a *use* — nearest enclosing binding of the same name whose scope
+    // covers the offset wins (inner shadows outer).
+    for (const b of bindings) {
+        if (b.name === name && b.scopeStart <= pos && pos < b.scopeEnd) {
+            return b;
+        }
+    }
+    return null;
+}
+
+/**
+ * All occurrences (declaration + uses) of the local binding `b` in `src`,
+ * shadow-aware: an inner binding that re-uses the same name is excluded because
+ * those tokens resolve to the inner binding, not `b`.
+ */
+export function localOccurrences(src: string, b: LocalBinding): Occurrence[] {
+    const out: Occurrence[] = [];
+    for (const occ of findOccurrences(src, b.name)) {
+        if (occ.start === b.declStart) {
+            out.push(occ);
+            continue;
+        }
+        if (occ.start < b.declStart || occ.start >= b.scopeEnd) {
+            continue;
+        }
+        const resolved = resolveLocalAt(src, occ.start);
+        if (resolved && resolved.declStart === b.declStart) {
+            out.push(occ);
+        }
+    }
+    return out;
+}
+
+/**
+ * Names of every local binding visible at `offset`, nearest-scope first and
+ * de-duplicated. Used to surface in-scope locals in completion.
+ */
+export function localsInScopeAt(src: string, offset: number): string[] {
+    const forms = parseAll(src);
+    const path = pathAt(forms, offset);
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const b of bindingsOnPath(src, path)) {
+        // A local is offerable once its scope has opened at the cursor, or when
+        // the cursor sits inside the binding form at all (params being typed).
+        if (offset >= b.scopeStart || (offset >= b.declStart && offset < b.scopeEnd)) {
+            if (!seen.has(b.name)) {
+                seen.add(b.name);
+                out.push(b.name);
+            }
+        }
+    }
+    return out;
+}

--- a/src/test/phelScope.test.ts
+++ b/src/test/phelScope.test.ts
@@ -1,0 +1,183 @@
+import * as assert from 'node:assert/strict';
+import { resolveLocalAt, localOccurrences, localsInScopeAt } from '../phelScope';
+
+/** Offset of the `nth` (0-based) occurrence of `token` in `src`. */
+function idx(src: string, token: string, nth = 0): number {
+    let i = -1;
+    for (let k = 0; k <= nth; k++) {
+        i = src.indexOf(token, i + 1);
+        if (i < 0) {
+            throw new Error(`token ${token} #${nth} not found`);
+        }
+    }
+    return i;
+}
+
+function occStarts(src: string, offset: number): number[] {
+    const b = resolveLocalAt(src, offset);
+    assert.ok(b, 'expected a local binding');
+    return localOccurrences(src, b).map((o) => o.start);
+}
+
+describe('phelScope.resolveLocalAt', () => {
+    it('resolves a let-bound local from a use', () => {
+        const src = '(let [x 1] (+ x x))';
+        const b = resolveLocalAt(src, idx(src, 'x', 1));
+        assert.ok(b);
+        assert.equal(b.name, 'x');
+        assert.equal(b.declStart, idx(src, 'x', 0));
+    });
+
+    it('resolves from the declaration itself', () => {
+        const src = '(let [x 1] x)';
+        const b = resolveLocalAt(src, idx(src, 'x', 0));
+        assert.ok(b);
+        assert.equal(b.declStart, idx(src, 'x', 0));
+    });
+
+    it('returns null for a global def name', () => {
+        const src = '(def answer 42)\n(+ answer 1)';
+        assert.equal(resolveLocalAt(src, idx(src, 'answer', 0)), null);
+        assert.equal(resolveLocalAt(src, idx(src, 'answer', 1)), null);
+    });
+
+    it('returns null for a core symbol', () => {
+        const src = '(map inc [1 2 3])';
+        assert.equal(resolveLocalAt(src, idx(src, 'map')), null);
+        assert.equal(resolveLocalAt(src, idx(src, 'inc')), null);
+    });
+
+    it('does not treat a defn name as a local', () => {
+        const src = '(defn foo [a] (foo a))';
+        assert.equal(resolveLocalAt(src, idx(src, 'foo', 0)), null);
+        assert.equal(resolveLocalAt(src, idx(src, 'foo', 1)), null);
+        assert.ok(resolveLocalAt(src, idx(src, 'a', 1)));
+    });
+
+    it('resolves a named fn self-reference as local', () => {
+        const src = '(fn fact [n] (fact n))';
+        const b = resolveLocalAt(src, idx(src, 'fact', 1));
+        assert.ok(b);
+        assert.equal(b.declStart, idx(src, 'fact', 0));
+    });
+});
+
+describe('phelScope.localOccurrences', () => {
+    it('collects declaration and uses of a let local', () => {
+        const src = '(let [x 1] (+ x x))';
+        assert.deepEqual(occStarts(src, idx(src, 'x', 1)), [
+            idx(src, 'x', 0),
+            idx(src, 'x', 1),
+            idx(src, 'x', 2),
+        ]);
+    });
+
+    it('excludes a same-named global outside the scope', () => {
+        const src = '(def x 1)\n(let [x 2] x)';
+        // Rename target is the *local* x; the global def x must be untouched.
+        assert.deepEqual(occStarts(src, idx(src, 'x', 2)), [
+            idx(src, 'x', 1),
+            idx(src, 'x', 2),
+        ]);
+    });
+
+    it('respects inner shadowing (a nested let re-binds the name)', () => {
+        const src = '(let [x 1] (list x (let [x 2] x) x))';
+        // Outer x: decl + the two outer uses, but NOT the inner shadow.
+        const outer = occStarts(src, idx(src, 'x', 0));
+        assert.deepEqual(outer, [idx(src, 'x', 0), idx(src, 'x', 1), idx(src, 'x', 4)]);
+        // Inner x: its own decl + use only.
+        const inner = occStarts(src, idx(src, 'x', 2));
+        assert.deepEqual(inner, [idx(src, 'x', 2), idx(src, 'x', 3)]);
+    });
+
+    it('keeps separate fn arities apart', () => {
+        const src = '(fn ([a] a) ([a b] (+ a b)))';
+        // First arity a: decl + one use.
+        assert.deepEqual(occStarts(src, idx(src, 'a', 1)), [
+            idx(src, 'a', 0),
+            idx(src, 'a', 1),
+        ]);
+    });
+
+    it('scopes fn parameters', () => {
+        const src = '(fn [a b] (+ a b))';
+        assert.deepEqual(occStarts(src, idx(src, 'a', 1)), [idx(src, 'a', 0), idx(src, 'a', 1)]);
+    });
+});
+
+describe('phelScope destructuring', () => {
+    it('binds vector destructuring names', () => {
+        const src = '(let [[a b] xs] (+ a b))';
+        assert.deepEqual(occStarts(src, idx(src, 'a', 1)), [idx(src, 'a', 0), idx(src, 'a', 1)]);
+    });
+
+    it('binds :keys map destructuring', () => {
+        const src = '(let [{:keys [x y]} m] (+ x y))';
+        assert.deepEqual(occStarts(src, idx(src, 'x', 1)), [idx(src, 'x', 0), idx(src, 'x', 1)]);
+    });
+
+    it('binds :as map destructuring', () => {
+        const src = '(let [{:as whole} m] whole)';
+        assert.deepEqual(occStarts(src, idx(src, 'whole', 1)), [
+            idx(src, 'whole', 0),
+            idx(src, 'whole', 1),
+        ]);
+    });
+});
+
+describe('phelScope binding forms', () => {
+    it('binds when-let targets', () => {
+        const src = '(when-let [v (find x)] (use v))';
+        const b = resolveLocalAt(src, idx(src, 'v', 1));
+        assert.ok(b);
+        assert.equal(b.declStart, idx(src, 'v', 0));
+    });
+
+    it('binds a catch exception var with a php class type', () => {
+        const src = '(try (boom) (catch \\Throwable ex (log ex)))';
+        const b = resolveLocalAt(src, idx(src, 'ex', 1));
+        assert.ok(b);
+        assert.equal(b.name, 'ex');
+        assert.deepEqual(localOccurrences(src, b).map((o) => o.start), [
+            idx(src, 'ex', 0),
+            idx(src, 'ex', 1),
+        ]);
+    });
+
+    it('binds a for loop var', () => {
+        const src = '(for [x :in coll] (inc x))';
+        assert.deepEqual(occStarts(src, idx(src, 'x', 1)), [idx(src, 'x', 0), idx(src, 'x', 1)]);
+    });
+
+    it('binds a doseq loop var', () => {
+        const src = '(doseq [x coll] (print x))';
+        assert.deepEqual(occStarts(src, idx(src, 'x', 1)), [idx(src, 'x', 0), idx(src, 'x', 1)]);
+    });
+
+    it('binds foreach key/value vars but not the collection', () => {
+        const src = '(foreach [k v m] (print k v))';
+        assert.deepEqual(occStarts(src, idx(src, 'k', 1)), [idx(src, 'k', 0), idx(src, 'k', 1)]);
+        assert.deepEqual(occStarts(src, idx(src, 'v', 1)), [idx(src, 'v', 0), idx(src, 'v', 1)]);
+        // `m` is the collection, not a binding.
+        assert.equal(resolveLocalAt(src, idx(src, 'm', 0)), null);
+    });
+});
+
+describe('phelScope.localsInScopeAt', () => {
+    it('lists params and let names visible in the body', () => {
+        const src = '(defn f [a b] (let [c 1] BODY))';
+        // Cursor at the BODY marker sees a, b and c.
+        const inBody = localsInScopeAt(src, idx(src, 'BODY'));
+        assert.ok(inBody.includes('a'));
+        assert.ok(inBody.includes('b'));
+        assert.ok(inBody.includes('c'));
+    });
+
+    it('does not leak locals outside their form', () => {
+        const src = '(defn f [a] a)\n(defn g [b] b)';
+        const inG = localsInScopeAt(src, idx(src, 'b', 1));
+        assert.ok(inG.includes('b'));
+        assert.ok(!inG.includes('a'));
+    });
+});

--- a/src/test/phelScope.test.ts
+++ b/src/test/phelScope.test.ts
@@ -75,10 +75,7 @@ describe('phelScope.localOccurrences', () => {
     it('excludes a same-named global outside the scope', () => {
         const src = '(def x 1)\n(let [x 2] x)';
         // Rename target is the *local* x; the global def x must be untouched.
-        assert.deepEqual(occStarts(src, idx(src, 'x', 2)), [
-            idx(src, 'x', 1),
-            idx(src, 'x', 2),
-        ]);
+        assert.deepEqual(occStarts(src, idx(src, 'x', 2)), [idx(src, 'x', 1), idx(src, 'x', 2)]);
     });
 
     it('respects inner shadowing (a nested let re-binds the name)', () => {
@@ -94,10 +91,7 @@ describe('phelScope.localOccurrences', () => {
     it('keeps separate fn arities apart', () => {
         const src = '(fn ([a] a) ([a b] (+ a b)))';
         // First arity a: decl + one use.
-        assert.deepEqual(occStarts(src, idx(src, 'a', 1)), [
-            idx(src, 'a', 0),
-            idx(src, 'a', 1),
-        ]);
+        assert.deepEqual(occStarts(src, idx(src, 'a', 1)), [idx(src, 'a', 0), idx(src, 'a', 1)]);
     });
 
     it('scopes fn parameters', () => {
@@ -139,10 +133,10 @@ describe('phelScope binding forms', () => {
         const b = resolveLocalAt(src, idx(src, 'ex', 1));
         assert.ok(b);
         assert.equal(b.name, 'ex');
-        assert.deepEqual(localOccurrences(src, b).map((o) => o.start), [
-            idx(src, 'ex', 0),
-            idx(src, 'ex', 1),
-        ]);
+        assert.deepEqual(
+            localOccurrences(src, b).map((o) => o.start),
+            [idx(src, 'ex', 0), idx(src, 'ex', 1)]
+        );
     });
 
     it('binds a for loop var', () => {


### PR DESCRIPTION
Makes the extension's navigation understand **lexical scope**, so editing Phel — writing functions/macros and moving between local and global vars — is precise instead of name-matched.

## Problem

Go-to-definition, find-references, rename, and highlight were purely **name-based**. On a `let`/`fn` local `x` they matched *every* `x` in the file — unrelated locals, and same-named globals. Rename a parameter `x` and it rewrote a global `x` and other functions' `x` too.

## What changed

New pure module **`src/phelScope.ts`** (built on the existing `phelParedit` reader) with `resolveLocalAt`, `localOccurrences`, and `localsInScopeAt`. It understands:

- `fn` / `defn` / `defn-` / `defmacro` parameters — including **multi-arity** and the optional `fn` **self-name**
- `let` / `loop` / `binding` / `with-open` bindings (sequential scope)
- `if-let` / `when-let` / `if-some` / `when-some`
- `for` / `doseq` / `dofor` loop vars (+ `:let` clauses), `foreach` key/value vars
- `catch` exception var (robust to `\Throwable` PHP-class types)
- vector, `:keys` / `:syms` / `:strs`, and `:as` destructuring
- **shadowing**: an inner binding that reuses a name correctly splits occurrences

Wired into the providers:

| Feature | Local symbol | Global symbol |
|---|---|---|
| Go-to-definition | jumps to the binding site | workspace/core (unchanged) |
| Find references / highlight | scoped to the binding's extent | workspace-wide (unchanged) |
| Rename | only within the local scope | workspace-wide (unchanged) |
| Completion | in-scope locals ranked first + current-file `defn-` | core + workspace (unchanged) |

**Safety:** unrecognised forms yield no local, so anything uncertain falls back to today's global behaviour — rename never gets *broader*, only correctly *narrower*.

## Verification

- `npm run pretest` (compile + eslint) — clean
- `npm test` — **350 passing** (+21 new `phelScope` tests: shadowing, multi-arity, destructuring, catch, loop vars, global fallback)
- `npm run bundle:prod` — clean

Also bumps stale version refs in `CONTRIBUTING.md` and `docs/installation.md`.