### PR TITLE
feat(highlight): semantic tokens for locals + unused-local hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Language support
+
+- **Semantic highlighting for locals.** A `DocumentSemanticTokensProvider` tags every `fn` / `defn` parameter (as `parameter`) and every `let` / `loop` / `for` / `catch` / … binding (as `variable`), with each declaration site flagged, so colour themes render locals distinctly from globals and core symbols. It reuses the `phelScope` analyzer, so highlighting and go-to-definition always agree on what a local is.
+- **Unused-local hints.** Bindings that are declared but never read are marked with `DiagnosticTag.Unnecessary` (VS Code renders them faded); parameters and `_`-prefixed names are exempt. Both features are part of the bundled providers and stand down when the Phel language server is active.
+
 ## [0.10.0] - 2026-07-24
 
 ### Language support

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,8 @@ import { PhelDocumentHighlightProvider } from './phelDocumentHighlight';
 import { PhelReferenceProvider } from './phelReferenceProvider';
 import { PhelRenameProvider } from './phelRenameProvider';
 import { PhelDocumentSymbolProvider, PhelWorkspaceSymbolProvider } from './phelSymbolProviders';
+import { PhelSemanticTokensProvider, SEMANTIC_LEGEND } from './phelSemanticTokens';
+import { PhelUnusedLocals } from './phelUnusedLocals';
 import { registerPareditCommands } from './phelPareditProvider';
 import { registerReplCommands } from './phelReplProvider';
 import { registerNreplCommands } from './phelNreplProvider';
@@ -345,6 +347,16 @@ function registerLanguageProviders(context: vscode.ExtensionContext): void {
             new PhelWorkspaceSymbolProvider(workspaceIndexer)
         )
     );
+
+    context.subscriptions.push(
+        vscode.languages.registerDocumentSemanticTokensProvider(
+            'phel',
+            new PhelSemanticTokensProvider(),
+            SEMANTIC_LEGEND
+        )
+    );
+
+    context.subscriptions.push(new PhelUnusedLocals());
 
     workspaceIndexer.onDidChange(() => {
         // Trigger re-evaluation of the active doc so providers refresh.

--- a/src/phelScope.ts
+++ b/src/phelScope.ts
@@ -30,6 +30,8 @@ export interface LocalBinding {
     scopeStart: number;
     /** End of the region where the binding is visible (exclusive). */
     scopeEnd: number;
+    /** True when this binding is a function parameter (vs a let/loop/… name). */
+    param?: boolean;
 }
 
 /** `let`-shaped forms: `(head [name init name init …] body…)`. */
@@ -303,6 +305,7 @@ function fnBindings(src: string, form: Form, head: string): LocalBinding[] {
                 declEnd: t.end,
                 scopeStart: paramVec.end,
                 scopeEnd,
+                param: true,
             });
         }
     };
@@ -409,6 +412,58 @@ export function localsInScopeAt(src: string, offset: number): string[] {
                 seen.add(b.name);
                 out.push(b.name);
             }
+        }
+    }
+    return out;
+}
+
+/**
+ * Every local binding declared anywhere in `src`, de-duplicated by declaration
+ * site. Used by whole-document consumers (semantic highlighting, unused-local
+ * analysis) that need every binding rather than the one under a cursor.
+ */
+export function collectAllBindings(src: string): LocalBinding[] {
+    const out: LocalBinding[] = [];
+    const seen = new Set<number>();
+    const walk = (form: Form): void => {
+        if (form.kind === 'list') {
+            for (const b of bindingsOf(src, form)) {
+                if (!seen.has(b.declStart)) {
+                    seen.add(b.declStart);
+                    out.push(b);
+                }
+            }
+        }
+        for (const child of form.children) {
+            walk(child);
+        }
+    };
+    for (const form of parseAll(src)) {
+        walk(form);
+    }
+    return out;
+}
+
+export interface UnusedLocal {
+    name: string;
+    start: number;
+    end: number;
+}
+
+/**
+ * Local bindings that are declared but never read within their scope.
+ * Parameters and `_`-prefixed names are exempt (an unused parameter is often
+ * required by a callback/arity contract; `_` is the conventional ignore).
+ */
+export function findUnusedLocals(src: string): UnusedLocal[] {
+    const out: UnusedLocal[] = [];
+    for (const b of collectAllBindings(src)) {
+        if (b.param || b.name.startsWith('_')) {
+            continue;
+        }
+        // A single occurrence is the declaration itself with no reads.
+        if (localOccurrences(src, b).length <= 1) {
+            out.push({ name: b.name, start: b.declStart, end: b.declEnd });
         }
     }
     return out;

--- a/src/phelSemanticTokens.ts
+++ b/src/phelSemanticTokens.ts
@@ -1,0 +1,54 @@
+// Semantic highlighting for locally-bound symbols. TextMate scopes colour
+// syntax categories (keywords, strings, numbers); this layer adds *meaning*:
+// every `fn`/`defn` parameter and `let`/`loop`/… binding — and each of its
+// uses — is tagged so themes can render locals distinctly from globals and
+// core symbols. Built on the same `phelScope` analyzer the navigation
+// providers use, so highlighting and go-to-definition agree on what a local is.
+
+import * as vscode from 'vscode';
+import { collectAllBindings, localOccurrences } from './phelScope';
+
+export const SEMANTIC_LEGEND = new vscode.SemanticTokensLegend(
+    ['parameter', 'variable'],
+    ['declaration', 'readonly']
+);
+
+// Skip the whole pass on very large buffers: semantic tokens are recomputed on
+// every edit and the per-binding occurrence walk is superlinear.
+const MAX_CHARS = 200_000;
+
+export class PhelSemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
+    provideDocumentSemanticTokens(document: vscode.TextDocument): vscode.SemanticTokens {
+        const builder = new vscode.SemanticTokensBuilder(SEMANTIC_LEGEND);
+        const src = document.getText();
+        if (src.length > MAX_CHARS) {
+            return builder.build();
+        }
+
+        interface Tok {
+            start: number;
+            end: number;
+            type: string;
+            mods: string[];
+        }
+        const toks: Tok[] = [];
+        for (const b of collectAllBindings(src)) {
+            const type = b.param ? 'parameter' : 'variable';
+            for (const occ of localOccurrences(src, b)) {
+                const mods = occ.start === b.declStart ? ['declaration', 'readonly'] : ['readonly'];
+                toks.push({ start: occ.start, end: occ.end, type, mods });
+            }
+        }
+        // The builder encodes tokens as deltas, so they must be pushed in
+        // document order.
+        toks.sort((a, b) => a.start - b.start);
+        for (const t of toks) {
+            const range = new vscode.Range(
+                document.positionAt(t.start),
+                document.positionAt(t.end)
+            );
+            builder.push(range, t.type, t.mods);
+        }
+        return builder.build();
+    }
+}

--- a/src/phelUnusedLocals.ts
+++ b/src/phelUnusedLocals.ts
@@ -1,0 +1,89 @@
+// Flags local bindings that are declared but never read, so VS Code can render
+// them faded (via `DiagnosticTag.Unnecessary`). The detector `findUnusedLocals`
+// lives in `phelScope` (pure, unit-tested); this module owns the diagnostic
+// collection and wires it to the bundled-provider lifecycle so it never runs
+// alongside the language server.
+
+import * as vscode from 'vscode';
+import { findUnusedLocals } from './phelScope';
+
+const MAX_CHARS = 200_000;
+
+/** Owns a diagnostic collection updated (debounced) as `.phel` buffers change. */
+export class PhelUnusedLocals implements vscode.Disposable {
+    private readonly collection = vscode.languages.createDiagnosticCollection('phel-unused');
+    private readonly subs: vscode.Disposable[] = [];
+    private readonly timers = new Map<string, NodeJS.Timeout>();
+
+    constructor() {
+        this.subs.push(
+            vscode.workspace.onDidOpenTextDocument((d) => this.schedule(d)),
+            vscode.workspace.onDidChangeTextDocument((e) => this.schedule(e.document)),
+            vscode.workspace.onDidCloseTextDocument((d) => {
+                this.collection.delete(d.uri);
+                const key = d.uri.toString();
+                const t = this.timers.get(key);
+                if (t) {
+                    clearTimeout(t);
+                    this.timers.delete(key);
+                }
+            })
+        );
+        for (const d of vscode.workspace.textDocuments) {
+            this.refresh(d);
+        }
+    }
+
+    private schedule(doc: vscode.TextDocument): void {
+        if (doc.languageId !== 'phel') {
+            return;
+        }
+        const key = doc.uri.toString();
+        const existing = this.timers.get(key);
+        if (existing) {
+            clearTimeout(existing);
+        }
+        this.timers.set(
+            key,
+            setTimeout(() => {
+                this.timers.delete(key);
+                this.refresh(doc);
+            }, 250)
+        );
+    }
+
+    private refresh(doc: vscode.TextDocument): void {
+        if (doc.languageId !== 'phel') {
+            return;
+        }
+        const src = doc.getText();
+        if (src.length > MAX_CHARS) {
+            // Too large to analyse on every change; clear stale results.
+            this.collection.delete(doc.uri);
+            return;
+        }
+        const diags = findUnusedLocals(src).map((u) => {
+            const range = new vscode.Range(doc.positionAt(u.start), doc.positionAt(u.end));
+            const diag = new vscode.Diagnostic(
+                range,
+                `'${u.name}' is bound but never used`,
+                vscode.DiagnosticSeverity.Hint
+            );
+            diag.tags = [vscode.DiagnosticTag.Unnecessary];
+            diag.source = 'phel';
+            return diag;
+        });
+        this.collection.set(doc.uri, diags);
+    }
+
+    dispose(): void {
+        for (const t of this.timers.values()) {
+            clearTimeout(t);
+        }
+        this.timers.clear();
+        this.collection.dispose();
+        for (const s of this.subs) {
+            s.dispose();
+        }
+    }
+}

--- a/src/test/phelScope.test.ts
+++ b/src/test/phelScope.test.ts
@@ -1,5 +1,11 @@
 import * as assert from 'node:assert/strict';
-import { resolveLocalAt, localOccurrences, localsInScopeAt } from '../phelScope';
+import {
+    resolveLocalAt,
+    localOccurrences,
+    localsInScopeAt,
+    collectAllBindings,
+    findUnusedLocals,
+} from '../phelScope';
 
 /** Offset of the `nth` (0-based) occurrence of `token` in `src`. */
 function idx(src: string, token: string, nth = 0): number {
@@ -173,5 +179,40 @@ describe('phelScope.localsInScopeAt', () => {
         const inG = localsInScopeAt(src, idx(src, 'b', 1));
         assert.ok(inG.includes('b'));
         assert.ok(!inG.includes('a'));
+    });
+});
+
+describe('phelScope.collectAllBindings', () => {
+    it('collects nested bindings across every form', () => {
+        const src = '(defn f [a] (let [b 1] (+ a b)))\n(fn [c] c)';
+        const names = collectAllBindings(src)
+            .map((b) => b.name)
+            .sort();
+        assert.deepEqual(names, ['a', 'b', 'c']);
+    });
+
+    it('tags parameters distinctly from let names', () => {
+        const src = '(defn f [a] (let [b 1] b))';
+        const all = collectAllBindings(src);
+        assert.equal(all.find((b) => b.name === 'a')?.param, true);
+        assert.ok(!all.find((b) => b.name === 'b')?.param);
+    });
+});
+
+describe('phelScope.findUnusedLocals', () => {
+    it('flags a let binding that is never read', () => {
+        const src = '(let [used 1 dead 2] used)';
+        const unused = findUnusedLocals(src).map((u) => u.name);
+        assert.deepEqual(unused, ['dead']);
+    });
+
+    it('does not flag used bindings', () => {
+        const src = '(let [x 1] (+ x x))';
+        assert.deepEqual(findUnusedLocals(src), []);
+    });
+
+    it('exempts parameters and _-prefixed names', () => {
+        const src = '(defn f [a] (let [_ignored 1] 42))';
+        assert.deepEqual(findUnusedLocals(src), []);
     });
 });


### PR DESCRIPTION
Adds **meaning-aware highlighting** on top of the TextMate grammar — the first of a set of Calva/clojure-lsp-inspired improvements, tuned for Phel. Reuses the `phelScope` analyzer shipped earlier, so highlighting and go-to-definition never disagree about what a local is.

## What you get

- **Semantic tokens.** Every `fn` / `defn` parameter is tagged `parameter`; every `let` / `loop` / `for` / `doseq` / `foreach` / `catch` / `if-let` / `with-open` / … binding is tagged `variable`; declaration sites carry the `declaration` modifier and all locals `readonly`. Themes can now colour a parameter or let-binding differently from a global `def` or a core fn.
- **Unused-local hints.** A binding declared but never read is flagged with `DiagnosticTag.Unnecessary`, which VS Code renders **faded** — no squiggle noise (severity `Hint`). Parameters and `_`-prefixed names are exempt (unused params are often contract-required).

Both are part of the **bundled providers** and stand down automatically when `phel lsp` is active, matching the existing mutual-exclusion.

## Implementation

- `phelScope`: `collectAllBindings` (every binding in a document) + `findUnusedLocals` (pure, tested) + a `param` tag on parameter bindings.
- `phelSemanticTokens.ts`: `DocumentSemanticTokensProvider` (size-guarded at 200 KB; tokens emitted in document order for the delta encoder).
- `phelUnusedLocals.ts`: debounced (250 ms) `DiagnosticCollection` keyed per document.

## Verification

- `npm run compile` / `npm run lint` / `npm run format:check` — clean
- `npm test` — **355 passing** (+5 new: `collectAllBindings`, `findUnusedLocals`)
- `npm run bundle:prod` — clean

No new standard-token contributions needed — `parameter` / `variable` and `declaration` / `readonly` are themed by default.