### PR TITLE
feat(refactor): thread/unthread, cycle collection, add-require code actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - **Semantic highlighting for locals.** A `DocumentSemanticTokensProvider` tags every `fn` / `defn` parameter (as `parameter`) and every `let` / `loop` / `for` / `catch` / … binding (as `variable`), with each declaration site flagged, so colour themes render locals distinctly from globals and core symbols. It reuses the `phelScope` analyzer, so highlighting and go-to-definition always agree on what a local is.
 - **Unused-local hints.** Bindings that are declared but never read are marked with `DiagnosticTag.Unnecessary` (VS Code renders them faded); parameters and `_`-prefixed names are exempt. Both features are part of the bundled providers and stand down when the Phel language server is active.
 
+### Refactoring & code actions
+
+- **Structural refactorings** on the form at the cursor (lightbulb / `Ctrl+.`): **Thread first** (`->`) and **Thread last** (`->>`), each fully unwinding the threaded-argument spine (`(map f (filter p xs))` → `(->> xs (filter p) (map f))`); **Unwind thread**, the inverse; and **Cycle collection**, rotating a collection's delimiters `(` → `[` → `{` → `(`.
+- **Add missing `:require`** quick-fix: when the bare symbol under the cursor is a known core/workspace name that the file has not imported, offers to insert the matching `(:require [ns :refer [name]])` entry into the `(ns …)` form. Bundled-only; stands down under `phel lsp`.
+
 ## [0.10.0] - 2026-07-24
 
 ### Language support

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import { PhelRenameProvider } from './phelRenameProvider';
 import { PhelDocumentSymbolProvider, PhelWorkspaceSymbolProvider } from './phelSymbolProviders';
 import { PhelSemanticTokensProvider, SEMANTIC_LEGEND } from './phelSemanticTokens';
 import { PhelUnusedLocals } from './phelUnusedLocals';
+import { PhelCodeActionProvider } from './phelCodeActionsProvider';
 import { registerPareditCommands } from './phelPareditProvider';
 import { registerReplCommands } from './phelReplProvider';
 import { registerNreplCommands } from './phelNreplProvider';
@@ -357,6 +358,14 @@ function registerLanguageProviders(context: vscode.ExtensionContext): void {
     );
 
     context.subscriptions.push(new PhelUnusedLocals());
+
+    context.subscriptions.push(
+        vscode.languages.registerCodeActionsProvider(
+            'phel',
+            new PhelCodeActionProvider(workspaceIndexer),
+            { providedCodeActionKinds: PhelCodeActionProvider.kinds }
+        )
+    );
 
     workspaceIndexer.onDidChange(() => {
         // Trigger re-evaluation of the active doc so providers refresh.

--- a/src/phelCodeActionsProvider.ts
+++ b/src/phelCodeActionsProvider.ts
@@ -1,0 +1,95 @@
+// Lightbulb refactorings for `.phel`, inspired by clojure-lsp / Calva but
+// scoped to what the bundled analyzer can do reliably:
+//   - Thread first / last (`->` / `->>`) and unwind, over the form at the cursor
+//   - Cycle a collection's delimiters: `(` → `[` → `{` → `(`
+//   - Quick-fix: add a missing `:require` for a known symbol
+// The structural transforms live in `phelRefactor` (pure, unit-tested); this
+// module adapts them to VS Code code actions.
+
+import * as vscode from 'vscode';
+import { threadForm, unthreadForm, cycleCollection, type RefactorEdit } from './phelRefactor';
+import { lookupSymbol } from './phelDocsLookup';
+import { parseNsForm, buildRequireEdit } from './phelNsAnalyzer';
+import { combineDocs } from './phelWorkspaceIndex';
+import { PHEL_DOCS } from './phelCoreDocs';
+import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
+
+const SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;
+
+export class PhelCodeActionProvider implements vscode.CodeActionProvider {
+    static readonly kinds = [vscode.CodeActionKind.RefactorRewrite, vscode.CodeActionKind.QuickFix];
+
+    constructor(private readonly indexer: PhelWorkspaceIndexer) {}
+
+    provideCodeActions(
+        document: vscode.TextDocument,
+        range: vscode.Range | vscode.Selection
+    ): vscode.CodeAction[] {
+        const src = document.getText();
+        const offset = document.offsetAt(range.start);
+        const actions: vscode.CodeAction[] = [];
+
+        const rewrite = (title: string, edit: RefactorEdit | null): void => {
+            if (!edit) {
+                return;
+            }
+            const action = new vscode.CodeAction(title, vscode.CodeActionKind.RefactorRewrite);
+            action.edit = new vscode.WorkspaceEdit();
+            action.edit.replace(
+                document.uri,
+                new vscode.Range(document.positionAt(edit.start), document.positionAt(edit.end)),
+                edit.text
+            );
+            actions.push(action);
+        };
+
+        rewrite('Thread first (->)', threadForm(src, offset, false));
+        rewrite('Thread last (->>)', threadForm(src, offset, true));
+        rewrite('Unwind thread', unthreadForm(src, offset));
+        rewrite('Cycle collection () [] {}', cycleCollection(src, offset));
+
+        const req = this.addRequireAction(document, range, src);
+        if (req) {
+            actions.push(req);
+        }
+        return actions;
+    }
+
+    /** Offer to add a `:require` when the symbol at the cursor is a known, un-imported name. */
+    private addRequireAction(
+        document: vscode.TextDocument,
+        range: vscode.Range,
+        src: string
+    ): vscode.CodeAction | null {
+        const wordRange = document.getWordRangeAtPosition(range.start, SYMBOL_RE);
+        if (!wordRange) {
+            return null;
+        }
+        const word = document.getText(wordRange);
+        // Only bare names: qualified/keyword tokens need `:as`, which the
+        // require builder does not synthesise.
+        if (word.includes('/') || word.startsWith(':')) {
+            return null;
+        }
+        const nsForm = parseNsForm(src);
+        if (!nsForm) {
+            return null;
+        }
+        const merged = combineDocs(this.indexer.index.allDocs(), PHEL_DOCS);
+        const doc = lookupSymbol(word, merged);
+        if (!doc || !doc.ns) {
+            return null;
+        }
+        const edit = buildRequireEdit(nsForm, doc.ns, word);
+        if (!edit) {
+            return null; // already required, core, or same namespace
+        }
+        const action = new vscode.CodeAction(
+            `Add (:require [${doc.ns} :refer [${word}]])`,
+            vscode.CodeActionKind.QuickFix
+        );
+        action.edit = new vscode.WorkspaceEdit();
+        action.edit.insert(document.uri, document.positionAt(edit.insertAt), edit.text);
+        return action;
+    }
+}

--- a/src/phelRefactor.ts
+++ b/src/phelRefactor.ts
@@ -1,0 +1,160 @@
+// Pure structural refactorings over the `phelParedit` reader. Each takes source
+// plus a cursor offset and returns a single text replacement (or null when the
+// refactor does not apply at that position). No `vscode` imports, so the
+// transforms are unit-testable in isolation from the code-action provider.
+
+import { parseAll, pathAt, type Form } from './phelParedit';
+
+export interface RefactorEdit {
+    /** Replace `[start, end)` in the source with `text`. */
+    start: number;
+    end: number;
+    text: string;
+}
+
+function text(src: string, f: Form): string {
+    return src.slice(f.start, f.end);
+}
+
+function headName(src: string, f: Form): string | null {
+    if (f.kind !== 'list' || f.children.length === 0) {
+        return null;
+    }
+    const head = f.children[0];
+    return head.kind === 'atom' ? text(src, head) : null;
+}
+
+/** Innermost enclosing list form at `offset`, or null. */
+function enclosingList(src: string, offset: number): Form | null {
+    const path = pathAt(parseAll(src), offset);
+    for (let i = path.length - 1; i >= 0; i--) {
+        if (path[i].kind === 'list') {
+            return path[i];
+        }
+    }
+    return null;
+}
+
+/** Innermost enclosing container (list / vector / map) at `offset`, or null. */
+function enclosingContainer(src: string, offset: number): Form | null {
+    const path = pathAt(parseAll(src), offset);
+    for (let i = path.length - 1; i >= 0; i--) {
+        const k = path[i].kind;
+        if (k === 'list' || k === 'vector' || k === 'map') {
+            return path[i];
+        }
+    }
+    return null;
+}
+
+const ARROWS = new Set(['->', '->>']);
+
+/**
+ * Thread the call at `offset` into a `->` (first) or `->>` (last) pipeline,
+ * fully unwinding the threaded-argument spine. `(map f (filter p xs))` becomes
+ * `(->> xs (filter p) (map f))` with `last`, or a `->` chain otherwise.
+ */
+export function threadForm(src: string, offset: number, last: boolean): RefactorEdit | null {
+    const target = enclosingList(src, offset);
+    if (!target) {
+        return null;
+    }
+    const startHead = headName(src, target);
+    if (startHead === null || ARROWS.has(startHead)) {
+        return null; // not a plain call, or already threaded
+    }
+
+    const arrow = last ? '->>' : '->';
+    const steps: string[] = [];
+    let cur: Form = target;
+    for (;;) {
+        if (cur.kind !== 'list' || cur.children.length < 2) {
+            return null; // nothing to thread out of this node
+        }
+        const head = cur.children[0];
+        if (head.kind !== 'atom') {
+            return null;
+        }
+        const args = cur.children.slice(1);
+        const threadedIdx = last ? args.length - 1 : 0;
+        const threaded = args[threadedIdx];
+        const others = args.filter((_, i) => i !== threadedIdx);
+        const headText = text(src, head);
+        const step =
+            others.length === 0
+                ? headText
+                : `(${headText} ${others.map((a) => text(src, a)).join(' ')})`;
+        steps.unshift(step);
+
+        const threadable =
+            threaded.kind === 'list' &&
+            threaded.children.length >= 2 &&
+            threaded.children[0].kind === 'atom';
+        if (!threadable) {
+            const body = [arrow, text(src, threaded), ...steps].join(' ');
+            return { start: target.start, end: target.end, text: `(${body})` };
+        }
+        cur = threaded;
+    }
+}
+
+/**
+ * Unwind the `->` / `->>` pipeline at `offset` back into nested calls.
+ * `(->> xs (filter p) (map f))` becomes `(map f (filter p xs))`.
+ */
+export function unthreadForm(src: string, offset: number): RefactorEdit | null {
+    const path = pathAt(parseAll(src), offset);
+    let form: Form | null = null;
+    for (let i = path.length - 1; i >= 0; i--) {
+        const name = headName(src, path[i]);
+        if (name && ARROWS.has(name)) {
+            form = path[i];
+            break;
+        }
+    }
+    if (!form) {
+        return null;
+    }
+    const last = headName(src, form) === '->>';
+    const parts = form.children.slice(1);
+    if (parts.length === 0) {
+        return null;
+    }
+    let expr = text(src, parts[0]);
+    for (let i = 1; i < parts.length; i++) {
+        const step = parts[i];
+        if (step.kind === 'list' && step.children.length >= 1) {
+            const head = text(src, step.children[0]);
+            const rest = step.children.slice(1).map((c) => text(src, c));
+            const restText = rest.length ? ' ' + rest.join(' ') : '';
+            expr = last ? `(${head}${restText} ${expr})` : `(${head} ${expr}${restText})`;
+        } else {
+            expr = `(${text(src, step)} ${expr})`;
+        }
+    }
+    return { start: form.start, end: form.end, text: expr };
+}
+
+const BRACKET_CYCLE: Record<string, [string, string]> = {
+    '(': ['[', ']'],
+    '[': ['{', '}'],
+    '{': ['(', ')'],
+};
+
+/**
+ * Cycle the delimiters of the enclosing collection: `(` → `[` → `{` → `(`.
+ * Only plain list / vector / map forms cycle (not `#(` / `#{`).
+ */
+export function cycleCollection(src: string, offset: number): RefactorEdit | null {
+    const form = enclosingContainer(src, offset);
+    if (!form) {
+        return null;
+    }
+    const open = src[form.bodyStart];
+    const next = BRACKET_CYCLE[open];
+    if (!next) {
+        return null;
+    }
+    const inner = src.slice(form.bodyStart + 1, form.bodyEnd - 1);
+    return { start: form.bodyStart, end: form.bodyEnd, text: `${next[0]}${inner}${next[1]}` };
+}

--- a/src/test/phelRefactor.test.ts
+++ b/src/test/phelRefactor.test.ts
@@ -1,0 +1,82 @@
+import * as assert from 'node:assert/strict';
+import { threadForm, unthreadForm, cycleCollection } from '../phelRefactor';
+
+function idx(src: string, token: string, nth = 0): number {
+    let i = -1;
+    for (let k = 0; k <= nth; k++) {
+        i = src.indexOf(token, i + 1);
+        if (i < 0) {
+            throw new Error(`token ${token} #${nth} not found`);
+        }
+    }
+    return i;
+}
+
+function apply(src: string, edit: ReturnType<typeof threadForm>): string {
+    assert.ok(edit, 'expected a refactor edit');
+    return src.slice(0, edit.start) + edit.text + src.slice(edit.end);
+}
+
+describe('phelRefactor.threadForm', () => {
+    it('threads first (->), unwinding the spine', () => {
+        const src = '(f (g x))';
+        assert.equal(apply(src, threadForm(src, idx(src, 'f'), false)), '(-> x g f)');
+    });
+
+    it('keeps extra args on the step while unwinding fully', () => {
+        const src = '(f (g x) y)';
+        assert.equal(apply(src, threadForm(src, idx(src, 'f'), false)), '(-> x g (f y))');
+    });
+
+    it('threads last (->>) for seq pipelines', () => {
+        const src = '(map f (filter p xs))';
+        assert.equal(
+            apply(src, threadForm(src, idx(src, 'map'), true)),
+            '(->> xs (filter p) (map f))'
+        );
+    });
+
+    it('threads a single call', () => {
+        const src = '(inc x)';
+        assert.equal(apply(src, threadForm(src, idx(src, 'inc'), false)), '(-> x inc)');
+    });
+
+    it('refuses an already-threaded form', () => {
+        const src = '(-> x f g)';
+        assert.equal(threadForm(src, idx(src, 'x'), false), null);
+    });
+});
+
+describe('phelRefactor.unthreadForm', () => {
+    it('unwinds a -> chain', () => {
+        const src = '(-> x g f)';
+        assert.equal(apply(src, unthreadForm(src, idx(src, 'x'))), '(f (g x))');
+    });
+
+    it('unwinds a ->> chain with steps', () => {
+        const src = '(->> xs (filter p) (map f))';
+        assert.equal(apply(src, unthreadForm(src, idx(src, 'xs'))), '(map f (filter p xs))');
+    });
+
+    it('returns null outside a thread', () => {
+        const src = '(f x)';
+        assert.equal(unthreadForm(src, idx(src, 'x')), null);
+    });
+});
+
+describe('phelRefactor.cycleCollection', () => {
+    it('cycles ( -> [', () => {
+        const src = '(a b)';
+        assert.equal(apply(src, cycleCollection(src, idx(src, 'a'))), '[a b]');
+    });
+
+    it('cycles [ -> {', () => {
+        const src = '[1 2 3]';
+        assert.equal(apply(src, cycleCollection(src, idx(src, '1'))), '{1 2 3}');
+    });
+
+    it('cycles { -> (', () => {
+        const src = '{:a 1}';
+        assert.equal(apply(src, cycleCollection(src, idx(src, ':a'))), '(:a 1)');
+    });
+});


### PR DESCRIPTION
Second of the Calva / clojure-lsp-inspired improvements: **structural refactorings** and a **quick-fix**, delivered as VS Code code actions (lightbulb / `Ctrl+.`).

## Actions

On the form at the cursor:

- **Thread first (`->`)** and **Thread last (`->>`)** — fully unwind the threaded-argument spine.
  `(map f (filter p xs))` → `(->> xs (filter p) (map f))`
- **Unwind thread** — the inverse. `(-> x g f)` → `(f (g x))`
- **Cycle collection** — rotate delimiters `(` → `[` → `{` → `(`

Quick-fix:

- **Add missing `:require`** — when the bare symbol under the cursor is a known core/workspace name the file hasn't imported, insert `(:require [ns :refer [name]])` into the `(ns …)` form (reuses the same require builder as completion's auto-import).

## Implementation

- `src/phelRefactor.ts` — pure transforms (`threadForm`, `unthreadForm`, `cycleCollection`) returning a single `RefactorEdit`, operating on the `phelParedit` form tree. No `vscode` import → unit-tested.
- `src/phelCodeActionsProvider.ts` — adapts them to `CodeAction`s; add-require reuses `phelNsAnalyzer.buildRequireEdit`.
- Registered in the bundled-provider path, so it stands down under `phel lsp`.

## Verification

- `npm run compile` / `lint` / `format:check` — clean
- `npm test` — **366 passing** (+11 `phelRefactor` tests: thread/unthread first & last, extra-arg steps, already-threaded refusal, all three collection cycles)