### PR TITLE
feat(editing): paredit drag/splice/kill, form folding, native selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 - **Structural refactorings** on the form at the cursor (lightbulb / `Ctrl+.`): **Thread first** (`->`) and **Thread last** (`->>`), each fully unwinding the threaded-argument spine (`(map f (filter p xs))` → `(->> xs (filter p) (map f))`); **Unwind thread**, the inverse; and **Cycle collection**, rotating a collection's delimiters `(` → `[` → `{` → `(`.
 - **Add missing `:require`** quick-fix: when the bare symbol under the cursor is a known core/workspace name that the file has not imported, offers to insert the matching `(:require [ns :refer [name]])` entry into the `(ns …)` form. Bundled-only; stands down under `phel lsp`.
 
+### Structural editing
+
+- **More paredit.** New commands joining slurp/barf/raise/wrap: **drag form forward/backward** — swap a form with its adjacent sibling (`ctrl+shift+.` / `ctrl+shift+,`); **splice** — drop the enclosing brackets, lifting children into the parent (`alt+shift+s`); **kill form** — delete the form at the cursor (`alt+shift+k`).
+- **Form-aware folding & selection.** A `FoldingRangeProvider` folds every multi-line form and runs of `;` line comments (in place of indentation folding), and a `SelectionRangeProvider` makes VS Code's native expand/shrink selection (`Shift+Alt+→` / `←`) grow through the enclosing forms.
+
 ## [0.10.0] - 2026-07-24
 
 ### Language support

--- a/docs/repl-and-paredit.md
+++ b/docs/repl-and-paredit.md
@@ -42,8 +42,16 @@ Structural editing for Phel forms. All commands are scoped to `editorLangId == p
 | Raise form | `ctrl+shift+r` (`cmd+shift+r`) |
 | Wrap with `( )` | `alt+w` |
 | Wrap with `[ ]` / `{ }` | _unbound_ (commands `phel.paredit.wrapSquare`, `phel.paredit.wrapCurly`) |
+| Drag form forward | `ctrl+shift+.` (`cmd+shift+.`) |
+| Drag form backward | `ctrl+shift+,` (`cmd+shift+,`) |
+| Splice form | `alt+shift+s` |
+| Kill form | `alt+shift+k` |
 | Expand selection | `ctrl+shift+space` (`cmd+shift+space`) |
 | Shrink selection | `ctrl+shift+alt+space` (`cmd+shift+alt+space`) |
+
+Native **expand/shrink** (`Shift+Alt+→` / `Shift+Alt+←`) is also form-aware via a
+selection-range provider, and code **folding** follows the actual form structure
+(every multi-line form folds, plus runs of `;` line comments).
 
 ### Examples
 
@@ -53,4 +61,7 @@ Structural editing for Phel forms. All commands are scoped to `editorLangId == p
 a (b c)            ; cursor in (b c), slurp-back  → (a b c)
 (foo (bar baz))    ; cursor on bar, raise         → (foo bar)
 foo                ; cursor on foo, wrap-round    → (foo)
+(a b c)            ; cursor on b, drag-forward    → (a c b)
+(a (b c) d)        ; cursor in (b c), splice      → (a b c d)
+(a b c)            ; cursor on b, kill-form       → (a c)
 ```

--- a/package.json
+++ b/package.json
@@ -267,6 +267,26 @@
                 "category": "Phel"
             },
             {
+                "command": "phel.paredit.dragForward",
+                "title": "Phel: Drag Form Forward",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.paredit.dragBackward",
+                "title": "Phel: Drag Form Backward",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.paredit.splice",
+                "title": "Phel: Splice Form",
+                "category": "Phel"
+            },
+            {
+                "command": "phel.paredit.kill",
+                "title": "Phel: Kill Form",
+                "category": "Phel"
+            },
+            {
                 "command": "phel.repl.start",
                 "title": "Phel: Start REPL",
                 "category": "Phel"
@@ -386,6 +406,28 @@
             {
                 "command": "phel.paredit.wrapRound",
                 "key": "alt+w",
+                "when": "editorTextFocus && editorLangId == phel"
+            },
+            {
+                "command": "phel.paredit.dragForward",
+                "key": "ctrl+shift+.",
+                "mac": "cmd+shift+.",
+                "when": "editorTextFocus && editorLangId == phel"
+            },
+            {
+                "command": "phel.paredit.dragBackward",
+                "key": "ctrl+shift+,",
+                "mac": "cmd+shift+,",
+                "when": "editorTextFocus && editorLangId == phel"
+            },
+            {
+                "command": "phel.paredit.splice",
+                "key": "alt+shift+s",
+                "when": "editorTextFocus && editorLangId == phel"
+            },
+            {
+                "command": "phel.paredit.kill",
+                "key": "alt+shift+k",
                 "when": "editorTextFocus && editorLangId == phel"
             },
             {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,8 @@ import { PhelDocumentSymbolProvider, PhelWorkspaceSymbolProvider } from './phelS
 import { PhelSemanticTokensProvider, SEMANTIC_LEGEND } from './phelSemanticTokens';
 import { PhelUnusedLocals } from './phelUnusedLocals';
 import { PhelCodeActionProvider } from './phelCodeActionsProvider';
+import { PhelFoldingRangeProvider } from './phelFoldingProvider';
+import { PhelSelectionRangeProvider } from './phelSelectionRangeProvider';
 import { registerPareditCommands } from './phelPareditProvider';
 import { registerReplCommands } from './phelReplProvider';
 import { registerNreplCommands } from './phelNreplProvider';
@@ -365,6 +367,14 @@ function registerLanguageProviders(context: vscode.ExtensionContext): void {
             new PhelCodeActionProvider(workspaceIndexer),
             { providedCodeActionKinds: PhelCodeActionProvider.kinds }
         )
+    );
+
+    context.subscriptions.push(
+        vscode.languages.registerFoldingRangeProvider('phel', new PhelFoldingRangeProvider())
+    );
+
+    context.subscriptions.push(
+        vscode.languages.registerSelectionRangeProvider('phel', new PhelSelectionRangeProvider())
     );
 
     workspaceIndexer.onDidChange(() => {

--- a/src/phelFolding.ts
+++ b/src/phelFolding.ts
@@ -1,0 +1,80 @@
+// Pure folding-range computation for `.phel`: every multi-line collection form
+// folds, as do runs of consecutive line comments. Line numbers are 0-based to
+// match VS Code's `FoldingRange`. No `vscode` import, so it is unit-testable.
+
+import { parseAll, isContainer, type Form } from './phelParedit';
+
+export interface FoldRange {
+    start: number;
+    end: number;
+    comment?: boolean;
+}
+
+function lineStarts(src: string): number[] {
+    const starts = [0];
+    for (let i = 0; i < src.length; i++) {
+        if (src[i] === '\n') {
+            starts.push(i + 1);
+        }
+    }
+    return starts;
+}
+
+function lineOf(starts: readonly number[], offset: number): number {
+    let lo = 0;
+    let hi = starts.length - 1;
+    let ans = 0;
+    while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        if (starts[mid] <= offset) {
+            ans = mid;
+            lo = mid + 1;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return ans;
+}
+
+export function computeFoldRanges(src: string): FoldRange[] {
+    const starts = lineStarts(src);
+    const out: FoldRange[] = [];
+
+    const walk = (f: Form): void => {
+        if (isContainer(f)) {
+            const startLine = lineOf(starts, f.start);
+            const endLine = lineOf(starts, Math.max(f.start, f.bodyEnd - 1));
+            if (endLine > startLine) {
+                out.push({ start: startLine, end: endLine });
+            }
+        }
+        for (const child of f.children) {
+            walk(child);
+        }
+    };
+    for (const f of parseAll(src)) {
+        walk(f);
+    }
+
+    // Runs of two or more consecutive line-comment (`;`) lines fold together.
+    const lines = src.split('\n');
+    let runStart = -1;
+    const flush = (endLine: number): void => {
+        if (runStart >= 0 && endLine > runStart) {
+            out.push({ start: runStart, end: endLine, comment: true });
+        }
+        runStart = -1;
+    };
+    for (let i = 0; i < lines.length; i++) {
+        if (/^\s*;/.test(lines[i])) {
+            if (runStart < 0) {
+                runStart = i;
+            }
+        } else {
+            flush(i - 1);
+        }
+    }
+    flush(lines.length - 1);
+
+    return out;
+}

--- a/src/phelFoldingProvider.ts
+++ b/src/phelFoldingProvider.ts
@@ -1,0 +1,18 @@
+// Form-aware folding: replaces VS Code's indentation heuristic with ranges
+// derived from the actual `.phel` structure (multi-line forms + comment runs).
+
+import * as vscode from 'vscode';
+import { computeFoldRanges } from './phelFolding';
+
+export class PhelFoldingRangeProvider implements vscode.FoldingRangeProvider {
+    provideFoldingRanges(document: vscode.TextDocument): vscode.FoldingRange[] {
+        return computeFoldRanges(document.getText()).map(
+            (r) =>
+                new vscode.FoldingRange(
+                    r.start,
+                    r.end,
+                    r.comment ? vscode.FoldingRangeKind.Comment : undefined
+                )
+        );
+    }
+}

--- a/src/phelParedit.ts
+++ b/src/phelParedit.ts
@@ -563,3 +563,99 @@ export function wrap(src: string, offset: number, open: '(' | '[' | '{'): Paredi
         cursor: target.start + 1,
     };
 }
+
+/** The form at `offset` together with its sibling list and index within it. */
+function currentAndSiblings(
+    forms: readonly Form[],
+    offset: number
+): { current: Form; siblings: readonly Form[]; index: number } | null {
+    const path = pathAt(forms, offset);
+    if (path.length === 0) {
+        return null;
+    }
+    const current = path[path.length - 1];
+    const parent = path.length >= 2 ? path[path.length - 2] : null;
+    const siblings = parent ? parent.children : forms;
+    const index = siblings.indexOf(current);
+    if (index < 0) {
+        return null;
+    }
+    return { current, siblings, index };
+}
+
+/** Swap the form at `offset` with its next sibling, preserving the separator. */
+export function dragForward(src: string, offset: number): PareditEdit | null {
+    const ctx = currentAndSiblings(parseAll(src), offset);
+    if (!ctx || ctx.index + 1 >= ctx.siblings.length) {
+        return null;
+    }
+    const a = ctx.siblings[ctx.index];
+    const b = ctx.siblings[ctx.index + 1];
+    const sep = src.slice(a.end, b.start);
+    const aText = src.slice(a.start, a.end);
+    const bText = src.slice(b.start, b.end);
+    return {
+        replaceStart: a.start,
+        replaceEnd: b.end,
+        replacement: bText + sep + aText,
+        cursor: a.start + bText.length + sep.length + (offset - a.start),
+    };
+}
+
+/** Swap the form at `offset` with its previous sibling, preserving the separator. */
+export function dragBackward(src: string, offset: number): PareditEdit | null {
+    const ctx = currentAndSiblings(parseAll(src), offset);
+    if (!ctx || ctx.index === 0) {
+        return null;
+    }
+    const a = ctx.siblings[ctx.index - 1];
+    const b = ctx.siblings[ctx.index];
+    const sep = src.slice(a.end, b.start);
+    const aText = src.slice(a.start, a.end);
+    const bText = src.slice(b.start, b.end);
+    return {
+        replaceStart: a.start,
+        replaceEnd: b.end,
+        replacement: bText + sep + aText,
+        cursor: a.start + (offset - b.start),
+    };
+}
+
+/** Remove the enclosing container's brackets, lifting its children into the parent. */
+export function spliceForm(src: string, offset: number): PareditEdit | null {
+    const container = enclosingContainer(parseAll(src), offset);
+    if (!container) {
+        return null;
+    }
+    // Only plain containers: splicing `#(` / `#{` would leave a dangling `#`.
+    if (container.kind !== 'list' && container.kind !== 'vector' && container.kind !== 'map') {
+        return null;
+    }
+    const removedBefore = container.innerStart - container.start;
+    return {
+        replaceStart: container.start,
+        replaceEnd: container.end,
+        replacement: src.slice(container.innerStart, container.innerEnd),
+        cursor: Math.max(container.start, offset - removedBefore),
+    };
+}
+
+/** Delete the form at `offset` (innermost), tidying one adjacent space. */
+export function killForm(src: string, offset: number): PareditEdit | null {
+    const target = formAt(parseAll(src), offset);
+    if (!target) {
+        return null;
+    }
+    let end = target.end;
+    while (end < src.length && (src[end] === ' ' || src[end] === '\t')) {
+        end++;
+    }
+    let start = target.start;
+    if (end === target.end) {
+        // Nothing trailing consumed; drop one leading space instead.
+        while (start > 0 && (src[start - 1] === ' ' || src[start - 1] === '\t')) {
+            start--;
+        }
+    }
+    return { replaceStart: start, replaceEnd: end, replacement: '', cursor: start };
+}

--- a/src/phelPareditProvider.ts
+++ b/src/phelPareditProvider.ts
@@ -6,9 +6,13 @@ import * as vscode from 'vscode';
 import {
     barfBackward,
     barfForward,
+    dragBackward,
+    dragForward,
+    killForm,
     raise as raiseForm,
     slurpBackward,
     slurpForward,
+    spliceForm,
     wrap,
     type PareditEdit,
 } from './phelParedit';
@@ -45,6 +49,10 @@ export function registerPareditCommands(context: vscode.ExtensionContext): void 
         vscode.commands.registerCommand('phel.paredit.slurpBackward', () => runOp(slurpBackward)),
         vscode.commands.registerCommand('phel.paredit.barfBackward', () => runOp(barfBackward)),
         vscode.commands.registerCommand('phel.paredit.raise', () => runOp(raiseForm)),
+        vscode.commands.registerCommand('phel.paredit.dragForward', () => runOp(dragForward)),
+        vscode.commands.registerCommand('phel.paredit.dragBackward', () => runOp(dragBackward)),
+        vscode.commands.registerCommand('phel.paredit.splice', () => runOp(spliceForm)),
+        vscode.commands.registerCommand('phel.paredit.kill', () => runOp(killForm)),
         vscode.commands.registerCommand('phel.paredit.wrapRound', () =>
             runOp((src, off) => wrap(src, off, '('))
         ),

--- a/src/phelSelectionRangeProvider.ts
+++ b/src/phelSelectionRangeProvider.ts
@@ -1,0 +1,30 @@
+// Native structural selection: expanding the selection (Shift+Alt+Right) grows
+// it through the enclosing forms — atom → list → outer list → … — using the
+// same reader the paredit commands use. Complements the stack-based
+// expand/shrink commands with VS Code's built-in smart-select.
+
+import * as vscode from 'vscode';
+import { parseAll, pathAt } from './phelParedit';
+
+export class PhelSelectionRangeProvider implements vscode.SelectionRangeProvider {
+    provideSelectionRanges(
+        document: vscode.TextDocument,
+        positions: vscode.Position[]
+    ): vscode.SelectionRange[] {
+        const forms = parseAll(document.getText());
+        return positions.map((pos) => {
+            const path = pathAt(forms, document.offsetAt(pos));
+            // Build outermost → innermost so each form's parent is the one
+            // enclosing it; the innermost node is returned.
+            let range: vscode.SelectionRange | undefined;
+            for (const f of path) {
+                const r = new vscode.Range(
+                    document.positionAt(f.start),
+                    document.positionAt(f.end)
+                );
+                range = new vscode.SelectionRange(r, range);
+            }
+            return range ?? new vscode.SelectionRange(new vscode.Range(pos, pos));
+        });
+    }
+}

--- a/src/test/phelFolding.test.ts
+++ b/src/test/phelFolding.test.ts
@@ -1,0 +1,23 @@
+import * as assert from 'node:assert/strict';
+import { computeFoldRanges } from '../phelFolding';
+
+describe('phelFolding.computeFoldRanges', () => {
+    it('folds a multi-line form from its first to last line', () => {
+        const src = '(defn f [a]\n  (+ a 1))';
+        assert.ok(computeFoldRanges(src).some((r) => r.start === 0 && r.end === 1 && !r.comment));
+    });
+
+    it('does not fold a single-line form', () => {
+        assert.deepEqual(computeFoldRanges('(inc x)'), []);
+    });
+
+    it('folds a run of consecutive line comments', () => {
+        const src = '; one\n; two\n; three\n(def x 1)';
+        assert.ok(computeFoldRanges(src).some((r) => r.comment && r.start === 0 && r.end === 2));
+    });
+
+    it('does not fold a lone comment line', () => {
+        const src = '; solo\n(def x 1)';
+        assert.ok(!computeFoldRanges(src).some((r) => r.comment));
+    });
+});

--- a/src/test/phelPareditOps.test.ts
+++ b/src/test/phelPareditOps.test.ts
@@ -1,0 +1,54 @@
+import * as assert from 'node:assert/strict';
+import { dragForward, dragBackward, spliceForm, killForm, type PareditEdit } from '../phelParedit';
+
+function idx(src: string, token: string, nth = 0): number {
+    let i = -1;
+    for (let k = 0; k <= nth; k++) {
+        i = src.indexOf(token, i + 1);
+        if (i < 0) {
+            throw new Error(`token ${token} #${nth} not found`);
+        }
+    }
+    return i;
+}
+
+function apply(src: string, edit: PareditEdit | null): string {
+    assert.ok(edit, 'expected edit, got null');
+    return src.slice(0, edit.replaceStart) + edit.replacement + src.slice(edit.replaceEnd);
+}
+
+describe('phelParedit.dragForward / dragBackward', () => {
+    it('swaps a form with its next sibling', () => {
+        const src = '(a b c)';
+        assert.equal(apply(src, dragForward(src, idx(src, 'b'))), '(a c b)');
+    });
+
+    it('swaps a form with its previous sibling', () => {
+        const src = '(a b c)';
+        assert.equal(apply(src, dragBackward(src, idx(src, 'c'))), '(a c b)');
+    });
+
+    it('returns null at the forward edge', () => {
+        const src = '(a b c)';
+        assert.equal(dragForward(src, idx(src, 'c')), null);
+    });
+
+    it('returns null at the backward edge', () => {
+        const src = '(a b c)';
+        assert.equal(dragBackward(src, idx(src, 'a')), null);
+    });
+});
+
+describe('phelParedit.spliceForm', () => {
+    it('removes the enclosing brackets, lifting children up', () => {
+        const src = '(a (b c) d)';
+        assert.equal(apply(src, spliceForm(src, idx(src, 'b'))), '(a b c d)');
+    });
+});
+
+describe('phelParedit.killForm', () => {
+    it('deletes the form at the cursor and a trailing space', () => {
+        const src = '(a b c)';
+        assert.equal(apply(src, killForm(src, idx(src, 'b'))), '(a c)');
+    });
+});


### PR DESCRIPTION
Third of the Calva-inspired batch: rounds out **structural editing** toward paredit parity, plus form-aware **folding** and native **selection**.

## Paredit — new commands

| Command | Key | Effect |
|---|---|---|
| Drag form forward | `ctrl+shift+.` | `(a b c)` on `b` → `(a c b)` |
| Drag form backward | `ctrl+shift+,` | `(a b c)` on `c` → `(a c b)` |
| Splice | `alt+shift+s` | `(a (b c) d)` in inner → `(a b c d)` |
| Kill form | `alt+shift+k` | `(a b c)` on `b` → `(a c)` |

Joining the existing slurp / barf / raise / wrap. All keybindings are scoped to `editorLangId == phel`.

## Folding & selection

- **`FoldingRangeProvider`** — folds every multi-line form and runs of `;` line comments, replacing VS Code's indentation heuristic with the real structure.
- **`SelectionRangeProvider`** — VS Code's native expand/shrink (`Shift+Alt+→` / `←`) now grows through the enclosing forms (atom → list → outer list → …), complementing the existing stack-based expand/shrink commands.

## Implementation

- `phelParedit.ts` — `dragForward` / `dragBackward` / `spliceForm` / `killForm`, pure `PareditEdit` ops in the existing `runOp` pattern.
- `phelFolding.ts` — pure `computeFoldRanges` (unit-tested); `phelFoldingProvider.ts` wraps it.
- `phelSelectionRangeProvider.ts` — builds the range chain from the `parseAll` path.
- Registered in the bundled-provider path; stand down under `phel lsp`.

## Verification

- `npm run compile` / `lint` / `format:check` — clean; `package.json` validated
- `npm test` — **376 passing** (+10: drag/splice/kill + folding)
- Docs: `docs/repl-and-paredit.md` updated with the new commands and examples.