### PR TITLE
feat(nrepl): inline evaluation results as end-of-line decorations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - **Structural refactorings** on the form at the cursor (lightbulb / `Ctrl+.`): **Thread first** (`->`) and **Thread last** (`->>`), each fully unwinding the threaded-argument spine (`(map f (filter p xs))` → `(->> xs (filter p) (map f))`); **Unwind thread**, the inverse; and **Cycle collection**, rotating a collection's delimiters `(` → `[` → `{` → `(`.
 - **Add missing `:require`** quick-fix: when the bare symbol under the cursor is a known core/workspace name that the file has not imported, offers to insert the matching `(:require [ns :refer [name]])` entry into the `(ns …)` form. Bundled-only; stands down under `phel lsp`.
 
+### REPL
+
+- **Inline evaluation results.** `Phel: nREPL Eval Form Inline` (`ctrl+alt+enter` / `cmd+alt+enter`) evaluates the top-level form under the cursor over the nREPL connection and shows the value as a dimmed `=> …` decoration at the end of the form's line — Calva-style — with errors in the error colour. The decoration clears on the next edit; the full value and any stdout/stack trace still go to the **Phel nREPL** channel.
+
 ### Structural editing
 
 - **More paredit.** New commands joining slurp/barf/raise/wrap: **drag form forward/backward** — swap a form with its adjacent sibling (`ctrl+shift+.` / `ctrl+shift+,`); **splice** — drop the enclosing brackets, lifting children into the parent (`alt+shift+s`); **kill form** — delete the form at the cursor (`alt+shift+k`).

--- a/docs/repl-and-paredit.md
+++ b/docs/repl-and-paredit.md
@@ -12,6 +12,14 @@
 | `Phel: Eval File` | _unbound_ | Sends the entire buffer. |
 | `Phel: Switch REPL to Current Namespace` | _unbound_ | Sends `(in-ns 'this.ns)` for the active file. |
 
+### Inline results (nREPL)
+
+`Phel: nREPL Eval Form Inline` (`ctrl+alt+enter` / `cmd+alt+enter`) evaluates the
+top-level form under the cursor over the nREPL connection and shows the value as
+a dimmed `=> …` decoration at the end of the form's line (errors in the error
+colour). The decoration clears as soon as you edit the buffer. The full value,
+captured stdout, and stack traces still go to the **Phel nREPL** output channel.
+
 ### Namespace tracking
 
 Each REPL terminal remembers which namespace it last switched into. When you eval from a different file, the extension first sends `(in-ns 'that.ns)` so cross-file evals don't silently land in the previous namespace.

--- a/package.json
+++ b/package.json
@@ -332,6 +332,11 @@
                 "category": "Phel"
             },
             {
+                "command": "phel.nrepl.evalInline",
+                "title": "Phel: nREPL Eval Form Inline",
+                "category": "Phel"
+            },
+            {
                 "command": "phel.nrepl.evalSelection",
                 "title": "Phel: nREPL Eval Selection",
                 "category": "Phel"
@@ -434,6 +439,12 @@
                 "command": "phel.repl.evalForm",
                 "key": "ctrl+enter",
                 "mac": "cmd+enter",
+                "when": "editorTextFocus && editorLangId == phel"
+            },
+            {
+                "command": "phel.nrepl.evalInline",
+                "key": "ctrl+alt+enter",
+                "mac": "cmd+alt+enter",
                 "when": "editorTextFocus && editorLangId == phel"
             },
             {

--- a/src/phelInlineEval.ts
+++ b/src/phelInlineEval.ts
@@ -1,0 +1,104 @@
+// Calva-style inline evaluation results: after evaluating a form, its value is
+// shown as a dimmed `=> …` decoration at the end of the form's last line. The
+// decoration is cleared as soon as the buffer changes, so a stale result never
+// lingers next to edited code.
+
+import * as vscode from 'vscode';
+
+export interface InlineResult {
+    text: string;
+    isError: boolean;
+}
+
+interface DocDecorations {
+    ok: vscode.DecorationOptions[];
+    err: vscode.DecorationOptions[];
+}
+
+export class PhelInlineEval implements vscode.Disposable {
+    private readonly okType = vscode.window.createTextEditorDecorationType({
+        after: {
+            margin: '0 0 0 1.5rem',
+            color: new vscode.ThemeColor('editorCodeLens.foreground'),
+            fontStyle: 'italic',
+        },
+        rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
+    });
+    private readonly errType = vscode.window.createTextEditorDecorationType({
+        after: {
+            margin: '0 0 0 1.5rem',
+            color: new vscode.ThemeColor('errorForeground'),
+            fontStyle: 'italic',
+        },
+        rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
+    });
+    private readonly perDoc = new Map<string, DocDecorations>();
+    private readonly subs: vscode.Disposable[] = [];
+
+    constructor() {
+        this.subs.push(
+            vscode.workspace.onDidChangeTextDocument((e) => this.clear(e.document)),
+            vscode.window.onDidChangeVisibleTextEditors(() => this.reapply())
+        );
+    }
+
+    /** Show `=> result` at the end of the line containing `formEndOffset`. */
+    show(editor: vscode.TextEditor, formEndOffset: number, result: InlineResult): void {
+        const doc = editor.document;
+        const lastCharOffset = Math.max(0, Math.min(formEndOffset, doc.getText().length) - 1);
+        const line = doc.positionAt(lastCharOffset).line;
+        const eol = doc.lineAt(line).range.end;
+        const option: vscode.DecorationOptions = {
+            range: new vscode.Range(eol, eol),
+            renderOptions: { after: { contentText: `  => ${result.text}` } },
+        };
+
+        const key = doc.uri.toString();
+        const bucket = this.perDoc.get(key) ?? { ok: [], err: [] };
+        // Replace any existing decoration on the same line.
+        const sameLine = (o: vscode.DecorationOptions): boolean => o.range.start.line === line;
+        bucket.ok = bucket.ok.filter((o) => !sameLine(o));
+        bucket.err = bucket.err.filter((o) => !sameLine(o));
+        if (result.isError) {
+            bucket.err.push(option);
+        } else {
+            bucket.ok.push(option);
+        }
+        this.perDoc.set(key, bucket);
+        editor.setDecorations(this.okType, bucket.ok);
+        editor.setDecorations(this.errType, bucket.err);
+    }
+
+    private clear(doc: vscode.TextDocument): void {
+        const key = doc.uri.toString();
+        if (!this.perDoc.has(key)) {
+            return;
+        }
+        this.perDoc.delete(key);
+        for (const editor of vscode.window.visibleTextEditors) {
+            if (editor.document.uri.toString() === key) {
+                editor.setDecorations(this.okType, []);
+                editor.setDecorations(this.errType, []);
+            }
+        }
+    }
+
+    private reapply(): void {
+        for (const editor of vscode.window.visibleTextEditors) {
+            const bucket = this.perDoc.get(editor.document.uri.toString());
+            if (bucket) {
+                editor.setDecorations(this.okType, bucket.ok);
+                editor.setDecorations(this.errType, bucket.err);
+            }
+        }
+    }
+
+    dispose(): void {
+        this.okType.dispose();
+        this.errType.dispose();
+        for (const s of this.subs) {
+            s.dispose();
+        }
+        this.perDoc.clear();
+    }
+}

--- a/src/phelInlineFormat.ts
+++ b/src/phelInlineFormat.ts
@@ -1,0 +1,27 @@
+// Pure formatting for inline evaluation results: collapse a (possibly
+// multi-line) nREPL value or error into a single, length-bounded line suitable
+// for an end-of-line decoration. No `vscode` import, so it is unit-testable.
+
+const DEFAULT_MAX = 120;
+
+/** Collapse whitespace and clip to `max` characters with an ellipsis. */
+export function oneLine(s: string, max = DEFAULT_MAX): string {
+    const collapsed = s.replace(/\s+/g, ' ').trim();
+    return collapsed.length > max ? collapsed.slice(0, max - 1) + '…' : collapsed;
+}
+
+/**
+ * Render an nREPL op result as a one-line inline string. Errors take the error
+ * text; success joins the returned values (empty → `nil`).
+ */
+export function formatInlineResult(
+    values: readonly string[],
+    err: string,
+    isError: boolean,
+    max = DEFAULT_MAX
+): string {
+    if (isError) {
+        return oneLine(err || 'error', max);
+    }
+    return oneLine(values.join(', ') || 'nil', max);
+}

--- a/src/phelNreplProvider.ts
+++ b/src/phelNreplProvider.ts
@@ -3,6 +3,7 @@
 //
 //   phel.nrepl.connect / phel.nrepl.disconnect
 //   phel.nrepl.eval            — eval the form under the cursor, show the result
+//   phel.nrepl.evalInline      — eval the form under the cursor, show `=> …` inline
 //   phel.nrepl.evalSelection   — eval the selection
 //   phel.nrepl.loadFile        — load the whole file
 //   phel.nrepl.reload          — reload changed namespaces
@@ -20,6 +21,18 @@ import { type OpResult, PhelNreplConnection } from './phelNreplClient';
 import { parseNsForm } from './phelNsAnalyzer';
 import { topLevelFormAt } from './phelRepl';
 import { folderForDocument as folderForDoc } from './phelWorkspace';
+import { PhelInlineEval } from './phelInlineEval';
+import { formatInlineResult } from './phelInlineFormat';
+
+let inlineEval: PhelInlineEval | undefined;
+
+function isErrorResult(result: OpResult): boolean {
+    return (
+        result.status.includes('error') ||
+        result.status.includes('eval-error') ||
+        result.err.trim() !== ''
+    );
+}
 
 const OUTPUT_CHANNEL_NAME = 'Phel nREPL';
 const DEFTEST_HEAD_RE = /^\(deftest\s+(?:\^\S+\s+)*([^\s()[\]{}]+)/;
@@ -146,6 +159,30 @@ async function evalForm(): Promise<void> {
     });
 }
 
+/** Eval the top-level form under the cursor and show the value inline (`=> …`). */
+async function evalFormInline(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'phel') {
+        return;
+    }
+    const doc = editor.document;
+    const offset = doc.offsetAt(editor.selection.active);
+    const form = topLevelFormAt(doc.getText(), offset);
+    if (!form) {
+        vscode.window.showWarningMessage('No Phel form under cursor.');
+        return;
+    }
+    await withConnection(doc, async (conn) => {
+        const result = await conn.eval(form.text, nsFor(doc));
+        reportResult('eval', result);
+        const isError = isErrorResult(result);
+        inlineEval?.show(editor, form.end, {
+            text: formatInlineResult(result.values, result.err, isError),
+            isError,
+        });
+    });
+}
+
 async function evalSelection(): Promise<void> {
     const editor = vscode.window.activeTextEditor;
     if (!editor || editor.document.languageId !== 'phel') {
@@ -267,11 +304,14 @@ function disposeAll(): void {
 }
 
 export function registerNreplCommands(context: vscode.ExtensionContext): void {
+    inlineEval = new PhelInlineEval();
     context.subscriptions.push(
+        inlineEval,
         channel(),
         vscode.commands.registerCommand('phel.nrepl.connect', connect),
         vscode.commands.registerCommand('phel.nrepl.disconnect', disconnect),
         vscode.commands.registerCommand('phel.nrepl.eval', evalForm),
+        vscode.commands.registerCommand('phel.nrepl.evalInline', evalFormInline),
         vscode.commands.registerCommand('phel.nrepl.evalSelection', evalSelection),
         vscode.commands.registerCommand('phel.nrepl.loadFile', loadFile),
         vscode.commands.registerCommand('phel.nrepl.reload', () => reload(false)),

--- a/src/test/phelInlineFormat.test.ts
+++ b/src/test/phelInlineFormat.test.ts
@@ -1,0 +1,30 @@
+import * as assert from 'node:assert/strict';
+import { oneLine, formatInlineResult } from '../phelInlineFormat';
+
+describe('phelInlineFormat.oneLine', () => {
+    it('collapses whitespace to single spaces', () => {
+        assert.equal(oneLine('a\n  b\tc'), 'a b c');
+    });
+
+    it('truncates overlong text with an ellipsis', () => {
+        assert.equal(oneLine('abcdef', 4), 'abc…');
+    });
+
+    it('leaves short text untouched', () => {
+        assert.equal(oneLine('short'), 'short');
+    });
+});
+
+describe('phelInlineFormat.formatInlineResult', () => {
+    it('joins returned values on success', () => {
+        assert.equal(formatInlineResult(['6'], '', false), '6');
+    });
+
+    it('renders nil when there are no values', () => {
+        assert.equal(formatInlineResult([], '', false), 'nil');
+    });
+
+    it('uses the (collapsed) error text on error', () => {
+        assert.equal(formatInlineResult([], 'boom\n at line 1', true), 'boom at line 1');
+    });
+});


### PR DESCRIPTION
Last of the Calva-inspired batch: **inline evaluation results**, the feature Calva users reach for most.

## What it does

`Phel: nREPL Eval Form Inline` (**`ctrl+alt+enter`** / `cmd+alt+enter`) evaluates the top-level form under the cursor over the existing nREPL connection and shows the value **right where you're working**:

```phel
(+ 1 2 3)              => 6
(map inc [1 2 3])      => [2 3 4]
(/ 1 0)                Division by zero      ← error colour
```

- Dimmed `=> …` decoration at the end of the form's last line (uses `editorCodeLens.foreground`; errors use `errorForeground`).
- **Clears on the next edit**, so a result never lingers next to changed code.
- The full value, captured stdout, and stack traces still stream to the **Phel nREPL** output channel as before — this is additive.

## Implementation

- `src/phelInlineFormat.ts` — pure one-line formatter (whitespace collapse + length clamp); **unit-tested**, no `vscode` import.
- `src/phelInlineEval.ts` — `PhelInlineEval` decoration manager: per-document decoration buckets, same-line replacement, cleared on `onDidChangeTextDocument`, re-applied on editor visibility changes.
- `src/phelNreplProvider.ts` — new `phel.nrepl.evalInline` command reusing `topLevelFormAt` + `conn.eval`.

## Verification

- `npm run compile` / `lint` / `format:check` — clean; `package.json` validated
- `npm test` — **382 passing** (+6 `phelInlineFormat` tests)
- Docs: `docs/repl-and-paredit.md` gains an "Inline results" section.