### PR TITLE
chore(ci): run format:check in pretest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Internal
+
+- `npm run pretest` now also runs `format:check`, so a Prettier violation fails locally (before commit) instead of only in CI.
+
 ## [0.11.0] - 2026-07-24
 
 ### Language support

--- a/package.json
+++ b/package.json
@@ -599,7 +599,7 @@
         "lint:fix": "eslint src --ext ts --fix",
         "format": "prettier --write \"src/**/*.ts\"",
         "format:check": "prettier --check \"src/**/*.ts\"",
-        "pretest": "npm run compile && npm run lint",
+        "pretest": "npm run compile && npm run lint && npm run format:check",
         "test": "mocha out/test/**/*.test.js",
         "check:changelog": "node scripts/check-changelog.cjs",
         "tokenize": "node scripts/tokenize-sample.mjs",


### PR DESCRIPTION
Adds `format:check` to the `pretest` script so a Prettier violation fails locally (before commit) instead of only in CI — which red-flagged several PRs this cycle after a green local `npm run pretest`.

One-line change to `package.json`; `pretest` verified green (compile + lint + format:check).