### PR TITLE
feat(lang): highlight every literal the phel v0.49.0 reader accepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,18 @@
 
 ## [Unreleased]
 
+### Language support
+
+- **Every literal the Phel reader accepts now highlights.** The grammar gained rules for character literals (`\A`, `\1`, `\(`, `\space`, `\newline`, `\u00e9`, `\o101`), regex literals (`#"^\d+$"`, distinct from the `#regex "…"` tagged literal), symbolic numbers (`##Inf`, `##-Inf`, `##NaN`), radix numbers (`2r1010`, `16rFF`, `36rZZ`), `BigInt` (`123N`), `BigDecimal` (`1.5M`), and ratios (`3/4`). Signed forms (`+7`, `-3.5`, `-1/2`) and digit separators now scope as numbers across every base. A PHP fully-qualified name (`\Throwable`) still scopes as a symbol, matching the lexer's own lookahead.
+- **Gensyms no longer break a macro body.** A trailing `#` is part of the symbol (`x#`), so `` `(let [x# ~x] …) `` highlights as code; previously the `#` opened a comment that swallowed the rest of the line.
+- **Namespaced tagged literals.** `#my.app/Person {:name "Ada"}` scopes the whole dotted/namespaced name as the tag, and paredit reads the tag plus its value as one form.
+- **Regex literals are one form to paredit.** `#"…"` is read as a single string form rather than a `#` atom followed by a string, so slurp/barf/raise/kill, folding, and expand-selection no longer split it.
+- `phel.router/compiled-router` highlights as a macro, closing the last gap between the grammar keyword list and the v0.49.0 macro corpus.
+
 ### Internal
 
+- Grammar coverage is pinned by `src/test/grammar.test.ts`, which tokenizes with the same `vscode-textmate` engine VS Code ships and asserts scopes, so a grammar regression fails `npm test` instead of needing a manual read of `npm run tokenize`.
+- `scripts/sample.phel` used `0o17`, which is not valid Phel (octal is the leading-zero `017`); fixed and extended with the newly covered literal forms.
 - `npm run pretest` now also runs `format:check`, so a Prettier violation fails locally (before commit) instead of only in CI.
 
 ## [0.11.0] - 2026-07-24

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -20,11 +20,30 @@ Other: `comment`, `time`, `lazy-seq`, `lazy-cat`, `match`, `instance?`, `pop`, `
 
 ## Literals
 
-- Keywords: `:keyword`, `::auto-resolved`
-- Numbers: `42`, `3.14`, `2e-3`, `0xff`, `0b1010`, `1_000`
+Every numeric form the reader accepts (see phel-lang's `AtomParser`) has its own scope:
+
+| Form | Example | Scope |
+| --- | --- | --- |
+| Decimal | `42`, `+7`, `-3`, `1_000` | `constant.numeric.decimal.phel` |
+| Float | `3.14`, `.5`, `2e-3` | `constant.numeric.decimal.phel` |
+| Hex / binary / octal | `0xff`, `0b1010`, `017` | `constant.numeric.{hex,binary,octal}.phel` |
+| Radix (2-36) | `2r1010`, `16rFF`, `36rZZ` | `constant.numeric.radix.phel` |
+| BigInt | `123N` | `constant.numeric.bigint.phel` |
+| BigDecimal | `1.5M`, `-2.5e3M` | `constant.numeric.bigdecimal.phel` |
+| Ratio | `3/4`, `-1/2` | `constant.numeric.ratio.phel` |
+| Symbolic | `##Inf`, `##-Inf`, `##NaN` | `constant.language.symbolic-number.phel` |
+
+Octal is the leading-zero spelling `017`; `0o17` is not valid Phel.
+
+The rest:
+
+- Keywords: `:keyword`, `::auto-resolved`, `:my.ns/name`
 - Booleans / nil: `true`, `false`, `nil`
 - Strings: `"hello"` with `\\` escapes
-- Collections: `[1 2]`, `{:a 1}`, `#{1 2}`, `'(a b)`
+- Characters: `\A`, `\1`, `\(`, `\space`, `\newline`, `\tab`, `\formfeed`, `\backspace`, `\return`, `\u00e9`, `\o101` → `constant.character.phel`. A PHP fully-qualified name (`\Throwable`, `\Foo\Bar`) still scopes as a symbol, matching the lexer's lookahead.
+- Regex literals: `#"^\d+$"` → `string.regexp.phel` (distinct from the `#regex "…"` tagged literal)
+- Collections: `[1 2]`, `{:a 1}`, `#{1 2}`, `'(a b)`, PHP arrays `@[1 2]` / `@{:a 1}`
+- Gensyms: a trailing `#` belongs to the symbol (`x#`), so `` `(let [x# ~x] …) `` highlights as code rather than opening a comment
 
 ## Anonymous functions
 
@@ -70,10 +89,11 @@ Type and metadata tags (`^int`, `^"?int"`, `^:memoize`, `^:async`, any `^:keywor
 #inst "2026-01-01T00:00:00Z"
 #regex "\\d+"
 #php/Foo\Bar
+#my.app/Person {:name "Ada"}  ;; EDN-style namespaced tag
 #money "10.00 EUR"            ;; custom tag via register-tag
 ```
 
-`#` highlights as `punctuation.definition.tag.phel`; the tag name as `storage.type.tagged.phel`.
+`#` highlights as `punctuation.definition.tag.phel`; the tag name as `storage.type.tagged.phel`. Dotted and namespaced tag names (`#my.app/Person`) are one tag, and paredit treats the tag plus its value as a single form.
 
 ## Reader conditionals
 
@@ -101,3 +121,5 @@ npm run tokenize
 ```
 
 That tokenises `scripts/sample.phel` against `syntaxes/phel.tmLanguage.json` via `vscode-textmate` + `vscode-oniguruma` and prints every token with its scope. Edit the sample to add new edge cases.
+
+`npm test` runs the same engine over pinned assertions in `src/test/grammar.test.ts`, so a dropped or broken literal rule fails CI rather than needing a manual read of the tokenizer output.

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -29,7 +29,7 @@
         ["(", ")"],
         ["\"", "\""]
     ],
-    "wordPattern": "[^\\s\\(\\)\\[\\]\\{\\}\"'`,;#]+",
+    "wordPattern": "[^\\s\\(\\)\\[\\]\\{\\}\"'`,;#]+#?",
     "indentationRules": {
         "increaseIndentPattern": "^.*\\([^)]*$|^.*\\[[^\\]]*$|^.*\\{[^}]*$",
         "decreaseIndentPattern": "^\\s*[)\\]\\}]"

--- a/scripts/sample.phel
+++ b/scripts/sample.phel
@@ -9,8 +9,12 @@
 # legacy line comment - deprecated, should still highlight
 
 (def ^:private answer 42)
-(def numbers [1 2 3 4 5 0xff 0b1010 0o17 1_000 3.14 2e-3])
+(def numbers [1 2 3 4 5 0xff 0b1010 017 1_000 3.14 2e-3 +7 -3.5])
 (def ratios #{1/2 -3/4})
+(def radixes [2r1010 16rFF 36rZZ])
+(def bigs [123N 1_000N 1.5M -2.5e3M])
+(def symbolic [##Inf ##-Inf ##NaN])
+(def chars [\A \1 \( \space \newline \tab \u00e9 \o101])
 
 (defn greet
   "Public function with docstring."
@@ -21,9 +25,10 @@
   (when (pos? x) (* x x)))
 
 (defmacro when-positive [x & body]
-  `(when (pos? ~x)
-     ~@body
-     :done))
+  `(let [x# ~x]
+     (when (pos? x#)
+       ~@body
+       :done)))
 
 (deftest arithmetic
   (testing "addition"
@@ -57,8 +62,10 @@
 ;; Tagged literals
 (def created #inst "2026-01-01T00:00:00Z")
 (def re #regex "\\d+")
+(def re-literal #"^\d+(\.\d+)?$")
 (def m #money "10.00 EUR")
 (def php-call #php/Foo\Bar)
+(def person #my.app/Person {:name "Ada"})
 
 ;; Reader conditionals
 (def now #?(:phel (php/time) :clj 0))

--- a/src/phelParedit.ts
+++ b/src/phelParedit.ts
@@ -110,10 +110,11 @@ function isReaderPrefix(src: string, i: number, end: number): number {
         if (n === '?') {
             return 2;
         }
-        // Tagged literal `#tag` (but not `#(`, `#{`, `#_`, `#|`).
+        // Tagged literal `#tag`, including EDN-style namespaced tags such as
+        // `#my.app/Person` (but not `#(`, `#{`, `#_`, `#|`, `#"`).
         if (n && /[A-Za-z]/.test(n)) {
             let j = i + 1;
-            while (j < end && /[A-Za-z0-9_\-.]/.test(src[j])) {
+            while (j < end && /[A-Za-z0-9_\-./]/.test(src[j])) {
                 j++;
             }
             return j - i;
@@ -259,8 +260,11 @@ export function readForm(src: string, start: number, end: number): Form | null {
         };
     }
 
-    if (c === '"') {
-        const stringEnd = readString(src, bodyStart, end);
+    // `"..."` and the regex literal `#"..."`, which is one form, not a `#`
+    // atom followed by a string.
+    if (c === '"' || (c === '#' && src[bodyStart + 1] === '"')) {
+        const quoteStart = c === '"' ? bodyStart : bodyStart + 1;
+        const stringEnd = readString(src, quoteStart, end);
         return {
             start: formStart,
             end: stringEnd,

--- a/src/test/grammar.test.ts
+++ b/src/test/grammar.test.ts
@@ -1,0 +1,141 @@
+// Grammar regression tests: tokenize snippets against
+// `syntaxes/phel.tmLanguage.json` with the same engine VS Code ships
+// (vscode-textmate + vscode-oniguruma) and assert the resulting scopes.
+//
+// `npm run tokenize` prints the same information for a whole sample file;
+// these tests pin the literal forms the Phel lexer accepts so a grammar edit
+// cannot silently drop one.
+
+import * as assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { Registry, parseRawGrammar, INITIAL, type IGrammar } from 'vscode-textmate';
+import * as oniguruma from 'vscode-oniguruma';
+
+const repoRoot = join(__dirname, '..', '..');
+
+interface Token {
+    text: string;
+    scopes: string[];
+}
+
+let grammar: IGrammar;
+
+async function loadGrammar(): Promise<IGrammar> {
+    const wasmPath = require.resolve('vscode-oniguruma/release/onig.wasm');
+    await oniguruma.loadWASM(readFileSync(wasmPath).buffer as ArrayBuffer);
+
+    const grammarPath = join(repoRoot, 'syntaxes', 'phel.tmLanguage.json');
+    const grammarRaw = readFileSync(grammarPath, 'utf-8');
+    const registry = new Registry({
+        onigLib: Promise.resolve({
+            createOnigScanner: (sources: string[]) => new oniguruma.OnigScanner(sources),
+            createOnigString: (str: string) => new oniguruma.OnigString(str),
+        }),
+        loadGrammar: () => Promise.resolve(parseRawGrammar(grammarRaw, grammarPath)),
+    });
+    const loaded = await registry.loadGrammar('source.phel');
+    assert.ok(loaded, 'failed to load source.phel grammar');
+    return loaded;
+}
+
+function tokenize(line: string): Token[] {
+    const result = grammar.tokenizeLine(line, INITIAL);
+    return result.tokens.map((t) => ({
+        text: line.slice(t.startIndex, t.endIndex),
+        scopes: t.scopes,
+    }));
+}
+
+/** Scopes of the first token whose text is exactly `text`. */
+function scopesOf(line: string, text: string): string[] {
+    const token = tokenize(line).find((t) => t.text === text);
+    assert.ok(token, `no token with text ${JSON.stringify(text)} in ${JSON.stringify(line)}`);
+    return token.scopes;
+}
+
+function assertScoped(line: string, text: string, scope: string): void {
+    const scopes = scopesOf(line, text);
+    assert.ok(
+        scopes.includes(scope),
+        `expected ${JSON.stringify(text)} to carry ${scope}, got ${scopes.join(' ')}`
+    );
+}
+
+describe('phel.tmLanguage numeric literals', () => {
+    before(async () => {
+        grammar = await loadGrammar();
+    });
+
+    const cases: [string, string, string][] = [
+        ['(def x 42)', '42', 'constant.numeric.decimal.phel'],
+        ['(def x +7)', '+7', 'constant.numeric.decimal.phel'],
+        ['(def x 1_000)', '1_000', 'constant.numeric.decimal.phel'],
+        ['(def x 0xff)', '0xff', 'constant.numeric.hex.phel'],
+        ['(def x 0b1010)', '0b1010', 'constant.numeric.binary.phel'],
+        ['(def x 017)', '017', 'constant.numeric.octal.phel'],
+        ['(def x 16rFF)', '16rFF', 'constant.numeric.radix.phel'],
+        ['(def x 2r1010)', '2r1010', 'constant.numeric.radix.phel'],
+        ['(def x 123N)', '123N', 'constant.numeric.bigint.phel'],
+        ['(def x 1.5M)', '1.5M', 'constant.numeric.bigdecimal.phel'],
+        ['(def x 3/4)', '3/4', 'constant.numeric.ratio.phel'],
+        ['(def x -3/4)', '-3/4', 'constant.numeric.ratio.phel'],
+        ['(def x ##Inf)', '##Inf', 'constant.language.symbolic-number.phel'],
+        ['(def x ##-Inf)', '##-Inf', 'constant.language.symbolic-number.phel'],
+        ['(def x ##NaN)', '##NaN', 'constant.language.symbolic-number.phel'],
+    ];
+
+    for (const [line, text, scope] of cases) {
+        it(`scopes ${text} as ${scope}`, () => {
+            assertScoped(line, text, scope);
+        });
+    }
+});
+
+describe('phel.tmLanguage character literals', () => {
+    before(async () => {
+        grammar = await loadGrammar();
+    });
+
+    for (const text of ['\\A', '\\1', '\\(', '\\space', '\\newline', '\\u00e9', '\\o101']) {
+        it(`scopes ${text} as a character`, () => {
+            assertScoped(`(def c ${text})`, text, 'constant.character.phel');
+        });
+    }
+
+    it('leaves a PHP fully-qualified name as a symbol', () => {
+        assertScoped('(catch \\Throwable e', '\\Throwable', 'meta.symbol.phel');
+    });
+});
+
+describe('phel.tmLanguage reader syntax', () => {
+    before(async () => {
+        grammar = await loadGrammar();
+    });
+
+    it('scopes a regex literal as a regexp string', () => {
+        assertScoped('(def re #"^\\d+$")', '^', 'string.regexp.phel');
+    });
+
+    it('keeps a gensym suffix inside the symbol instead of starting a comment', () => {
+        const tokens = tokenize('(let [x# 1] x#)');
+        assertScoped('(let [x# 1] x#)', 'x#', 'meta.symbol.phel');
+        assert.ok(
+            !tokens.some((t) => t.scopes.some((s) => s.startsWith('comment'))),
+            'gensym must not open a comment'
+        );
+    });
+
+    it('scopes a namespaced tagged literal name', () => {
+        assertScoped('#my.app/Person {:a 1}', 'my.app/Person', 'storage.type.tagged.phel');
+    });
+
+    it('still scopes a bare-# line comment', () => {
+        assertScoped('# legacy comment', '# legacy comment'.slice(1), 'comment.line.phel');
+    });
+
+    it('scopes phel.router/compiled-router as a keyword', () => {
+        assertScoped('(compiled-router routes)', 'compiled-router', 'keyword.control.phel');
+    });
+});

--- a/src/test/phelParedit.test.ts
+++ b/src/test/phelParedit.test.ts
@@ -226,4 +226,39 @@ describe('phelParedit.readForm', () => {
         assert.equal(f?.start, 0);
         assert.equal(f?.kind, 'string');
     });
+
+    it('reads a namespaced tagged literal as one form', () => {
+        const src = '#my.app/Person {:name "Ada"}';
+        const f = readForm(src, 0, src.length);
+        assert.ok(f);
+        assert.equal(f?.start, 0);
+        assert.equal(f?.end, src.length);
+        assert.equal(f?.kind, 'map');
+    });
+
+    it('reads a regex literal as a single string form', () => {
+        const src = '#"^\\d+$"';
+        const f = readForm(src, 0, src.length);
+        assert.ok(f);
+        assert.equal(f?.start, 0);
+        assert.equal(f?.end, src.length);
+        assert.equal(f?.kind, 'string');
+    });
+
+    it('does not let a regex literal swallow the rest of a list', () => {
+        const forms = parseAll('(def re #"a\\"b") (def x 1)');
+        assert.equal(forms.length, 2);
+        assert.equal(forms[0].children.length, 3);
+        assert.equal(forms[0].children[2].kind, 'string');
+    });
+
+    it('reads a char literal that is an open paren', () => {
+        const forms = parseAll('[\\( \\space \\A]');
+        assert.equal(forms.length, 1);
+        assert.equal(forms[0].children.length, 3);
+        assert.deepEqual(
+            forms[0].children.map((c) => c.kind),
+            ['char', 'char', 'char']
+        );
+    });
 });

--- a/syntaxes/phel.tmLanguage.json
+++ b/syntaxes/phel.tmLanguage.json
@@ -9,6 +9,9 @@
 			"include": "#comment"
 		},
 		{
+			"include": "#regexp"
+		},
+		{
 			"include": "#strings"
 		},
 		{
@@ -36,6 +39,9 @@
 			"include": "#metadata"
 		},
 		{
+			"include": "#char"
+		},
+		{
 			"include": "#readermac"
 		},
 		{
@@ -59,7 +65,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.phel",
-					"match": "(?<=\\(|\\{|\\[|\\s)(with-output-buffer|with-mock-wrapper|unquote-splicing|extend-protocol|definterface\\*?|defexception\\*?|defenum\\*?|with-bindings|future-fiber|with-redefs|with-config|symbol-info|extend-type|explain-sym|defprotocol|with-mocks|with-open|when-first|defstruct\\*?|when-some|instance\\?|defrecord|defmethod|defmacro-|when-not|when-let|prefer-method|prefers|lazy-seq|lazy-cat|hash-map|defmulti|defmacro|unquote|testing|some->>|set-var|require|if-some|foreach|finally|dotrace|dotimes|deftrace|deftype|deftest|defspec|declare|cond->>|comment|break|binding|vector|source|some->|reify\\*?|if-not|if-let|future|cond->|concat|assert|throw|recur|quote|match|letfn|in-ns|doseq|dofor|deref|delay|defn-|condp|catch|async|apply|while|when|time|loop|load|list|html|dbg|doto|defonce|defn|def-|conj|cond|case|aset|as->|var|use|try|pop|new|let|for|doc|dir|def|are|and|->>|or|ns|is|if|fn|do|->)(?=\\s|\\)|\\]|\\})"
+					"match": "(?<=\\(|\\{|\\[|\\s)(with-output-buffer|with-mock-wrapper|unquote-splicing|extend-protocol|compiled-router|definterface\\*?|defexception\\*?|defenum\\*?|with-bindings|future-fiber|with-redefs|with-config|symbol-info|extend-type|explain-sym|defprotocol|with-mocks|with-open|when-first|defstruct\\*?|when-some|instance\\?|defrecord|defmethod|defmacro-|when-not|when-let|prefer-method|prefers|lazy-seq|lazy-cat|hash-map|defmulti|defmacro|unquote|testing|some->>|set-var|require|if-some|foreach|finally|dotrace|dotimes|deftrace|deftype|deftest|defspec|declare|cond->>|comment|break|binding|vector|source|some->|reify\\*?|if-not|if-let|future|cond->|concat|assert|throw|recur|quote|match|letfn|in-ns|doseq|dofor|deref|delay|defn-|condp|catch|async|apply|while|when|time|loop|load|list|html|dbg|doto|defonce|defn|def-|conj|cond|case|aset|as->|var|use|try|pop|new|let|for|doc|dir|def|are|and|->>|or|ns|is|if|fn|do|->)(?=\\s|\\)|\\]|\\})"
 				},
 				{
 					"name": "keyword.control.phel",
@@ -68,21 +74,42 @@
 			]
 		},
 		"number": {
+			"comment": "Mirrors phel-lang's AtomParser numeric regexes; the suffixed / radix / ratio forms must precede the plain decimal rule so `16rFF` is not chewed as `16`.",
 			"patterns": [
 				{
-					"match": "0[xX][0-9a-fA-F]+(?:_[0-9a-fA-F]+)*",
+					"match": "##(?:-?Inf|NaN)(?![A-Za-z0-9_\\-])",
+					"name": "constant.language.symbolic-number.phel"
+				},
+				{
+					"match": "[+-]?(?:2|[3-9]|[12][0-9]|3[0-6])[rR][0-9a-zA-Z]+(?:_[0-9a-zA-Z]+)*",
+					"name": "constant.numeric.radix.phel"
+				},
+				{
+					"match": "[+-]?[0-9]+(?:_[0-9]+)*(?:\\.[0-9]+(?:_[0-9]+)*)?(?:[eE][+-]?[0-9]+)?M(?![A-Za-z0-9_\\-])",
+					"name": "constant.numeric.bigdecimal.phel"
+				},
+				{
+					"match": "[+-]?[0-9]+(?:_[0-9]+)*N(?![A-Za-z0-9_\\-])",
+					"name": "constant.numeric.bigint.phel"
+				},
+				{
+					"match": "[+-]?[0-9]+(?:_[0-9]+)*/[0-9]+(?:_[0-9]+)*(?![A-Za-z0-9_\\-])",
+					"name": "constant.numeric.ratio.phel"
+				},
+				{
+					"match": "[+-]?0[xX][0-9a-fA-F]+(?:_[0-9a-fA-F]+)*",
 					"name": "constant.numeric.hex.phel"
 				},
 				{
-					"match": "0[bB][01]+(?:_[01]+)*",
+					"match": "[+-]?0[bB][01]+(?:_[01]+)*",
 					"name": "constant.numeric.binary.phel"
 				},
 				{
-					"match": "0(?:_?[0-7]+)+",
+					"match": "[+-]?0(?:_?[0-7]+)+",
 					"name": "constant.numeric.octal.phel"
 				},
 				{
-					"match": "(?x)\n(?:\n  (?:[0-9]+(?:_[0-9]+)*)?(\\.)[0-9]+(?:_[0-9]+)*(?:[eE][+-]?[0-9]+(?:_[0-9]+)*)?| # .3\n  [0-9]+(?:_[0-9]+)*(\\.)(?:[0-9]+(?:_[0-9]+)*)?(?:[eE][+-]?[0-9]+(?:_[0-9]+)*)?| # 3.\n  [0-9]+(?:_[0-9]+)*[eE][+-]?[0-9]+(?:_[0-9]+)*                                   # 2e-3\n)",
+					"match": "(?x)\n(?:\n  [+-]?(?:[0-9]+(?:_[0-9]+)*)?(\\.)[0-9]+(?:_[0-9]+)*(?:[eE][+-]?[0-9]+(?:_[0-9]+)*)?| # .3\n  [+-]?[0-9]+(?:_[0-9]+)*(\\.)(?:[0-9]+(?:_[0-9]+)*)?(?:[eE][+-]?[0-9]+(?:_[0-9]+)*)?| # 3.\n  [+-]?[0-9]+(?:_[0-9]+)*[eE][+-]?[0-9]+(?:_[0-9]+)*                                   # 2e-3\n)",
 					"name": "constant.numeric.decimal.phel",
 					"captures": {
 						"1": {
@@ -94,7 +121,7 @@
 					}
 				},
 				{
-					"match": "(-?\\d+)",
+					"match": "([+-]?\\d+(?:_\\d+)*)",
 					"name": "constant.numeric.decimal.phel"
 				}
 			]
@@ -136,8 +163,38 @@
 			"match": ":[^\\s\\#\\(\\)\\{\\}\\[\\]\\'\\\"\\,\\`]+"
 		},
 		"symbol": {
+			"comment": "Mirrors the lexer's atom rule: a trailing `#` is part of the symbol (gensym syntax, e.g. `x#`), so it must not fall through to the bare-`#` comment rule.",
 			"name": "meta.symbol.phel",
-			"match": "(?<![\\-])[^\\s\\#\\(\\)\\{\\}\\[\\]\\'\\\"\\,\\`]+"
+			"match": "(?<![\\-])[^\\s\\#\\(\\)\\{\\}\\[\\]\\'\\\"\\,\\`]+\\#?"
+		},
+		"char": {
+			"comment": "Character literals: \\a, \\A, \\1, \\(, \\space, \\newline, \\uNNNN, \\oNNN. The lookahead lets `\\Phel\\Lang\\Symbol` stay a symbol, matching the lexer.",
+			"name": "constant.character.phel",
+			"match": "\\\\(?:space|newline|tab|formfeed|backspace|return|u[0-9a-fA-F]{4}|o[0-7]{1,3}|[^\\s])(?![A-Za-z0-9_\\-\\\\])"
+		},
+		"regexp": {
+			"name": "string.regexp.phel",
+			"begin": "(#)\"",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.phel"
+				},
+				"1": {
+					"name": "punctuation.definition.tag.phel"
+				}
+			},
+			"end": "\"",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.phel"
+				}
+			},
+			"patterns": [
+				{
+					"name": "constant.character.escape.phel",
+					"match": "\\\\."
+				}
+			]
 		},
 		"short-fn": {
 			"begin": "(#\\(|\\|\\()",
@@ -247,7 +304,8 @@
 			"end": "\\|#"
 		},
 		"tagged-literal": {
-			"match": "(#)([a-zA-Z][\\w-]*)",
+			"comment": "`#inst`, `#uuid`, and EDN-style namespaced tags such as `#my.app/Person`.",
+			"match": "(#)([a-zA-Z][\\w-]*(?:\\.[\\w-]+)*(?:/[a-zA-Z][\\w-]*(?:\\.[\\w-]+)*)?)",
 			"captures": {
 				"1": {
 					"name": "punctuation.definition.tag.phel"
@@ -337,6 +395,9 @@
 					"include": "#comment"
 				},
 				{
+					"include": "#regexp"
+				},
+				{
 					"include": "#strings"
 				},
 				{
@@ -362,6 +423,9 @@
 				},
 				{
 					"include": "#metadata"
+				},
+				{
+					"include": "#char"
 				},
 				{
 					"include": "#readermac"


### PR DESCRIPTION
## Why

The symbol corpus is already pinned to **v0.49.0** (the latest phel-lang release), so completion / hover / signature help are current, and `SPECIAL_FORMS` matches every `NAME_*` in phel-lang's `src/php/Lang/Symbol.php`.

The gap was the **reader**: `syntaxes/phel.tmLanguage.json` covered only the literals the extension shipped with, so most of what `Compiler/Application/Lexer.php` and `AtomParser` accept fell through to `meta.symbol.phel`.

Two of those gaps were bugs, not just missing colour:

- **Gensym `x#` opened a line comment.** The symbol rule excluded `#`, so the trailing `#` hit the bare-`#` comment rule and everything after it in a macro body rendered as a comment.
- **`#"…"` was two forms to paredit** (a `#` atom followed by a string), so slurp / barf / raise / kill, folding and expand-selection split a regex literal in half.

## What

Grammar rules mirroring the lexer:

| Form | Before | After |
| --- | --- | --- |
| `\A` `\1` `\(` `\space` `\newline` `é` `\o101` | plain symbol | `constant.character.phel` |
| `#"^\d+$"` | stray `#` + string | `string.regexp.phel` |
| `##Inf` `##-Inf` `##NaN` | mis-read as a tagged literal | `constant.language.symbolic-number.phel` |
| `2r1010` `16rFF` `36rZZ` | `16` + symbol `rFF` | `constant.numeric.radix.phel` |
| `123N` / `1.5M` | number + symbol `N`/`M` | `constant.numeric.bigint` / `.bigdecimal` |
| `3/4` | `3` + symbol `/4` | `constant.numeric.ratio.phel` |
| `+7` | symbol | `constant.numeric.decimal.phel` |
| `#my.app/Person` | tag cut at the first `.` | full namespaced tag |

Signed forms and digit separators now scope as numbers across every base. The character rule copies the lexer's own lookahead, so a PHP fully-qualified name (`\Throwable`, `\Foo\Bar`) still scopes as a symbol.

Beyond the grammar:

- `src/phelParedit.ts` reads `#"…"` as a single string form, and takes `/` in a tag name so `#my.app/Person {…}` is one form.
- `language-configuration.json` `wordPattern` accepts a trailing `#`, so double-click selects the whole gensym.
- `compiled-router` (`phel.router`) was the only public macro in the v0.49.0 corpus missing from the keyword alternation.

## Verification

- New `src/test/grammar.test.ts` tokenizes through the same `vscode-textmate` + `vscode-oniguruma` engine VS Code ships and asserts scopes, so a grammar regression fails `npm test` instead of needing a manual read of `npm run tokenize`.
- `npm run pretest` + `npm test`: **414 passing**. `npm run check:changelog` green.
- `scripts/sample.phel` used `0o17`, which the reader rejects — confirmed against the phel binary (`017` → `int(15)`, `0o17` → "not defined"). Fixed and extended with the newly covered forms.
- No corpus regen: `assets/phel-core-docs.json` is already pinned to `v0.49.0`.
