### PR TITLE
feat(scope): resolve locals in letfn, dotimes, when-first, as-> and every for clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Language support
 
+- **Scope analysis covers the remaining core binding forms.** `dotimes`, `when-first`, `as->`, and `letfn` now introduce locals, so go-to-definition, find-references, rename, document-highlight, semantic tokens, unused-local hints, and in-scope completion work inside them. `letfn` is modelled properly: the function names are visible across every spec and the body (mutual recursion), while each spec's parameters stay confined to that spec.
+- **`for` / `doseq` / `dofor` heads are read in full.** Only the first `binding :verb expr` clause used to bind; a second clause (`(for [x :in xs y :in ys] …)`) and the `:reduce [acc init]` accumulator were treated as globals. All clauses, `:let` pairs, and the accumulator now resolve as locals.
+- A local whose scope has closed is no longer offered by completion — a `letfn` spec's parameters stop at that spec instead of leaking into the body.
+- Find-references on a `letfn` name now includes a mutually recursive call that appears *before* the name's own spec; references were previously cut off at the declaration offset.
+- `with-redefs` targets stay globals (they rebind existing vars), so renaming one remains a workspace-wide rename — pinned by a test.
 - **Every literal the Phel reader accepts now highlights.** The grammar gained rules for character literals (`\A`, `\1`, `\(`, `\space`, `\newline`, `\u00e9`, `\o101`), regex literals (`#"^\d+$"`, distinct from the `#regex "…"` tagged literal), symbolic numbers (`##Inf`, `##-Inf`, `##NaN`), radix numbers (`2r1010`, `16rFF`, `36rZZ`), `BigInt` (`123N`), `BigDecimal` (`1.5M`), and ratios (`3/4`). Signed forms (`+7`, `-3.5`, `-1/2`) and digit separators now scope as numbers across every base. A PHP fully-qualified name (`\Throwable`) still scopes as a symbol, matching the lexer's own lookahead.
 - **Gensyms no longer break a macro body.** A trailing `#` is part of the symbol (`x#`), so `` `(let [x# ~x] …) `` highlights as code; previously the `#` opened a comment that swallowed the rest of the line.
 - **Namespaced tagged literals.** `#my.app/Person {:name "Ada"}` scopes the whole dotted/namespaced name as the tag, and paredit reads the tag plus its value as one form.

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -14,6 +14,27 @@ Rewrites every occurrence of the symbol in the workspace via a single `Workspace
 
 Same skipping rules as Find References - you can rename `foo` without touching the literal `"foo"` inside a string.
 
+## Locals vs globals
+
+Go to Definition, Find References, Rename, and document-highlight are **scope-aware**: when the symbol under the cursor is a local, they resolve to its binding site and stay inside its own scope, so a same-named global or a binding shadowed elsewhere is never touched.
+
+These forms introduce locals:
+
+| Form | Binds |
+| --- | --- |
+| `fn`, `defn`, `defn-`, `defmacro`, `defmacro-` | parameters, plus a named `fn`'s self-name |
+| `let`, `loop`, `binding`, `with-open` | every `name init` pair, sequentially |
+| `if-let`, `when-let`, `if-some`, `when-some`, `when-first`, `dotimes` | the single binding pair |
+| `for`, `doseq`, `dofor` | every `binding :verb expr` clause, each `:let` pair, and the `:reduce` accumulator |
+| `foreach` | every element of the head except the trailing collection |
+| `letfn` | each function name (visible across all specs and the body — they are mutually recursive) and each spec's own parameters |
+| `as->` | the threading name |
+| `catch` | the exception var |
+
+Vector, `:keys` / `:syms` / `:strs`, and `:as` destructuring is followed in every one of them.
+
+Anything else is treated as a global, deliberately: `with-redefs` rebinds *existing* vars rather than declaring locals, so renaming one there stays a workspace-wide rename. A form whose binding shape is not recognised yields no locals at all and falls back to the workspace-wide behaviour, so the analyzer never makes a rename narrower than it should be.
+
 ## Document Outline & Breadcrumbs
 
 Every public form (`defn`, `defmacro`, `def`) shows up in the editor outline (`cmd+shift+O`) with its first arity signature as the detail.

--- a/src/phelScope.ts
+++ b/src/phelScope.ts
@@ -36,8 +36,17 @@ export interface LocalBinding {
 
 /** `let`-shaped forms: `(head [name init name init …] body…)`. */
 const PAIR_BINDING_HEADS = new Set(['let', 'loop', 'binding', 'with-open']);
-/** Single-pair conditional binding forms: `(head [name test] …)`. */
-const ONE_PAIR_HEADS = new Set(['if-let', 'when-let', 'if-some', 'when-some']);
+/** Single-pair binding forms: `(head [name test] …)`. */
+const ONE_PAIR_HEADS = new Set([
+    'if-let',
+    'when-let',
+    'if-some',
+    'when-some',
+    'when-first',
+    'dotimes',
+]);
+/** `for`-clause verbs: `binding :verb expr`. */
+const SEQ_VERBS = new Set([':range', ':in', ':keys', ':pairs']);
 /** `fn`-shaped forms whose parameter vector(s) introduce locals. */
 const FN_HEADS = new Set(['fn', 'defn', 'defn-', 'defmacro', 'defmacro-']);
 /** Sequential-iteration forms: `(head [var … coll] body…)`. */
@@ -226,47 +235,33 @@ function bindingsOf(src: string, form: Form): LocalBinding[] {
     }
 
     if (SEQ_HEADS.has(name)) {
-        // (for [x :in coll … :let [y (f x)] …] body): the leading element is the
-        // primary loop var; `:let [pairs]` sub-vectors add more. Visible through
-        // the remaining binding clauses and the body.
-        const vec = bindingVec(form);
-        if (!vec || vec.children.length === 0) {
+        return seqBindings(src, form, bodyEnd);
+    }
+
+    if (name === 'as->') {
+        // (as-> expr name form…): `name` is rebound to each form's result and is
+        // visible from after its own atom through the rest of the form.
+        const binding = form.children[2];
+        if (!isAtom(binding)) {
             return [];
         }
-        const out: LocalBinding[] = [];
-        const first = vec.children[0];
-        for (const t of collectTargets(src, first)) {
-            out.push({
-                name: t.name,
-                declStart: t.start,
-                declEnd: t.end,
-                scopeStart: first.end,
+        const bname = atomText(src, binding);
+        if (!isBindableName(bname)) {
+            return [];
+        }
+        return [
+            {
+                name: bname,
+                declStart: binding.bodyStart,
+                declEnd: binding.bodyEnd,
+                scopeStart: binding.bodyEnd,
                 scopeEnd: bodyEnd,
-            });
-        }
-        const kids = vec.children;
-        for (let i = 0; i + 1 < kids.length; i++) {
-            const k = kids[i];
-            if (k.kind === 'atom' && atomText(src, k) === ':let') {
-                const letVec = kids[i + 1];
-                if (letVec.kind === 'vector') {
-                    for (let j = 0; j + 1 < letVec.children.length; j += 2) {
-                        const target = letVec.children[j];
-                        const init = letVec.children[j + 1];
-                        for (const t of collectTargets(src, target)) {
-                            out.push({
-                                name: t.name,
-                                declStart: t.start,
-                                declEnd: t.end,
-                                scopeStart: init.end,
-                                scopeEnd: bodyEnd,
-                            });
-                        }
-                    }
-                }
-            }
-        }
-        return out;
+            },
+        ];
+    }
+
+    if (name === 'letfn') {
+        return letfnBindings(src, form, bodyEnd);
     }
 
     if (FN_HEADS.has(name)) {
@@ -274,6 +269,126 @@ function bindingsOf(src: string, form: Form): LocalBinding[] {
     }
 
     return [];
+}
+
+/**
+ * Bindings introduced by the head vector of `for` / `doseq` / `dofor`:
+ *
+ *   (for [x :in xs y :in ys :let [z (f x)] :when (p z) :reduce [acc 0]] body…)
+ *
+ * The head is a flat sequence of `binding :verb expr` clauses, interleaved with
+ * the `:while` / `:when` / `:let` modifiers and the `:reduce` option. Every
+ * loop binding, every `:let` pair, and the `:reduce` accumulator is a local.
+ */
+function seqBindings(src: string, form: Form, bodyEnd: number): LocalBinding[] {
+    const vec = bindingVec(form);
+    if (!vec || vec.children.length === 0) {
+        return [];
+    }
+    const kids = vec.children;
+    const out: LocalBinding[] = [];
+
+    const push = (target: Form, scopeStart: number): void => {
+        for (const t of collectTargets(src, target)) {
+            out.push({
+                name: t.name,
+                declStart: t.start,
+                declEnd: t.end,
+                scopeStart,
+                scopeEnd: bodyEnd,
+            });
+        }
+    };
+
+    let i = 0;
+    while (i < kids.length) {
+        const kid = kids[i];
+        const text = kid.kind === 'atom' ? atomText(src, kid) : '';
+
+        if (text === ':let' || text === ':reduce') {
+            const vecArg = kids[i + 1];
+            if (vecArg?.kind === 'vector') {
+                if (text === ':let') {
+                    // `:let [a 1 b 2]` — the same sequential pairs as `let`.
+                    for (let j = 0; j + 1 < vecArg.children.length; j += 2) {
+                        push(vecArg.children[j], vecArg.children[j + 1].end);
+                    }
+                } else {
+                    // `:reduce [acc init]` — the accumulator is visible in the body.
+                    push(vecArg.children[0], vecArg.end);
+                }
+            }
+            i += 2;
+            continue;
+        }
+
+        if (text === ':when' || text === ':while') {
+            i += 2;
+            continue;
+        }
+
+        // `binding :verb expr` — anything else followed by a loop verb.
+        const verb = kids[i + 1];
+        if (verb?.kind === 'atom' && SEQ_VERBS.has(atomText(src, verb))) {
+            const expr = kids[i + 2];
+            push(kid, expr ? expr.end : verb.end);
+            i += 3;
+            continue;
+        }
+
+        // `(doseq [x coll] …)` shorthand, or an unrecognised clause: treat a
+        // leading target followed by a single expression as one binding, then
+        // stop rather than guess at the rest.
+        if (i === 0 && kids.length >= 2) {
+            push(kid, kids[1].end);
+        }
+        break;
+    }
+
+    return out;
+}
+
+/**
+ * `(letfn [(f [a] …) (g [b] …)] body…)`. The function names are visible across
+ * every spec and the body (they are mutually recursive); each spec's parameters
+ * are visible only inside that spec.
+ */
+function letfnBindings(src: string, form: Form, bodyEnd: number): LocalBinding[] {
+    const vec = bindingVec(form);
+    if (!vec) {
+        return [];
+    }
+    const out: LocalBinding[] = [];
+    for (const spec of vec.children) {
+        if (spec.kind !== 'list' || spec.children.length === 0) {
+            continue;
+        }
+        const fnName = spec.children[0];
+        if (isAtom(fnName) && isBindableName(atomText(src, fnName))) {
+            out.push({
+                name: atomText(src, fnName),
+                declStart: fnName.bodyStart,
+                declEnd: fnName.bodyEnd,
+                scopeStart: vec.innerStart,
+                scopeEnd: bodyEnd,
+            });
+        }
+        const params = spec.children[1];
+        if (params?.kind === 'vector') {
+            for (const param of params.children) {
+                for (const t of collectTargets(src, param)) {
+                    out.push({
+                        name: t.name,
+                        declStart: t.start,
+                        declEnd: t.end,
+                        scopeStart: params.end,
+                        scopeEnd: spec.innerEnd,
+                    });
+                }
+            }
+        }
+    }
+    return out;
 }
 
 /** Parameter (and self-name) bindings for `fn` / `defn` shaped forms. */
@@ -384,7 +499,12 @@ export function localOccurrences(src: string, b: LocalBinding): Occurrence[] {
             out.push(occ);
             continue;
         }
-        if (occ.start < b.declStart || occ.start >= b.scopeEnd) {
+        // A reference is in range from wherever the binding first becomes
+        // visible. That is the declaration for every sequential form, but a
+        // `letfn` name is visible from the start of the binding vector, so a
+        // mutually recursive call *precedes* its own declaration.
+        const refStart = Math.min(b.declStart, b.scopeStart);
+        if (occ.start < refStart || occ.start >= b.scopeEnd) {
             continue;
         }
         const resolved = resolveLocalAt(src, occ.start);
@@ -405,9 +525,12 @@ export function localsInScopeAt(src: string, offset: number): string[] {
     const seen = new Set<string>();
     const out: string[] = [];
     for (const b of bindingsOnPath(src, path)) {
-        // A local is offerable once its scope has opened at the cursor, or when
-        // the cursor sits inside the binding form at all (params being typed).
-        if (offset >= b.scopeStart || (offset >= b.declStart && offset < b.scopeEnd)) {
+        // A local is offerable once its scope has opened at the cursor and has
+        // not closed again (a `letfn` spec's parameters are visible only inside
+        // that spec), or when the cursor sits on the binding itself (params
+        // being typed).
+        const inScope = offset >= b.scopeStart && offset < b.scopeEnd;
+        if (inScope || (offset >= b.declStart && offset < b.scopeEnd)) {
             if (!seen.has(b.name)) {
                 seen.add(b.name);
                 out.push(b.name);

--- a/src/test/phelScope.test.ts
+++ b/src/test/phelScope.test.ts
@@ -162,6 +162,61 @@ describe('phelScope binding forms', () => {
         // `m` is the collection, not a binding.
         assert.equal(resolveLocalAt(src, idx(src, 'm', 0)), null);
     });
+
+    it('binds a dotimes counter', () => {
+        const src = '(dotimes [q 5] (use q))';
+        assert.deepEqual(occStarts(src, idx(src, 'q', 1)), [idx(src, 'q', 0), idx(src, 'q', 1)]);
+    });
+
+    it('binds a when-first target', () => {
+        const src = '(when-first [x coll] (print x))';
+        assert.deepEqual(occStarts(src, idx(src, 'x', 1)), [idx(src, 'x', 0), idx(src, 'x', 1)]);
+    });
+
+    it('binds the as-> threading name', () => {
+        const src = '(as-> 1 v (+ v 2) (* v 3))';
+        assert.deepEqual(occStarts(src, idx(src, 'v', 1)), [
+            idx(src, 'v', 0),
+            idx(src, 'v', 1),
+            idx(src, 'v', 2),
+        ]);
+    });
+
+    it('binds every for clause, not just the first', () => {
+        const src = '(for [x :in coll y :in other] (+ x y))';
+        assert.deepEqual(occStarts(src, idx(src, 'y', 1)), [idx(src, 'y', 0), idx(src, 'y', 1)]);
+        assert.deepEqual(occStarts(src, idx(src, 'x', 1)), [idx(src, 'x', 0), idx(src, 'x', 1)]);
+    });
+
+    it('binds the for :reduce accumulator', () => {
+        const src = '(for [x :in coll :reduce [acc 0]] (+ acc x))';
+        assert.deepEqual(occStarts(src, idx(src, 'acc', 1)), [
+            idx(src, 'acc', 0),
+            idx(src, 'acc', 1),
+        ]);
+    });
+
+    it('binds letfn names across every spec and the body', () => {
+        const src = '(letfn [(p [a] (q a)) (q [b] b)] (p 1))';
+        // `q` is called from inside `p`'s body, before its own spec: letfn
+        // names are mutually recursive, so a use may precede the declaration.
+        assert.deepEqual(occStarts(src, idx(src, 'q', 0)), [idx(src, 'q', 0), idx(src, 'q', 1)]);
+        assert.deepEqual(occStarts(src, idx(src, 'p', 0)), [idx(src, 'p', 0), idx(src, 'p', 1)]);
+    });
+
+    it('scopes letfn parameters to their own spec', () => {
+        const src = '(letfn [(p [a] (php/abs a)) (q [a] a)] 1)';
+        // The two `a` parameters are distinct bindings, not one shared local.
+        assert.deepEqual(occStarts(src, idx(src, 'a', 0)), [idx(src, 'a', 0), idx(src, 'a', 2)]);
+        assert.deepEqual(occStarts(src, idx(src, 'a', 3)), [idx(src, 'a', 3), idx(src, 'a', 4)]);
+    });
+
+    it('leaves with-redefs targets as globals', () => {
+        // `foo` is an existing var being temporarily rebound, not a new local:
+        // renaming it must stay a workspace-wide rename.
+        const src = '(with-redefs [foo (fn [] 1)] (foo))';
+        assert.equal(resolveLocalAt(src, idx(src, 'foo', 1)), null);
+    });
 });
 
 describe('phelScope.localsInScopeAt', () => {
@@ -179,6 +234,12 @@ describe('phelScope.localsInScopeAt', () => {
         const inG = localsInScopeAt(src, idx(src, 'b', 1));
         assert.ok(inG.includes('b'));
         assert.ok(!inG.includes('a'));
+    });
+
+    it('does not offer a letfn spec parameter outside that spec', () => {
+        const src = '(letfn [(f [n] n) (g [m] m)] (f 1))';
+        const inBody = localsInScopeAt(src, idx(src, '(f 1)') + 1);
+        assert.deepEqual(inBody.sort(), ['f', 'g']);
     });
 });
 


### PR DESCRIPTION
Follow-up to #82. That PR closed the gap between the extension and the phel **reader**; this one closes the gap in the **scope analyzer**.

## Why

`src/phelScope.ts` knew only part of phel's binding surface. Inside the rest, a local was treated as a global — so rename rewrote every same-named token in the workspace, go-to-definition jumped to an unrelated `def`, and completion never offered the binding.

Verified against phel-lang v0.49.0 (`src/phel/core/{loops,io,protocols}.phel`) before implementing. Before this PR:

| Form | `resolveLocalAt` |
| --- | --- |
| `(dotimes [i 5] … i …)` | not local |
| `(when-first [x coll] … x …)` | not local |
| `(as-> 1 v (+ v 2))` | not local |
| `(letfn [(f [n] …)] …)` | not local (name *and* params) |
| `(for [x :in xs y :in ys] …)` | `y` not local — only the first clause bound |
| `(for [… :reduce [acc 0]] …)` | `acc` not local |

## What

- `dotimes` / `when-first` → single-pair binding heads.
- `as->` → binds the threading name from its own atom through the rest of the form.
- `letfn` → each function name is visible across every spec and the body (they are mutually recursive); each spec's parameters stay inside that spec.
- `for` / `doseq` / `dofor` → the head is walked as the flat clause sequence it is: every `binding :verb expr` clause (`:range` / `:in` / `:keys` / `:pairs`), every `:let` pair, the `:reduce` accumulator, skipping `:when` / `:while`. The `(doseq [x coll] …)` shorthand still works.

Two supporting fixes fall out of `letfn` — its bindings are the first that do not run to the end of the enclosing form, and the first that can be referenced *before* their own declaration:

- `localsInScopeAt` now honours `scopeEnd`, so a spec's parameters are not offered in the body.
- `localOccurrences` measures from `min(declStart, scopeStart)`, so a mutually recursive call preceding its declaration counts as a reference. For every sequential form `declStart` is still the lower bound, so behaviour there is unchanged.

Everything downstream of the analyzer — semantic tokens, unused-local hints, document-highlight, in-scope completion — picks these up for free.

## Deliberately excluded

`with-redefs` rebinds *existing* vars rather than declaring locals, so renaming a target there must stay a workspace-wide rename. Pinned by a test so a future pass does not "fix" it into a local.

## Verification

- 9 new cases in `src/test/phelScope.test.ts` covering each form, letfn parameter isolation, forward references, and the `with-redefs` non-regression.
- `npm run pretest` + `npm test`: **423 passing**. `npm run check:changelog` green.
- `docs/refactoring.md` gains a "Locals vs globals" table listing every form that introduces locals.
