### PR TITLE
feat(scope): resolve protocol-method and defmethod parameters as locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Language support
 
+- **Protocol-method parameters are locals.** `this` and friends inside a `defrecord` / `deftype` / `extend-type` / `extend-protocol` / `reify` implementation tail, and the parameters of a `defmethod`, now resolve to their own binding — previously renaming `this` in one method rewrote every `this` in the workspace. A `defprotocol` / `definterface` method form stays excluded: it is a signature with no body, so binding its names would report each one as an unused local. `defrecord` / `deftype` field vectors also stay out — those are struct keys, not locals.
 - **Scope analysis covers the remaining core binding forms.** `dotimes`, `when-first`, `as->`, and `letfn` now introduce locals, so go-to-definition, find-references, rename, document-highlight, semantic tokens, unused-local hints, and in-scope completion work inside them. `letfn` is modelled properly: the function names are visible across every spec and the body (mutual recursion), while each spec's parameters stay confined to that spec.
 - **`for` / `doseq` / `dofor` heads are read in full.** Only the first `binding :verb expr` clause used to bind; a second clause (`(for [x :in xs y :in ys] …)`) and the `:reduce [acc init]` accumulator were treated as globals. All clauses, `:let` pairs, and the accumulator now resolve as locals.
 - A local whose scope has closed is no longer offered by completion — a `letfn` spec's parameters stop at that spec instead of leaking into the body.

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -30,10 +30,18 @@ These forms introduce locals:
 | `letfn` | each function name (visible across all specs and the body — they are mutually recursive) and each spec's own parameters |
 | `as->` | the threading name |
 | `catch` | the exception var |
+| `defrecord`, `deftype`, `extend-type`, `extend-protocol`, `reify` | the parameters of each `(method [params] body…)` implementation in the tail |
+| `defmethod` | the parameters after the dispatch value |
 
 Vector, `:keys` / `:syms` / `:strs`, and `:as` destructuring is followed in every one of them.
 
-Anything else is treated as a global, deliberately: `with-redefs` rebinds *existing* vars rather than declaring locals, so renaming one there stays a workspace-wide rename. A form whose binding shape is not recognised yields no locals at all and falls back to the workspace-wide behaviour, so the analyzer never makes a rename narrower than it should be.
+Anything else is treated as a global, deliberately:
+
+- `with-redefs` rebinds *existing* vars rather than declaring locals, so renaming one there stays a workspace-wide rename.
+- A `defprotocol` / `definterface` method form is a **signature**, not an implementation. Its parameter names bind nothing — treating them as locals would report every one as unused.
+- The field vector of `defrecord` / `deftype` holds struct keys, reached with `get` or destructuring, so the fields are not locals in the method bodies.
+
+A form whose binding shape is not recognised yields no locals at all and falls back to the workspace-wide behaviour, so the analyzer never makes a rename narrower than it should be.
 
 ## Document Outline & Breadcrumbs
 

--- a/src/phelScope.ts
+++ b/src/phelScope.ts
@@ -51,6 +51,20 @@ const SEQ_VERBS = new Set([':range', ':in', ':keys', ':pairs']);
 const FN_HEADS = new Set(['fn', 'defn', 'defn-', 'defmacro', 'defmacro-']);
 /** Sequential-iteration forms: `(head [var … coll] body…)`. */
 const SEQ_HEADS = new Set(['for', 'doseq', 'dofor']);
+/**
+ * Forms carrying a tail of protocol-method *implementations*,
+ * `(method-name [params] body…)`. `defprotocol` / `definterface` are absent on
+ * purpose: their method forms are signatures with no body, so their parameter
+ * names are not locals and must not be reported as unused.
+ */
+const METHOD_IMPL_HEADS = new Set([
+    'defrecord',
+    'deftype',
+    'extend-type',
+    'extend-protocol',
+    'reify',
+    'reify*',
+]);
 
 function atomText(src: string, form: Form): string {
     return src.slice(form.bodyStart, form.bodyEnd);
@@ -264,6 +278,16 @@ function bindingsOf(src: string, form: Form): LocalBinding[] {
         return letfnBindings(src, form, bodyEnd);
     }
 
+    if (METHOD_IMPL_HEADS.has(name)) {
+        return methodImplBindings(src, form);
+    }
+
+    if (name === 'defmethod') {
+        // (defmethod multi-name dispatch-val [params] body…) — the fn tail
+        // starts after the dispatch value.
+        return fnTailBindings(src, form, 3, form.innerEnd);
+    }
+
     if (FN_HEADS.has(name)) {
         return fnBindings(src, form, name);
     }
@@ -412,30 +436,68 @@ function fnBindings(src: string, form: Form, head: string): LocalBinding[] {
         i++; // skip the def name
     }
 
-    const addArity = (paramVec: Form, scopeEnd: number): void => {
+    out.push(...fnTailBindings(src, form, i, form.innerEnd));
+    return out;
+}
+
+/**
+ * Parameter bindings for an `fn` tail — everything from `children[start]` on,
+ * which is either `[params] body…` or a run of `([params] body…)` arities.
+ */
+function fnTailBindings(src: string, form: Form, start: number, scopeEnd: number): LocalBinding[] {
+    const out: LocalBinding[] = [];
+    const rest = form.children.slice(start);
+
+    const addArity = (paramVec: Form, end: number): void => {
         for (const t of collectTargets(src, paramVec)) {
             out.push({
                 name: t.name,
                 declStart: t.start,
                 declEnd: t.end,
                 scopeStart: paramVec.end,
-                scopeEnd,
+                scopeEnd: end,
                 param: true,
             });
         }
     };
 
-    // Single-arity: the first vector child is the parameter list.
-    const directVec = kids.slice(i).find((c) => c.kind === 'vector');
+    // Single-arity: the first vector is the parameter list.
+    const directVec = rest.find((c) => c.kind === 'vector');
     if (directVec) {
-        addArity(directVec, form.innerEnd);
+        addArity(directVec, scopeEnd);
         return out;
     }
     // Multi-arity: each `([params] body…)` list is its own scope.
-    for (const arity of kids.slice(i)) {
+    for (const arity of rest) {
         if (arity.kind === 'list' && arity.children[0]?.kind === 'vector') {
             addArity(arity.children[0], arity.innerEnd);
         }
+    }
+    return out;
+}
+
+/**
+ * Parameters of the protocol-method implementations in a `defrecord` /
+ * `deftype` / `extend-type` / `extend-protocol` / `reify` tail. Each
+ * `(method-name [params] body…)` list is its own scope.
+ *
+ * A method form with no body is a *signature*, not an implementation, so its
+ * parameters bind nothing — that keeps `defprotocol`-style declarations out of
+ * the unused-local hints even when they appear in one of these tails.
+ *
+ * The field vector of `defrecord` / `deftype` is not a binding: those fields
+ * are struct keys, reached with `get` or destructuring, not locals in scope.
+ */
+function methodImplBindings(src: string, form: Form): LocalBinding[] {
+    const out: LocalBinding[] = [];
+    for (const spec of form.children.slice(1)) {
+        if (spec.kind !== 'list' || spec.children.length < 3) {
+            continue;
+        }
+        if (!isAtom(spec.children[0]) || spec.children[1].kind !== 'vector') {
+            continue;
+        }
+        out.push(...fnTailBindings(src, spec, 1, spec.innerEnd));
     }
     return out;
 }

--- a/src/test/phelScope.test.ts
+++ b/src/test/phelScope.test.ts
@@ -211,6 +211,50 @@ describe('phelScope binding forms', () => {
         assert.deepEqual(occStarts(src, idx(src, 'a', 3)), [idx(src, 'a', 3), idx(src, 'a', 4)]);
     });
 
+    it('binds protocol-method parameters in a defrecord tail', () => {
+        const src = '(defrecord P [w] G (draw [obj c] (paint obj c)))';
+        assert.deepEqual(occStarts(src, idx(src, 'obj', 1)), [
+            idx(src, 'obj', 0),
+            idx(src, 'obj', 1),
+        ]);
+    });
+
+    it('leaves defrecord fields as struct keys, not locals', () => {
+        // `w` is reached with `get` / destructuring, never as a local.
+        const src = '(defrecord P [w] G (draw [obj] obj))';
+        assert.equal(resolveLocalAt(src, idx(src, 'w', 0)), null);
+    });
+
+    it('binds reify and extend-type method parameters', () => {
+        const reified = '(reify G (draw [obj] (paint obj)))';
+        assert.deepEqual(occStarts(reified, idx(reified, 'obj', 1)), [
+            idx(reified, 'obj', 0),
+            idx(reified, 'obj', 1),
+        ]);
+        const extended = '(extend-type :string G (to-str [v] (up v)))';
+        assert.deepEqual(occStarts(extended, idx(extended, 'v', 1)), [
+            idx(extended, 'v', 0),
+            idx(extended, 'v', 1),
+        ]);
+    });
+
+    it('binds defmethod parameters after the dispatch value', () => {
+        const src = '(defmethod area :circle [z] (* z z))';
+        assert.deepEqual(occStarts(src, idx(src, 'z', 1)), [
+            idx(src, 'z', 0),
+            idx(src, 'z', 1),
+            idx(src, 'z', 2),
+        ]);
+    });
+
+    it('does not bind defprotocol signature parameters', () => {
+        // A signature has no body, so its names are declarations, not locals —
+        // binding them would report every one as an unused local.
+        const src = '(defprotocol G (draw [obj c]))';
+        assert.equal(resolveLocalAt(src, idx(src, 'obj', 0)), null);
+        assert.deepEqual(findUnusedLocals(src), []);
+    });
+
     it('leaves with-redefs targets as globals', () => {
         // `foo` is an existing var being temporarily rebound, not a new local:
         // renaming it must stay a workspace-wide rename.


### PR DESCRIPTION
Third in the series after #82 (reader literals) and #83 (core binding forms). This closes the last binding hole I could find in `src/phelScope.ts`: protocol-method implementations.

## Why

`this` inside a protocol implementation was a global. Renaming it in one method rewrote **every** `this` in the workspace; go-to-definition led nowhere; completion never offered it.

Shapes verified against phel-lang v0.49.0 `src/phel/core/protocols.phel` before implementing. Before this PR:

| Form | `resolveLocalAt` |
| --- | --- |
| `(defrecord P [w] G (draw [obj c] … obj …))` | not local |
| `(reify G (draw [obj] … obj …))` | not local |
| `(extend-type :string G (to-str [v] … v …))` | not local |
| `(extend-protocol D :int (describe [n] … n …))` | not local |
| `(defmethod area :circle [z] (* z z))` | not local |

## What

- Each `(method-name [params] body…)` in a `defrecord` / `deftype` / `extend-type` / `extend-protocol` / `reify` tail binds its parameters, scoped to that method.
- `defmethod` binds the `fn` tail after its dispatch value.
- The arity walk is factored out of `fnBindings` into a shared `fnTailBindings`, so a multi-arity method behaves like a multi-arity `fn` rather than being special-cased.

## Deliberately left unbound

- **`defprotocol` / `definterface` method forms are signatures**, not implementations — no body, so their names are declarations. Binding them would report every parameter as an unused local (a visible false positive, since unused locals render faded). The guard is a *body* check rather than only a head check, so a signature appearing inside one of the implementation tails is skipped as well.
- **`defrecord` / `deftype` field vectors** hold struct keys, reached with `get` or destructuring — not locals in the method bodies.

Both are pinned by tests so a later pass doesn't "fix" them into locals.

## Verification

- 5 new cases in `src/test/phelScope.test.ts`, including the two negative ones above.
- `npm run pretest` + `npm test`: **428 passing**. `npm run check:changelog` green.
- `docs/refactoring.md` "Locals vs globals" table extended, with the exclusions spelled out and why.
