### PR TITLE
feat(snippets): scaffold the binding, protocol, threading and test forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Snippets
+
+- **31 new snippets, 29 → 60.** The binding-vector conditionals (`if-let`, `when-let`, `if-some`, `when-some`, `when-first`), `binding`, `letfn`, `dotimes`, `foreach`, `condp`, `if-not`, `when-not`, `declare`; the rest of the threading family (`as->`, `some->`, `some->>`, `cond->`, `cond->>`, `doto`); the protocol surface (`defrecord`, `deftype`, `reify`, `extend-type`, `extend-protocol`, `defmulti`, `defmethod`); the test forms (`testing`, `are`, `with-mocks`); plus `match` and `lazy-seq`. Every body is taken from the form's own `:example` metadata or its phel-lang definition, so the scaffolding matches the real shape.
+- `src/test/snippets.test.ts` now fails the build when a snippet prefix matches no form in the symbol corpus, when two snippets share a prefix, or when a body's brackets do not balance.
+
 ### Language support
 
 - **Protocol-method parameters are locals.** `this` and friends inside a `defrecord` / `deftype` / `extend-type` / `extend-protocol` / `reify` implementation tail, and the parameters of a `defmethod`, now resolve to their own binding — previously renaming `this` in one method rewrote every `this` in the workspace. A `defprotocol` / `definterface` method form stays excluded: it is a signature with no body, so binding its names would report each one as an unused local. `defrecord` / `deftype` field vectors also stay out — those are struct keys, not locals.

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -34,21 +34,26 @@ npm run regen-docs -- /path/to/phel-lang --phel-version v0.49.0
 
 ## Snippets
 
-`snippets/phel.code-snippets` ships templates for the everyday forms. Type the prefix, accept the suggestion, and tab through the placeholders.
+`snippets/phel.code-snippets` ships 60 templates covering the everyday forms. Type the prefix, accept the suggestion, and tab through the placeholders.
 
 | Prefix | Expands to |
 |---|---|
 | `ns` | `(ns my-app.core (:require ...))` |
 | `defn`, `defn-` | Public / private function with docstring + args |
-| `def`, `defonce`, `fn`, `let` | Top-level binding, once-only binding, anonymous fn, local bindings |
-| `if`, `when`, `cond`, `case` | Conditionals |
-| `doseq`, `for`, `loop` | Iteration (with `recur` skeleton) |
+| `def`, `defonce`, `declare`, `fn`, `let` | Top-level binding, once-only binding, forward declaration, anonymous fn, local bindings |
+| `if`, `if-not`, `when`, `when-not`, `cond`, `condp`, `case` | Conditionals |
+| `if-let`, `when-let`, `if-some`, `when-some`, `when-first` | Bind-and-branch forms, with the binding vector already in place |
+| `binding`, `letfn` | Dynamic rebinding, mutually recursive local fns |
+| `doseq`, `for`, `foreach`, `dotimes`, `loop` | Iteration (`loop` with a `recur` skeleton) |
 | `try` | `try` + `catch \Throwable e` |
 | `defmacro`, `defstruct`, `defenum`, `definterface`, `defprotocol`, `defexception` | Definitions |
-| `deftest` | Test case with `(is ...)` |
-| `->`, `->>` | Threading skeletons |
+| `defrecord`, `deftype`, `reify`, `extend-type`, `extend-protocol` | Records / types / protocol implementations, with a method skeleton |
+| `defmulti`, `defmethod` | Multimethod and one dispatch implementation |
+| `deftest`, `testing`, `are`, `with-mocks` | Test case, labelled group, table-driven assertions, scoped mocks |
+| `->`, `->>`, `as->`, `some->`, `some->>`, `cond->`, `cond->>`, `doto` | Threading skeletons |
+| `match`, `lazy-seq` | Pattern match (`phel.match`), lazy sequence body |
 | `comment` | Form-aware comment block |
 | `while`, `with-open` | While loop, scoped resource cleanup |
 | `dbg`, `deftrace` | Debug-print a value, traced fn (`phel.trace`) |
 
-Add or refine entries when a form is fiddly enough that scaffolding helps. Keep the `prefix` matching the form name so it composes with completion.
+Add or refine entries when a form is fiddly enough that scaffolding helps. Keep the `prefix` matching the form name so it composes with completion — `src/test/snippets.test.ts` fails the build when a prefix matches no form in the corpus, when two snippets share a prefix, or when a body's brackets do not balance.

--- a/snippets/phel.code-snippets
+++ b/snippets/phel.code-snippets
@@ -76,6 +76,74 @@
         ],
         "description": "Multi-branch conditional"
     },
+    "condp": {
+        "prefix": "condp",
+        "body": [
+            "(condp ${1:=} ${2:expr}",
+            "  ${3:value} ${4:result}",
+            "  ${0:default})"
+        ],
+        "description": "Predicate dispatch: (pred value expr) per clause"
+    },
+    "if-not": {
+        "prefix": "if-not",
+        "body": [
+            "(if-not ${1:test}",
+            "  ${2:then}",
+            "  ${0:else})"
+        ],
+        "description": "Conditional on the negated test"
+    },
+    "when-not": {
+        "prefix": "when-not",
+        "body": [
+            "(when-not ${1:test}",
+            "  ${0})"
+        ],
+        "description": "Body when the test is falsy"
+    },
+    "if-let": {
+        "prefix": "if-let",
+        "body": [
+            "(if-let [${1:name} ${2:test}]",
+            "  ${3:then}",
+            "  ${0:else})"
+        ],
+        "description": "Bind and branch when the test is truthy"
+    },
+    "when-let": {
+        "prefix": "when-let",
+        "body": [
+            "(when-let [${1:name} ${2:test}]",
+            "  ${0})"
+        ],
+        "description": "Bind and run the body when the test is truthy"
+    },
+    "if-some": {
+        "prefix": "if-some",
+        "body": [
+            "(if-some [${1:name} ${2:test}]",
+            "  ${3:then}",
+            "  ${0:else})"
+        ],
+        "description": "Bind and branch when the test is non-nil"
+    },
+    "when-some": {
+        "prefix": "when-some",
+        "body": [
+            "(when-some [${1:name} ${2:test}]",
+            "  ${0})"
+        ],
+        "description": "Bind and run the body when the test is non-nil"
+    },
+    "when-first": {
+        "prefix": "when-first",
+        "body": [
+            "(when-first [${1:x} ${2:coll}]",
+            "  ${0})"
+        ],
+        "description": "Bind the first element and run the body when the collection is non-empty"
+    },
     "case": {
         "prefix": "case",
         "body": [
@@ -100,6 +168,38 @@
             "  ${0})"
         ],
         "description": "List comprehension"
+    },
+    "foreach": {
+        "prefix": "foreach",
+        "body": [
+            "(foreach [${1:k} ${2:v} ${3:coll}]",
+            "  ${0})"
+        ],
+        "description": "Iterate key/value pairs (drop the key for values only)"
+    },
+    "dotimes": {
+        "prefix": "dotimes",
+        "body": [
+            "(dotimes [${1:i} ${2:n}]",
+            "  ${0})"
+        ],
+        "description": "Evaluate the body n times with i bound to 0..n-1"
+    },
+    "binding": {
+        "prefix": "binding",
+        "body": [
+            "(binding [${1:*var*} ${2:value}]",
+            "  ${0})"
+        ],
+        "description": "Fiber-local rebinding of ^:dynamic vars"
+    },
+    "letfn": {
+        "prefix": "letfn",
+        "body": [
+            "(letfn [(${1:name} [${2:args}] ${3:body})]",
+            "  ${0})"
+        ],
+        "description": "Mutually recursive local functions"
     },
     "loop-recur": {
         "prefix": "loop",
@@ -157,6 +257,67 @@
         ],
         "description": "Protocol definition"
     },
+    "defrecord": {
+        "prefix": "defrecord",
+        "body": [
+            "(defrecord ${1:Name} [${2:fields}]",
+            "  ${3:Protocol}",
+            "  (${0:method [this args] body}))"
+        ],
+        "description": "Record with an optional protocol implementation tail"
+    },
+    "deftype": {
+        "prefix": "deftype",
+        "body": [
+            "(deftype ${1:Name} [${2:fields}]",
+            "  ${3:Protocol}",
+            "  (${0:method [this args] body}))"
+        ],
+        "description": "Type with an optional protocol implementation tail (no map factory)"
+    },
+    "reify": {
+        "prefix": "reify",
+        "body": [
+            "(reify ${1:Protocol}",
+            "  (${0:method [this args] body}))"
+        ],
+        "description": "Anonymous object implementing one or more protocols"
+    },
+    "extend-type": {
+        "prefix": "extend-type",
+        "body": [
+            "(extend-type ${1::string} ${2:Protocol}",
+            "  (${0:method [this args] body}))"
+        ],
+        "description": "Implement protocols for an existing type"
+    },
+    "extend-protocol": {
+        "prefix": "extend-protocol",
+        "body": [
+            "(extend-protocol ${1:Protocol}",
+            "  ${2::string} (${3:method [this] body})",
+            "  ${0::int} (method [this] body))"
+        ],
+        "description": "Extend one protocol to several types"
+    },
+    "defmulti": {
+        "prefix": "defmulti",
+        "body": ["(defmulti ${1:name} \"${2:doc}\" ${0:dispatch-fn})"],
+        "description": "Multimethod dispatching on the value of dispatch-fn"
+    },
+    "defmethod": {
+        "prefix": "defmethod",
+        "body": [
+            "(defmethod ${1:multi-name} ${2:dispatch-val} [${3:args}]",
+            "  ${0})"
+        ],
+        "description": "Multimethod implementation for one dispatch value"
+    },
+    "declare": {
+        "prefix": "declare",
+        "body": ["(declare ${0:name})"],
+        "description": "Forward declaration for mutual recursion between top-level defs"
+    },
     "defexception": {
         "prefix": "defexception",
         "body": ["(defexception ${1:Name} ${0:\"message\"})"],
@@ -170,6 +331,30 @@
         ],
         "description": "Test case"
     },
+    "testing": {
+        "prefix": "testing",
+        "body": [
+            "(testing \"${1:context}\"",
+            "  (is ${0}))"
+        ],
+        "description": "Label a group of assertions inside a deftest"
+    },
+    "are": {
+        "prefix": "are",
+        "body": [
+            "(are [${1:x} ${2:y}] (= ${1:x} ${2:y})",
+            "  ${0})"
+        ],
+        "description": "Table-driven assertions over an argument template"
+    },
+    "with-mocks": {
+        "prefix": "with-mocks",
+        "body": [
+            "(with-mocks [${1:some-fn} (mock ${2:result})]",
+            "  ${0})"
+        ],
+        "description": "Temporarily replace fns with mocks, reset after the body (phel.mock)"
+    },
     "->": {
         "prefix": "->",
         "body": ["(-> ${1:x}", "    ${0})"],
@@ -179,6 +364,50 @@
         "prefix": "->>",
         "body": ["(->> ${1:x}", "     ${0})"],
         "description": "Thread-last macro"
+    },
+    "as->": {
+        "prefix": "as->",
+        "body": ["(as-> ${1:expr} ${2:x}", "      ${0})"],
+        "description": "Thread through an explicitly named binding"
+    },
+    "some->": {
+        "prefix": "some->",
+        "body": ["(some-> ${1:x}", "        ${0})"],
+        "description": "Thread-first, short-circuiting on nil"
+    },
+    "some->>": {
+        "prefix": "some->>",
+        "body": ["(some->> ${1:x}", "         ${0})"],
+        "description": "Thread-last, short-circuiting on nil"
+    },
+    "cond->": {
+        "prefix": "cond->",
+        "body": ["(cond-> ${1:x}", "        ${2:test} ${0:form})"],
+        "description": "Thread-first through the forms whose test is truthy"
+    },
+    "cond->>": {
+        "prefix": "cond->>",
+        "body": ["(cond->> ${1:x}", "         ${2:test} ${0:form})"],
+        "description": "Thread-last through the forms whose test is truthy"
+    },
+    "doto": {
+        "prefix": "doto",
+        "body": ["(doto ${1:x}", "      ${0})"],
+        "description": "Call each form on x for side effects, returning x"
+    },
+    "lazy-seq": {
+        "prefix": "lazy-seq",
+        "body": ["(lazy-seq ${0})"],
+        "description": "Lazily evaluated sequence body"
+    },
+    "match": {
+        "prefix": "match",
+        "body": [
+            "(match ${1:value}",
+            "  ${2:pattern} ${3:result}",
+            "  ${0:_} nil)"
+        ],
+        "description": "Pattern match (phel.match)"
     },
     "comment": {
         "prefix": "comment",

--- a/src/test/snippets.test.ts
+++ b/src/test/snippets.test.ts
@@ -1,0 +1,113 @@
+// Guards `snippets/phel.code-snippets`: the file is hand-written, so a typo in
+// a prefix or a form that upstream removed would ship silently. Every prefix is
+// checked against the generated symbol corpus plus the hand-curated special
+// forms, which is the same surface completion offers.
+
+import * as assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { SPECIAL_FORMS, MACROS, CORE_FNS } from '../phelCoreSymbols';
+import { PHEL_DOCS } from '../phelCoreDocs';
+
+interface Snippet {
+    prefix: string;
+    body: string[];
+    description: string;
+}
+
+const snippets: Record<string, Snippet> = JSON.parse(
+    readFileSync(join(__dirname, '..', '..', 'snippets', 'phel.code-snippets'), 'utf-8')
+);
+
+const entries = Object.entries(snippets);
+
+describe('phel snippets', () => {
+    it('is not empty', () => {
+        assert.ok(entries.length > 0);
+    });
+
+    it('gives every snippet a prefix, a non-empty body, and a description', () => {
+        for (const [name, snip] of entries) {
+            assert.equal(typeof snip.prefix, 'string', `${name}: prefix`);
+            assert.ok(snip.prefix.length > 0, `${name}: empty prefix`);
+            assert.ok(Array.isArray(snip.body) && snip.body.length > 0, `${name}: body`);
+            assert.ok(
+                typeof snip.description === 'string' && snip.description.length > 0,
+                `${name}: description`
+            );
+        }
+    });
+
+    it('uses a distinct prefix per snippet', () => {
+        const seen = new Map<string, string>();
+        for (const [name, snip] of entries) {
+            const clash = seen.get(snip.prefix);
+            assert.equal(
+                clash,
+                undefined,
+                `prefix ${snip.prefix} used by both ${clash} and ${name}`
+            );
+            seen.set(snip.prefix, name);
+        }
+    });
+
+    it('only offers prefixes that exist in the Phel language surface', () => {
+        const known = new Set<string>([
+            ...SPECIAL_FORMS,
+            ...MACROS,
+            ...CORE_FNS,
+            ...PHEL_DOCS.filter((d) => !d.private).map((d) => d.name),
+        ]);
+        const unknown = entries
+            .map(([, snip]) => snip.prefix)
+            .filter((prefix) => !known.has(prefix));
+        assert.deepEqual(unknown, [], `snippet prefixes with no matching Phel form: ${unknown}`);
+    });
+
+    it('balances brackets in every body', () => {
+        const pairs: Record<string, string> = { ')': '(', ']': '[', '}': '{' };
+        for (const [name, snip] of entries) {
+            const text = snip.body.join('\n');
+            const stack: string[] = [];
+            let inString = false;
+            for (let i = 0; i < text.length; i++) {
+                const c = text[i];
+                if (c === '\\') {
+                    i++;
+                    continue;
+                }
+                if (c === '"') {
+                    inString = !inString;
+                    continue;
+                }
+                if (inString) {
+                    continue;
+                }
+                // `${1:...}` placeholders carry their own braces.
+                if (c === '$' && text[i + 1] === '{') {
+                    stack.push('${');
+                    i++;
+                    continue;
+                }
+                if ('(['.includes(c)) {
+                    stack.push(c);
+                    continue;
+                }
+                if (c === '{') {
+                    stack.push('{');
+                    continue;
+                }
+                if (c in pairs) {
+                    const open = stack.pop();
+                    const expected = c === '}' ? ['{', '${'] : [pairs[c]];
+                    assert.ok(
+                        open !== undefined && expected.includes(open),
+                        `${name}: unbalanced ${c} (open was ${open})`
+                    );
+                }
+            }
+            assert.deepEqual(stack, [], `${name}: unclosed ${stack.join('')}`);
+        }
+    });
+});


### PR DESCRIPTION
Fourth in the series after #82 (reader literals), #83 (core binding forms) and #84 (protocol-method params).

## Why

`snippets/phel.code-snippets` covered 29 forms and stopped short of exactly the ones where scaffolding pays off — everything taking a **binding vector**, the **protocol-implementation** family, most of the **threading** macros, and the **test** helpers.

Completion's generated call snippet doesn't fill the gap: `buildCallSnippet` turns a signature into flat placeholders, so `if-let` came out as `(if-let ${1:bindings} ${2:then} ${3:else})` — no `[]`, no method skeleton, nothing that matches how the form is actually written.

## What

31 new snippets, 29 → 60. Each body comes from the form's own `:example` metadata in the corpus or its definition in phel-lang v0.49.0, not from memory:

| Group | Added |
| --- | --- |
| Binding vectors | `if-let`, `when-let`, `if-some`, `when-some`, `when-first`, `binding`, `letfn`, `dotimes`, `foreach` |
| Conditionals | `if-not`, `when-not`, `condp` |
| Threading | `as->`, `some->`, `some->>`, `cond->`, `cond->>`, `doto` |
| Protocols | `defrecord`, `deftype`, `reify`, `extend-type`, `extend-protocol`, `defmulti`, `defmethod` |
| Tests | `testing`, `are`, `with-mocks` |
| Other | `declare`, `match`, `lazy-seq` |

## Guard

New `src/test/snippets.test.ts` fails the build on:

- a prefix matching no form in the symbol corpus (typos, and — after a corpus regen — a snippet for a form upstream removed);
- two snippets sharing a prefix;
- an unbalanced body, counting `${1:…}` placeholder braces separately from map braces.

Mutation-checked: adding a deliberately broken snippet trips both the duplicate-prefix and the unclosed-bracket assertions.


## Verification

- `npm run pretest` + `npm test`: **433 passing**. `npm run check:changelog` green.
- `docs/completion.md` snippet table rewritten to cover all 60.
