### PR TITLE
feat(completion): complete alias-qualified symbols and the ns form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Completion
+
+- **`alias/…` completes.** After `(:require [phel.string :as str])`, typing `str/` now offers every public symbol of that namespace with its docs. Hover, go-to-definition and signature help already resolved alias-qualified symbols; completion offered nothing, because every candidate label is a bare name.
+- **The `(ns …)` form gets its own candidates** instead of all 576 core symbols: `:require` / `:use` / `:require-file` directly inside `(ns …)`, the requirable namespaces inside a `(:require …)` clause, and `:as` / `:refer` inside an entry vector.
+
+### Fixed
+
+- **Flat `:require` entries resolved no alias.** `(:require phel.string :as str)` — the shape the compiler still accepts alongside the vector form — parsed as a namespace with no options, so `str/blank?` silently lost hover, go-to-definition and signature help. Several flat entries in one clause, and flat mixed with vector entries, are now read the way `NsSymbol` reads them.
+- **The backslash namespace separator never matched.** `phel\string`, which Phel's own sources use, was compared verbatim against the corpus's `phel.string`, so every alias-qualified lookup through it failed. Namespaces are now normalised to the dotted form on parse, which also stops auto-import from adding a duplicate `:require` for a namespace already imported with backslashes.
+
 ### Snippets
 
 - **31 new snippets, 29 → 60.** The binding-vector conditionals (`if-let`, `when-let`, `if-some`, `when-some`, `when-first`), `binding`, `letfn`, `dotimes`, `foreach`, `condp`, `if-not`, `when-not`, `declare`; the rest of the threading family (`as->`, `some->`, `some->>`, `cond->`, `cond->>`, `doto`); the protocol surface (`defrecord`, `deftype`, `reify`, `extend-type`, `extend-protocol`, `defmulti`, `defmethod`); the test forms (`testing`, `are`, `with-mocks`); plus `match` and `lazy-seq`. Every body is taken from the form's own `:example` metadata or its phel-lang definition, so the scaffolding matches the real shape.

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -10,6 +10,26 @@ The extension ships a static `CompletionItemProvider` for the `phel` language. I
 
 The provider respects the word range so `defn|` completes correctly without duplicating the prefix.
 
+### Context-aware candidate lists
+
+Two positions get their own, much smaller list instead of the flat core one:
+
+**`alias/…`** — after `(:require [phel.string :as str])`, typing `str/` offers every public symbol of `phel.string`, labelled `str/blank?`, with its docstring. Both `:require` shapes are understood, and both namespace separators:
+
+```phel
+(:require [phel.string :as str])   ;; vector entry
+(:require phel.string :as str)     ;; flat entry
+(:require phel\string :as str)     ;; backslash separator, normalised to phel.string
+```
+
+**Inside `(ns …)`** — core symbols are noise there, so the provider offers:
+
+| Position | Candidates |
+|---|---|
+| Directly inside `(ns …)` | `:require`, `:use`, `:require-file` |
+| Inside `(:require …)` | Every namespace in the corpus or workspace, minus this file's own and the ones already required |
+| Inside a `[some.ns …]` entry | `:as`, `:refer` |
+
 ### Bundled providers vs. the language server
 
 These bundled providers are the zero-config default: they work offline, with no extra process or warmup, and cover ~80% of the daily friction.

--- a/src/phelCompletionContext.ts
+++ b/src/phelCompletionContext.ts
@@ -1,0 +1,157 @@
+// What the cursor is *inside*, for the completion provider. Two contexts get
+// their own candidate list instead of the flat "every core symbol" one:
+//
+//   1. `alias/…` — an alias introduced by `[some.ns :as alias]`. Hover,
+//      go-to-definition and signature help already resolve these; completion
+//      used to offer nothing, because every candidate label is a bare name.
+//   2. inside the `(ns …)` form — where core symbols are noise and the useful
+//      candidates are the clause keywords, the entry options, and the
+//      namespaces the workspace actually has.
+//
+// Pure: no `vscode` import, so the decisions are unit-testable.
+
+import { parseAll, pathAt, type Form } from './phelParedit';
+import { aliasMapFromSource } from './phelNsAnalyzer';
+import type { PhelDoc } from './phelDocs';
+
+/** Clause heads a `(ns …)` form accepts, per the compiler's `NsSymbol`. */
+export const NS_CLAUSES: readonly string[] = [':require', ':use', ':require-file'];
+/** Options a single `:require` entry accepts, per the same source. */
+export const NS_ENTRY_OPTIONS: readonly string[] = [':as', ':refer'];
+
+export type CompletionContext =
+    | { kind: 'normal' }
+    /** Typing `alias/name`; `ns` is the namespace the alias resolves to. */
+    | { kind: 'alias-qualified'; alias: string; ns: string }
+    /** Inside `(ns …)`: a clause head like `(:require …)` is expected. */
+    | { kind: 'ns-clause' }
+    /** Inside `(:require …)` / `(:use …)`, outside any entry vector. */
+    | { kind: 'ns-namespace' }
+    /** Inside a `[some.ns …]` entry, past the namespace symbol. */
+    | { kind: 'ns-entry-option' };
+
+/**
+ * The alias being typed, when the token under the cursor looks like
+ * `alias/partial`. Returns null for a bare token, for a leading `/`, and for
+ * `php/…`, which is interop rather than a namespace alias.
+ */
+export function aliasPrefix(linePrefix: string): string | null {
+    const match = /([A-Za-z0-9_!?*+<>=.\-$&%]+)\/[A-Za-z0-9_!?*+<>=.\-$&%]*$/.exec(linePrefix);
+    if (!match) {
+        return null;
+    }
+    const alias = match[1];
+    return alias === 'php' ? null : alias;
+}
+
+function atomText(src: string, form: Form): string {
+    return src.slice(form.bodyStart, form.bodyEnd);
+}
+
+function headText(src: string, form: Form): string | null {
+    const head = form.children[0];
+    return head && head.kind === 'atom' ? atomText(src, head) : null;
+}
+
+/**
+ * Classify the cursor. `linePrefix` is the text before the cursor on its own
+ * line; `offset` is the same position as a document offset.
+ */
+export function completionContextAt(
+    src: string,
+    offset: number,
+    linePrefix: string
+): CompletionContext {
+    const alias = aliasPrefix(linePrefix);
+    if (alias) {
+        const ns = aliasMapFromSource(src).get(alias);
+        if (ns) {
+            return { kind: 'alias-qualified', alias, ns };
+        }
+        // An unknown alias is still a qualified position: offering the flat
+        // core list there would only produce noise, so fall through to normal
+        // handling and let the provider filter as usual.
+    }
+
+    const path = pathAt(parseAll(src), offset);
+    const nsIndex = path.findIndex((f) => f.kind === 'list' && headText(src, f) === 'ns');
+    if (nsIndex < 0) {
+        return { kind: 'normal' };
+    }
+
+    // Innermost list under the `(ns …)` form decides the sub-context.
+    for (let i = path.length - 1; i > nsIndex; i--) {
+        const form = path[i];
+        if (form.kind === 'vector') {
+            // `[some.ns :as x]` — past the namespace symbol, options are next.
+            return { kind: 'ns-entry-option' };
+        }
+        if (form.kind === 'list') {
+            const head = headText(src, form);
+            if (head && NS_CLAUSES.includes(head)) {
+                return { kind: 'ns-namespace' };
+            }
+        }
+    }
+    return { kind: 'ns-clause' };
+}
+
+/** A completion candidate produced by one of the qualified contexts. */
+export interface QualifiedCandidate {
+    /** Text to insert and match on, e.g. `str/blank?`. */
+    label: string;
+    /** Bare symbol name, for the docs lookup. */
+    name: string;
+    kind: 'macro' | 'fn' | 'def';
+    detail: string;
+}
+
+/**
+ * Every public symbol of `ns`, labelled with the alias so the label matches
+ * what the user is typing (`str/blank?`).
+ */
+export function aliasQualifiedCandidates(
+    alias: string,
+    ns: string,
+    docs: readonly PhelDoc[]
+): QualifiedCandidate[] {
+    const seen = new Set<string>();
+    const out: QualifiedCandidate[] = [];
+    for (const doc of docs) {
+        if (doc.ns !== ns || doc.private || seen.has(doc.name)) {
+            continue;
+        }
+        seen.add(doc.name);
+        out.push({
+            label: `${alias}/${doc.name}`,
+            name: doc.name,
+            kind: doc.kind === 'macro' ? 'macro' : doc.kind === 'def' ? 'def' : 'fn',
+            detail: `${ns}/${doc.name}`,
+        });
+    }
+    return out;
+}
+
+/**
+ * Namespaces offerable inside `(:require …)`: every namespace known to the
+ * corpus or the workspace, minus the file's own and the ones it already
+ * requires.
+ */
+export function requirableNamespaces(
+    src: string,
+    docs: readonly PhelDoc[],
+    ownNs?: string,
+    alreadyRequired: readonly string[] = []
+): string[] {
+    const skip = new Set<string>(alreadyRequired);
+    if (ownNs) {
+        skip.add(ownNs);
+    }
+    const out = new Set<string>();
+    for (const doc of docs) {
+        if (doc.ns && !skip.has(doc.ns)) {
+            out.add(doc.ns);
+        }
+    }
+    return [...out].sort();
+}

--- a/src/phelCompletionProvider.ts
+++ b/src/phelCompletionProvider.ts
@@ -4,6 +4,13 @@ import { CORE_FNS, MACROS, SPECIAL_FORMS } from './phelCoreSymbols';
 import { buildCallSnippet, isCalleePosition } from './phelCallSnippet';
 import { lookupSymbol, renderDocMarkdown } from './phelDocsLookup';
 import { buildRequireEdit, parseNsForm, type NsForm } from './phelNsAnalyzer';
+import {
+    aliasQualifiedCandidates,
+    completionContextAt,
+    requirableNamespaces,
+    NS_CLAUSES,
+    NS_ENTRY_OPTIONS,
+} from './phelCompletionContext';
 import { combineDocs } from './phelWorkspaceIndex';
 import { localsInScopeAt } from './phelScope';
 import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
@@ -163,13 +170,43 @@ export class PhelCompletionProvider implements vscode.CompletionItemProvider {
         const merged = this.indexer
             ? combineDocs(this.indexer.index.allDocs(), PHEL_DOCS)
             : [...PHEL_DOCS];
+        const linePrefix = document.lineAt(position.line).text.slice(0, position.character);
+        const context = completionContextAt(src, document.offsetAt(position), linePrefix);
+
+        // `alias/…` and the `(ns …)` form each have a small, exact candidate
+        // list; the flat core list would only be noise there.
+        if (context.kind === 'alias-qualified') {
+            return aliasQualifiedCandidates(context.alias, context.ns, merged).map((cand) => {
+                const item = new vscode.CompletionItem(
+                    cand.label,
+                    cand.kind === 'fn'
+                        ? vscode.CompletionItemKind.Function
+                        : vscode.CompletionItemKind.Keyword
+                );
+                item.detail = cand.detail;
+                const doc = merged.find((d) => d.qualifiedName === `${context.ns}/${cand.name}`);
+                if (doc) {
+                    const md = new vscode.MarkdownString(renderDocMarkdown(doc));
+                    md.isTrusted = false;
+                    md.supportHtml = false;
+                    item.documentation = md;
+                }
+                if (range) {
+                    item.range = range;
+                }
+                return item;
+            });
+        }
+        if (context.kind !== 'normal') {
+            return this.nsFormItems(context.kind, src, merged, range);
+        }
+
         const specs = [
             ...this.baseSpecs,
             ...workspaceSpecs(this.indexer),
             ...privateFileSpecs(this.indexer, document),
         ];
         const nsForm = parseNsForm(src);
-        const linePrefix = document.lineAt(position.line).text.slice(0, position.character);
         const callee = isCalleePosition(linePrefix);
         const items = specs.map((spec) => buildItem(spec, range, merged, document, nsForm, callee));
 
@@ -185,5 +222,53 @@ export class PhelCompletionProvider implements vscode.CompletionItemProvider {
             items.push(item);
         }
         return items;
+    }
+
+    /** Candidates inside a `(ns …)` form: clause heads, entry options, namespaces. */
+    private nsFormItems(
+        kind: 'ns-clause' | 'ns-namespace' | 'ns-entry-option',
+        src: string,
+        docs: readonly import('./phelDocs').PhelDoc[],
+        range: vscode.Range | undefined
+    ): vscode.CompletionItem[] {
+        const withRange = (item: vscode.CompletionItem): vscode.CompletionItem => {
+            if (range) {
+                item.range = range;
+            }
+            return item;
+        };
+
+        if (kind === 'ns-clause') {
+            return NS_CLAUSES.map((clause) => {
+                const item = new vscode.CompletionItem(clause, vscode.CompletionItemKind.Keyword);
+                item.detail = 'ns clause';
+                return withRange(item);
+            });
+        }
+        if (kind === 'ns-entry-option') {
+            return NS_ENTRY_OPTIONS.map((option) => {
+                const item = new vscode.CompletionItem(option, vscode.CompletionItemKind.Keyword);
+                item.detail = 'require option';
+                return withRange(item);
+            });
+        }
+
+        const nsForm = parseNsForm(src);
+        const already = nsForm?.requireClause?.entries.map((e) => e.ns) ?? [];
+        const namespaces = requirableNamespaces(src, docs, nsForm?.name, already).map((ns) => {
+            const item = new vscode.CompletionItem(ns, vscode.CompletionItemKind.Module);
+            item.detail = 'namespace';
+            return withRange(item);
+        });
+        // `[ns :as x]` is the shape the auto-import edit writes, so offer the
+        // options here too: the cursor may sit right after a namespace symbol.
+        return [
+            ...namespaces,
+            ...NS_ENTRY_OPTIONS.map((option) => {
+                const item = new vscode.CompletionItem(option, vscode.CompletionItemKind.Keyword);
+                item.detail = 'require option';
+                return withRange(item);
+            }),
+        ];
     }
 }

--- a/src/phelNsAnalyzer.ts
+++ b/src/phelNsAnalyzer.ts
@@ -94,6 +94,15 @@ function atomText(src: string, atom: Form): string {
     return src.slice(atom.start, atom.end);
 }
 
+/**
+ * Namespaces are written with either separator — `phel\string` is what Phel's
+ * own sources use, `phel.string` is what the compiler normalises them to and
+ * what the symbol corpus records. Compare and look up on the dotted form.
+ */
+export function normalizeNs(text: string): string {
+    return text.replace(/\\/g, '.');
+}
+
 function findRequireClause(src: string, ns: Form): RequireClause | null {
     for (const child of ns.children) {
         if (child.kind !== 'list' || child.children.length === 0) {
@@ -109,10 +118,78 @@ function findRequireClause(src: string, ns: Form): RequireClause | null {
         return {
             start: child.start,
             end: child.end,
-            entries: child.children.slice(1).map((entry) => parseRequireEntry(src, entry)),
+            entries: parseRequireEntries(src, child.children.slice(1)),
         };
     }
     return null;
+}
+
+/**
+ * Walk a `(:require …)` body the way the compiler's `NsSymbol` does: a vector
+ * is a self-contained entry, while a bare symbol opens a *flat* entry whose
+ * `:as` / `:refer` options follow as siblings until the next symbol or vector.
+ * Both shapes are legal, and several flat entries may share one clause.
+ */
+function parseRequireEntries(src: string, children: Form[]): RequireEntry[] {
+    const out: RequireEntry[] = [];
+    let i = 0;
+    while (i < children.length) {
+        const child = children[i];
+        if (child.kind === 'vector') {
+            out.push(parseRequireEntry(src, child));
+            i++;
+            continue;
+        }
+        if (child.kind !== 'atom' || atomText(src, child).startsWith(':')) {
+            i++; // stray option with no entry to attach to
+            continue;
+        }
+        out.push(parseFlatRequireEntry(src, children, i));
+        i++;
+        while (i < children.length) {
+            const option = children[i];
+            if (option.kind !== 'atom' || !atomText(src, option).startsWith(':')) {
+                break;
+            }
+            i += 2; // the option keyword plus its argument
+        }
+    }
+    return out;
+}
+
+/** `some.ns :as alias :refer [a b]` written flat inside the clause. */
+function parseFlatRequireEntry(src: string, children: Form[], start: number): RequireEntry {
+    const nsAtom = children[start];
+    const entry: RequireEntry = {
+        start: nsAtom.start,
+        end: nsAtom.end,
+        ns: normalizeNs(atomText(src, nsAtom)),
+        refer: [],
+    };
+    for (let i = start + 1; i < children.length; i++) {
+        const option = children[i];
+        if (option.kind !== 'atom') {
+            break;
+        }
+        const text = atomText(src, option);
+        if (!text.startsWith(':')) {
+            break;
+        }
+        const next = children[i + 1];
+        if (text === ':as' && next?.kind === 'atom') {
+            entry.as = atomText(src, next);
+        } else if (text === ':refer' && next?.kind === 'vector') {
+            entry.refer = next.children
+                .filter((c) => c.kind === 'atom')
+                .map((c) => atomText(src, c));
+            entry.referVector = { start: next.start, end: next.end };
+        }
+        if (next) {
+            entry.end = next.end;
+            i++;
+        }
+    }
+    return entry;
 }
 
 function parseRequireEntry(src: string, entry: Form): RequireEntry {
@@ -120,7 +197,7 @@ function parseRequireEntry(src: string, entry: Form): RequireEntry {
         return {
             start: entry.start,
             end: entry.end,
-            ns: atomText(src, entry),
+            ns: normalizeNs(atomText(src, entry)),
             refer: [],
         };
     }
@@ -133,7 +210,7 @@ function parseRequireEntry(src: string, entry: Form): RequireEntry {
         };
     }
     const nsAtom = entry.children[0];
-    const ns = nsAtom.kind === 'atom' ? atomText(src, nsAtom) : '';
+    const ns = nsAtom.kind === 'atom' ? normalizeNs(atomText(src, nsAtom)) : '';
     let refer: string[] = [];
     let referVector: { start: number; end: number } | undefined;
     let as: string | undefined;

--- a/src/test/phelCompletionContext.test.ts
+++ b/src/test/phelCompletionContext.test.ts
@@ -1,0 +1,133 @@
+import * as assert from 'node:assert/strict';
+import {
+    aliasPrefix,
+    aliasQualifiedCandidates,
+    completionContextAt,
+    requirableNamespaces,
+} from '../phelCompletionContext';
+import type { PhelDoc } from '../phelDocs';
+
+const DOCS: PhelDoc[] = [
+    { name: 'blank?', ns: 'phel.string', qualifiedName: 'phel.string/blank?', kind: 'fn' },
+    { name: 'join', ns: 'phel.string', qualifiedName: 'phel.string/join', kind: 'fn' },
+    {
+        name: 'hidden',
+        ns: 'phel.string',
+        qualifiedName: 'phel.string/hidden',
+        kind: 'fn',
+        private: true,
+    },
+    { name: 'is', ns: 'phel.test', qualifiedName: 'phel.test/is', kind: 'macro' },
+    { name: 'map', ns: 'phel.core', qualifiedName: 'phel.core/map', kind: 'fn' },
+] as PhelDoc[];
+
+describe('phelCompletionContext.aliasPrefix', () => {
+    it('reads the alias out of a qualified token being typed', () => {
+        assert.equal(aliasPrefix('(str/bla'), 'str');
+        assert.equal(aliasPrefix('  (foo (s/'), 's');
+    });
+
+    it('ignores bare tokens and php interop', () => {
+        assert.equal(aliasPrefix('(blan'), null);
+        assert.equal(aliasPrefix('(php/strlen'), null);
+        assert.equal(aliasPrefix(''), null);
+    });
+});
+
+describe('phelCompletionContext.completionContextAt', () => {
+    const src = [
+        '(ns my.app',
+        '  (:require [phel.string :as str])',
+        '  (:require phel.test :as t))',
+        '',
+        '(defn f [] (str/blank? ""))',
+    ].join('\n');
+
+    function ctxAt(marker: string, linePrefix: string) {
+        return completionContextAt(src, src.indexOf(marker) + marker.length, linePrefix);
+    }
+
+    it('resolves an alias from a vector require', () => {
+        assert.deepEqual(ctxAt('str/blank', '(defn f [] (str/blank'), {
+            kind: 'alias-qualified',
+            alias: 'str',
+            ns: 'phel.string',
+        });
+    });
+
+    it('resolves an alias from a flat require', () => {
+        const flat = '(ns a (:require phel.test :as t))\n(t/is true)';
+        assert.deepEqual(completionContextAt(flat, flat.lastIndexOf('t/is') + 2, '(t/i'), {
+            kind: 'alias-qualified',
+            alias: 't',
+            ns: 'phel.test',
+        });
+    });
+
+    it('reports a namespace position inside a require clause', () => {
+        const inClause = '(ns a\n  (:require ))';
+        const offset = inClause.indexOf('(:require ') + '(:require '.length;
+        assert.deepEqual(completionContextAt(inClause, offset, '  (:require '), {
+            kind: 'ns-namespace',
+        });
+    });
+
+    it('reports an option position inside a require entry vector', () => {
+        const inVector = '(ns a\n  (:require [phel.string ]))';
+        const offset = inVector.indexOf('phel.string ') + 'phel.string '.length;
+        assert.deepEqual(completionContextAt(inVector, offset, '  (:require [phel.string '), {
+            kind: 'ns-entry-option',
+        });
+    });
+
+    it('reports a clause position directly inside the ns form', () => {
+        const bare = '(ns a\n  )';
+        assert.deepEqual(completionContextAt(bare, bare.indexOf('\n  ') + 3, '  '), {
+            kind: 'ns-clause',
+        });
+    });
+
+    it('falls back to normal outside the ns form', () => {
+        assert.deepEqual(ctxAt('(defn f', '(defn f'), { kind: 'normal' });
+    });
+
+    it('falls back to normal for an alias that is not required', () => {
+        assert.deepEqual(completionContextAt(src, src.length, '(zzz/no'), { kind: 'normal' });
+    });
+});
+
+describe('phelCompletionContext.aliasQualifiedCandidates', () => {
+    it('labels every public symbol of the namespace with the alias', () => {
+        const cands = aliasQualifiedCandidates('str', 'phel.string', DOCS);
+        assert.deepEqual(
+            cands.map((c) => c.label),
+            ['str/blank?', 'str/join']
+        );
+        assert.equal(cands[0].detail, 'phel.string/blank?');
+        assert.equal(cands[0].name, 'blank?');
+    });
+
+    it('skips private symbols and other namespaces', () => {
+        const labels = aliasQualifiedCandidates('str', 'phel.string', DOCS).map((c) => c.label);
+        assert.ok(!labels.includes('str/hidden'));
+        assert.ok(!labels.includes('str/is'));
+    });
+});
+
+describe('phelCompletionContext.requirableNamespaces', () => {
+    it('lists known namespaces minus the file own and already-required ones', () => {
+        const src = '(ns my.app (:require [phel.string :as str]))';
+        assert.deepEqual(requirableNamespaces(src, DOCS, 'my.app', ['phel.string']), [
+            'phel.core',
+            'phel.test',
+        ]);
+    });
+
+    it('keeps every namespace when nothing is required yet', () => {
+        assert.deepEqual(requirableNamespaces('(ns my.app)', DOCS, 'my.app'), [
+            'phel.core',
+            'phel.string',
+            'phel.test',
+        ]);
+    });
+});

--- a/src/test/phelNsAnalyzer.test.ts
+++ b/src/test/phelNsAnalyzer.test.ts
@@ -99,4 +99,65 @@ describe('phelNsAnalyzer.aliasMapFromSource', () => {
         assert.equal(map.get('r'), 'phelgeon.render');
         assert.equal(map.get('i'), 'phelgeon.input');
     });
+
+    it('reads a flat entry, the legacy shape the compiler still accepts', () => {
+        const map = aliasMapFromSource('(ns my.app (:require phel.string :as str))');
+        assert.equal(map.get('str'), 'phel.string');
+    });
+
+    it('reads several flat entries in one clause', () => {
+        const map = aliasMapFromSource(
+            '(ns my.app (:require phel.string :as str phel.html :as h))'
+        );
+        assert.equal(map.get('str'), 'phel.string');
+        assert.equal(map.get('h'), 'phel.html');
+    });
+
+    it('reads flat and vector entries mixed in one clause', () => {
+        const map = aliasMapFromSource(
+            '(ns my.app (:require phel.string :as str [phel.test :as t :refer [is]]))'
+        );
+        assert.equal(map.get('str'), 'phel.string');
+        assert.equal(map.get('t'), 'phel.test');
+    });
+
+    it('normalises the backslash separator Phel sources use', () => {
+        // `phel\string` is what phel's own code writes; the compiler and the
+        // symbol corpus both use the dotted form.
+        assert.equal(
+            aliasMapFromSource('(ns a (:require [phel\\string :as str]))').get('str'),
+            'phel.string'
+        );
+        assert.equal(
+            aliasMapFromSource('(ns a (:require phel\\string :as str))').get('str'),
+            'phel.string'
+        );
+    });
+});
+
+describe('phelNsAnalyzer flat require entries', () => {
+    it('captures :refer names on a flat entry', () => {
+        const ns = parseNsForm('(ns a (:require phel.test :refer [deftest is]))');
+        const entry = ns?.requireClause?.entries[0];
+        assert.equal(entry?.ns, 'phel.test');
+        assert.deepEqual(entry?.refer, ['deftest', 'is']);
+    });
+
+    it('does not merge two flat entries into one', () => {
+        const ns = parseNsForm('(ns a (:require phel.string :as str phel.html :as h))');
+        assert.deepEqual(
+            ns?.requireClause?.entries.map((e) => e.ns),
+            ['phel.string', 'phel.html']
+        );
+    });
+
+    it('treats a backslash-spelled entry as already required', () => {
+        // buildRequireEdit compares against the normalised namespace, so an
+        // auto-import must not add a duplicate entry for the same namespace.
+        const ns = parseNsForm('(ns a (:require [phel\\string :as str]))');
+        const edit = buildRequireEdit(ns, 'phel.string', 'blank?');
+        assert.ok(edit);
+        assert.ok(edit.text.includes(':refer [blank?]'));
+        assert.ok(!edit.text.includes('[phel.string :refer'));
+    });
 });


### PR DESCRIPTION
Fifth in the series after #82, #83, #84, #85.

## Why

Hover, go-to-definition and signature help all resolve `alias/name` through the file's `:require` clause — they share `aliasMapFromSource`. **Completion did not**: every candidate label is a bare name, so typing `str/` matched nothing at all. You could hover `str/blank?` but never complete it.

Wiring completion to that alias map surfaced two bugs that were already breaking the three providers which *do* use it.

## Bugs fixed

**Flat `:require` entries resolved no alias.** `(:require phel.string :as str)` parsed as a namespace with no options. The compiler accepts this shape alongside the vector form (`NsSymbol::analyzeRequireFlatEntry`), and accepts several per clause — so in any file written that way, `str/blank?` silently lost hover, go-to-definition and signature help. Verified the shape runs before fixing:

```phel
(ns t (:require phel\string :as str))
(php/var_dump (str/blank? ""))   ;; => bool(true)
```

Entries are now walked the way `NsSymbol` walks them: a vector is self-contained; a bare symbol opens a flat entry whose `:as` / `:refer` options follow as siblings until the next symbol or vector.

**The backslash separator never matched.** `phel\string` — what phel's own sources write — was compared verbatim against the corpus's `phel.string`, so every alias-qualified lookup through it failed. Namespaces normalise to the dotted form on parse, matching `normalizeSymbolSeparators` in the compiler. That also stops auto-import from adding a duplicate `:require` for a namespace already imported with backslashes.

## Feature

New `src/phelCompletionContext.ts` classifies the cursor, so two positions get an exact candidate list instead of the flat 576-symbol one:

| Position | Candidates |
| --- | --- |
| `alias/…` | Every public symbol of the aliased namespace, labelled `str/blank?`, with docs |
| Directly inside `(ns …)` | `:require`, `:use`, `:require-file` |
| Inside `(:require …)` | Requirable namespaces, minus this file's own and those already required |
| Inside a `[some.ns …]` entry | `:as`, `:refer` |

The clause and option keywords come from the compiler's `NsSymbol`, not from memory — there is no `:import` in Phel.

Classification lives in a `vscode`-free module so it is unit-testable; the provider only maps candidates to `CompletionItem`s.

## Verification

- 20 new tests (13 for the context module, 7 for the analyzer shapes), `npm test`: **453 passing**.
- `npm run pretest` and `npm run check:changelog` green.
- `docs/completion.md` documents both new candidate lists and all three `:require` spellings.