### PR TITLE
feat(symbols): index the type, protocol, enum and test defining forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Symbols & navigation
+
+- **Ten more defining forms are indexed.** The parser behind the outline, "Go to Symbol in Workspace", cross-file completion, auto-import and go-to-definition recognised only `defn` / `defn-` / `defmacro` / `defmacro-` / `def` / `def-`. It now also reads `defonce`, `defstruct`, `defrecord`, `deftype`, `defprotocol`, `definterface`, `defenum`, `defexception`, `defmulti` and `deftest` — so a file of records, protocols or tests is no longer nearly invisible (a 14-definition sample produced 2 symbols before, 12 now), and those names resolve across files.
+- Struct-like forms carry their field vector as a signature, because that vector is the positional constructor: `(defrecord Circle [r] Shape (area [this] 1))` shows as `(Circle r)`, with the method tail correctly not read as a second arity.
+- Outline entries now pick an icon per form — Struct for `defrecord`, Interface for `defprotocol`, Enum for `defenum`, Event for `deftest`, and so on — via a new `form` field on `PhelDoc` that records the defining operator. `PhelDocKind` keeps its three values, so the `MACROS` / `CORE_FNS` projections are unchanged.
+- `declare` stays unindexed on purpose: it forward-declares names a real defining form supplies later in the same file, so indexing it would list every declared symbol twice.
+- Note for the next `npm run regen-docs`: the corpus generator shares this parser, so a regen will pick up the `phel.html` / `phel.http` / `phel.router` structs and add `form` to every entry. No `phel.core` symbol changes, so `CORE_FNS` and `MACROS` are unaffected.
+
 ### Completion
 
 - **`alias/…` completes.** After `(:require [phel.string :as str])`, typing `str/` now offers every public symbol of that namespace with its docs. Hover, go-to-definition and signature help already resolved alias-qualified symbols; completion offered nothing, because every candidate label is a bare name.

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -45,7 +45,25 @@ A form whose binding shape is not recognised yields no locals at all and falls b
 
 ## Document Outline & Breadcrumbs
 
-Every public form (`defn`, `defmacro`, `def`) shows up in the editor outline (`cmd+shift+O`) with its first arity signature as the detail.
+Every top-level defining form shows up in the editor outline (`cmd+shift+O`) with its first arity signature as the detail, and each gets an icon matching what it defines:
+
+| Form | Icon |
+|---|---|
+| `defn`, `defn-`, `defmulti` | Function |
+| `defmacro`, `defmacro-` | Method |
+| `def`, `def-` | Variable |
+| `defonce` | Constant |
+| `defstruct`, `defrecord`, `deftype` | Struct |
+| `defprotocol`, `definterface` | Interface |
+| `defenum` | Enum |
+| `defexception` | Class |
+| `deftest` | Event |
+
+The struct-like forms carry their field vector as a signature, because that vector *is* the positional constructor — `(defrecord Circle [r] …)` shows as `(Circle r)`.
+
+`declare` is not listed: it forward-declares names that a real defining form supplies later in the same file, so indexing it would show every such symbol twice.
+
+The same set drives "Go to Symbol in Workspace", cross-file completion, and go-to-definition — so a record or protocol defined in one file is now reachable from another.
 
 ## Go to Symbol in Workspace (`cmd+T`)
 

--- a/src/phelDocs.ts
+++ b/src/phelDocs.ts
@@ -26,6 +26,13 @@ export interface PhelDoc {
     qualifiedName: string;
     /** What kind of form introduced this binding. */
     kind: PhelDocKind;
+    /**
+     * The operator that introduced it, e.g. `defn`, `defrecord`, `deftest`.
+     * Finer-grained than `kind`, which the symbol corpus keeps to three values;
+     * used for outline icons. Absent on corpus entries generated before this
+     * field existed.
+     */
+    form?: string;
     /** Whether the form is private (`defn-`, `defmacro-`, `def-`). */
     private: boolean;
     /** First arity signature, e.g. `(assoc m k v)`; undefined for plain `def`. */
@@ -100,6 +107,21 @@ export function parsePhelFile(source: string, ns: string): PhelDoc[] {
     return docs;
 }
 
+/**
+ * Every top-level form that introduces a name.
+ *
+ * `kind` stays the three-way split the symbol corpus records; `form` keeps the
+ * operator that introduced the name so the outline can pick a precise icon
+ * without widening `PhelDocKind` (which `MACROS` / `CORE_FNS` filter on).
+ *
+ * The struct-like forms are `fn` rather than `def` because each one defines a
+ * positional constructor, and their field vector is that constructor's
+ * signature — exactly what the signature scan already extracts.
+ *
+ * `declare` is deliberately absent: it forward-declares names that a real
+ * defining form supplies later in the same file, so indexing it would double
+ * every declared symbol in the outline and the workspace picker.
+ */
 const DEFINING_OPS: Record<string, { kind: PhelDocKind; private: boolean }> = {
     defn: { kind: 'fn', private: false },
     'defn-': { kind: 'fn', private: true },
@@ -107,6 +129,16 @@ const DEFINING_OPS: Record<string, { kind: PhelDocKind; private: boolean }> = {
     'defmacro-': { kind: 'macro', private: true },
     def: { kind: 'def', private: false },
     'def-': { kind: 'def', private: true },
+    defonce: { kind: 'def', private: false },
+    defstruct: { kind: 'fn', private: false },
+    defrecord: { kind: 'fn', private: false },
+    deftype: { kind: 'fn', private: false },
+    defmulti: { kind: 'fn', private: false },
+    deftest: { kind: 'fn', private: false },
+    defprotocol: { kind: 'def', private: false },
+    definterface: { kind: 'def', private: false },
+    defenum: { kind: 'def', private: false },
+    defexception: { kind: 'def', private: false },
 };
 
 /**
@@ -149,6 +181,7 @@ function parseDefiningForm(
         ns,
         qualifiedName: `${ns}/${nameSlice.value}`,
         kind: meta.kind,
+        form: op.value,
         private: meta.private,
     };
 

--- a/src/phelSymbolProviders.ts
+++ b/src/phelSymbolProviders.ts
@@ -13,7 +13,28 @@ import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
 
 const NAMESPACE_RE = /\((?:ns|in-ns)\s+([A-Za-z][\w.-]*)/;
 
-function symbolKindFor(kind: PhelDocKind): vscode.SymbolKind {
+/** Icons for the forms whose `kind` is too coarse to distinguish them. */
+const SYMBOL_KIND_BY_FORM: Record<string, vscode.SymbolKind> = {
+    defstruct: vscode.SymbolKind.Struct,
+    defrecord: vscode.SymbolKind.Struct,
+    deftype: vscode.SymbolKind.Struct,
+    defprotocol: vscode.SymbolKind.Interface,
+    definterface: vscode.SymbolKind.Interface,
+    defenum: vscode.SymbolKind.Enum,
+    defexception: vscode.SymbolKind.Class,
+    deftest: vscode.SymbolKind.Event,
+    defonce: vscode.SymbolKind.Constant,
+};
+
+function symbolKindFor(doc: Pick<PhelDoc, 'kind' | 'form'>): vscode.SymbolKind {
+    const byForm = doc.form ? SYMBOL_KIND_BY_FORM[doc.form] : undefined;
+    if (byForm !== undefined) {
+        return byForm;
+    }
+    return symbolKindForKind(doc.kind);
+}
+
+function symbolKindForKind(kind: PhelDocKind): vscode.SymbolKind {
     switch (kind) {
         case 'fn':
             return vscode.SymbolKind.Function;
@@ -60,7 +81,7 @@ function buildDocumentSymbol(doc: PhelDoc, document: vscode.TextDocument): vscod
     return new vscode.DocumentSymbol(
         doc.name,
         detailFor(doc),
-        symbolKindFor(doc.kind),
+        symbolKindFor(doc),
         range,
         new vscode.Range(start, start.translate(0, doc.name.length))
     );
@@ -82,7 +103,7 @@ export class PhelWorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvid
             out.push(
                 new vscode.SymbolInformation(
                     doc.name,
-                    symbolKindFor(doc.kind),
+                    symbolKindFor(doc),
                     doc.ns,
                     new vscode.Location(vscode.Uri.file(doc.sourceFile), pos)
                 )

--- a/src/test/phelDocs.test.ts
+++ b/src/test/phelDocs.test.ts
@@ -113,6 +113,75 @@ describe('parsePhelFile', function () {
         });
     });
 
+    describe('type, protocol and test forms', function () {
+        it('indexes a defstruct with its positional constructor signature', function () {
+            const doc = single('(defstruct Point [x y])', 'my.app');
+            assert.strictEqual(doc.name, 'Point');
+            assert.strictEqual(doc.form, 'defstruct');
+            assert.strictEqual(doc.kind, 'fn');
+            assert.strictEqual(doc.signature, '(Point x y)');
+        });
+
+        it('indexes a defrecord without mistaking its method tail for an arity', function () {
+            const doc = single('(defrecord Circle [r] Shape (area [this] 1))', 'my.app');
+            assert.strictEqual(doc.name, 'Circle');
+            assert.strictEqual(doc.signature, '(Circle r)');
+            assert.strictEqual(doc.arities, undefined);
+        });
+
+        it('indexes deftype, defprotocol, definterface, defenum and defexception', function () {
+            const docs = parsePhelFile(
+                `(deftype Sq [s])
+(defprotocol Shape (area [this]))
+(definterface Drawable (draw [this]))
+(defenum Color :red :green)
+(defexception MyError)`,
+                'my.app'
+            );
+            assert.deepStrictEqual(
+                docs.map((d) => [d.name, d.form, d.kind]),
+                [
+                    ['Sq', 'deftype', 'fn'],
+                    ['Shape', 'defprotocol', 'def'],
+                    ['Drawable', 'definterface', 'def'],
+                    ['Color', 'defenum', 'def'],
+                    ['MyError', 'defexception', 'def'],
+                ]
+            );
+        });
+
+        it('indexes defonce, defmulti and deftest', function () {
+            const docs = parsePhelFile(
+                `(defonce cache {})
+(defmulti area "Area of a shape." :shape)
+(deftest my-test (is true))`,
+                'my.app'
+            );
+            assert.deepStrictEqual(
+                docs.map((d) => d.name),
+                ['cache', 'area', 'my-test']
+            );
+            assert.strictEqual(docs[1].doc, 'Area of a shape.');
+        });
+
+        it('skips declare, whose names are defined for real further down', function () {
+            // Indexing it would double every declared symbol in the outline.
+            const docs = parsePhelFile('(declare later-fn)\n(defn later-fn [] 1)', 'my.app');
+            assert.deepStrictEqual(
+                docs.map((d) => [d.name, d.form]),
+                [['later-fn', 'defn']]
+            );
+        });
+
+        it('records the defining operator on the classic forms too', function () {
+            const docs = parsePhelFile('(defn a [] 1)\n(defmacro- b [] 1)\n(def- c 1)', 'my.app');
+            assert.deepStrictEqual(
+                docs.map((d) => d.form),
+                ['defn', 'defmacro-', 'def-']
+            );
+        });
+    });
+
     describe('multi-form input', function () {
         it('returns one doc per top-level form, in order', function () {
             const docs = parsePhelFile(


### PR DESCRIPTION
Sixth in the series after #82, #83, #84, #85, #86.

## Why

`parsePhelFile` — the parser behind the outline, "Go to Symbol in Workspace", cross-file completion, auto-import and go-to-definition — recognised six operators: `defn`, `defn-`, `defmacro`, `defmacro-`, `def`, `def-`.

Everything else was invisible. A file of records, a protocol module, or a test namespace showed almost nothing in the outline, and none of those names resolved from another file. Measured on a 14-definition sample:

```
before: a, f                                     (2 of 12 real definitions)
after:  a, b, f, Point, Circle, Sq, Shape,
        Drawable, Color, MyError, area, my-test  (12)
```

## What

Ten operators added: `defonce`, `defstruct`, `defrecord`, `deftype`, `defprotocol`, `definterface`, `defenum`, `defexception`, `defmulti`, `deftest`.

**Struct-likes are `fn`, not `def`**, so the existing signature scan reads their field vector — which is exactly the positional constructor:

```phel
(defrecord Circle [r] Shape (area [this] 1))   ;; => signature (Circle r)
```

The method tail is correctly not read as a second arity — pinned by a test.

**`declare` is deliberately excluded.** It forward-declares names a real defining form supplies later in the same file, so indexing it would list every declared symbol twice in the outline and the picker. Also pinned by a test.

**Outline icons** come from a new `form` field on `PhelDoc` recording the defining operator, rather than from widening `PhelDocKind`:

| Form | Icon |
| --- | --- |
| `defn`, `defn-`, `defmulti` | Function |
| `defmacro`, `defmacro-` | Method |
| `def`, `def-` | Variable |
| `defonce` | Constant |
| `defstruct`, `defrecord`, `deftype` | Struct |
| `defprotocol`, `definterface` | Interface |
| `defenum` | Enum |
| `defexception` | Class |
| `deftest` | Event |

`MACROS` and `CORE_FNS` filter on `PhelDocKind`, so keeping it at three values leaves those projections untouched.

## Note for the next corpus regen

`scripts/regen-core-docs.cjs` shares this parser, so `npm run regen-docs` will now pick up the `phel.html` / `phel.http` / `phel.router` structs and add `form` to every entry. Checked upstream: `phel.core` defines none of the new forms, so `CORE_FNS` and `MACROS` do not change.

## Verification

- 6 new tests in `src/test/phelDocs.test.ts`, covering each form group, the constructor signature, the method-tail case, and the `declare` exclusion.
- `npm run pretest` + `npm test`: **459 passing**. `npm run check:changelog` green.
- `docs/refactoring.md` documents the full form-to-icon table and the `declare` rationale.