### PR TITLE
fix(hover): report the local under the cursor instead of a same-named core fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed (hover & signature help)
+
+- **Hover on a local showed an unrelated core function.** Go-to-definition, find-references, rename and document-highlight all consult the scope analyzer; hover did not, and looked the name up in the symbol corpus instead. Every one of the 20 most common parameter names — `name`, `map`, `key`, `count`, `str`, `first`, `type`, `next`, `get`, `list`, `keys`, `vals`, `set`, `max`, `min`, `val`, `rest`, `last`, `apply`, `print` — is also a `phel.core` function, so hovering the `name` in `(defn greet [name] …)` documented `phel.core/name`. It now reports the parameter and the line it is bound on.
+- **Signature help described the wrong function for a local callee.** `(f x)` where `f` is a let-bound function showed the signature of whatever global shared that name. It now stands down instead. `findCurrentCall` gained a `calleeStart` offset so the callee can be resolved against the scope analyzer.
+
 ### Symbols & navigation
 
 - **Ten more defining forms are indexed.** The parser behind the outline, "Go to Symbol in Workspace", cross-file completion, auto-import and go-to-definition recognised only `defn` / `defn-` / `defmacro` / `defmacro-` / `def` / `def-`. It now also reads `defonce`, `defstruct`, `defrecord`, `deftype`, `defprotocol`, `definterface`, `defenum`, `defexception`, `defmulti` and `deftest` — so a file of records, protocols or tests is no longer nearly invisible (a 14-definition sample produced 2 symbols before, 12 now), and those names resolve across files.

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -16,7 +16,9 @@ Same skipping rules as Find References - you can rename `foo` without touching t
 
 ## Locals vs globals
 
-Go to Definition, Find References, Rename, and document-highlight are **scope-aware**: when the symbol under the cursor is a local, they resolve to its binding site and stay inside its own scope, so a same-named global or a binding shadowed elsewhere is never touched.
+Go to Definition, Find References, Rename, document-highlight, hover, and signature help are **scope-aware**: when the symbol under the cursor is a local, they resolve to its binding site and stay inside its own scope, so a same-named global or a binding shadowed elsewhere is never touched.
+
+This matters more than it sounds: most short parameter names are also `phel.core` functions — `name`, `map`, `key`, `count`, `str`, `first`, `type`, `next`, `get`, `list`, `keys`, `vals`, `set`, `max`, `min`, `val`, `rest`, `last`, `apply`, `print`. Hovering the `name` in `(defn greet [name] …)` reports the parameter and its binding form, not `phel.core/name`. Signature help likewise stays silent for a local in callee position rather than describing an unrelated core function.
 
 These forms introduce locals:
 

--- a/src/phelDocsLookup.ts
+++ b/src/phelDocsLookup.ts
@@ -112,6 +112,31 @@ export function renderDocMarkdown(doc: PhelDoc): string {
     return lines.join('\n').trimEnd();
 }
 
+/**
+ * Render a hover for a *local* binding. Locals have no doc record, and looking
+ * one up by name would surface an unrelated core symbol — most common
+ * parameter names (`name`, `map`, `key`, `count`, `str`, …) are also
+ * `phel.core` functions.
+ *
+ * `declLine` is the source line the binding was declared on, trimmed; it gives
+ * the reader the binding form without needing a doc record.
+ */
+export function renderLocalMarkdown(
+    binding: { name: string; param?: boolean },
+    declLine?: string
+): string {
+    const lines: string[] = [];
+    lines.push(`**\`${binding.name}\`** _${binding.param ? 'parameter' : 'local binding'}_`);
+    const trimmed = declLine?.trim();
+    if (trimmed) {
+        lines.push('');
+        lines.push('```phel');
+        lines.push(trimmed);
+        lines.push('```');
+    }
+    return lines.join('\n').trimEnd();
+}
+
 function describeKind(doc: PhelDoc): string {
     const visibility = doc.private ? 'private ' : '';
     switch (doc.kind) {

--- a/src/phelHoverProvider.ts
+++ b/src/phelHoverProvider.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 import { PHEL_DOCS } from './phelCoreDocs';
-import { lookupSymbol, renderDocMarkdown } from './phelDocsLookup';
+import { lookupSymbol, renderDocMarkdown, renderLocalMarkdown } from './phelDocsLookup';
 import { aliasMapFromSource } from './phelNsAnalyzer';
+import { resolveLocalAt } from './phelScope';
 import { combineDocs } from './phelWorkspaceIndex';
 import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
 
@@ -19,10 +20,24 @@ export class PhelHoverProvider implements vscode.HoverProvider {
             return null;
         }
         const word = document.getText(range);
+        const src = document.getText();
+
+        // A local shadows any global of the same name, and most short parameter
+        // names (`name`, `map`, `key`, `count`, …) are also `phel.core`
+        // functions — showing those docs here would be plainly wrong.
+        const local = resolveLocalAt(src, document.offsetAt(range.start));
+        if (local) {
+            const declLine = document.lineAt(document.positionAt(local.declStart).line).text;
+            const md = new vscode.MarkdownString(renderLocalMarkdown(local, declLine));
+            md.isTrusted = false;
+            md.supportHtml = false;
+            return new vscode.Hover(md, range);
+        }
+
         const merged = this.indexer
             ? combineDocs(this.indexer.index.allDocs(), PHEL_DOCS)
             : [...PHEL_DOCS];
-        const aliases = aliasMapFromSource(document.getText());
+        const aliases = aliasMapFromSource(src);
         const doc = lookupSymbol(word, merged, aliases);
         if (!doc) {
             return null;

--- a/src/phelSignatureHelp.ts
+++ b/src/phelSignatureHelp.ts
@@ -18,6 +18,8 @@ import type { PhelDoc } from './phelDocs';
 export interface CurrentCall {
     /** Bare or qualified callee name as it appears in the source. */
     callee: string;
+    /** Offset of the first character of the callee token. */
+    calleeStart: number;
     /** Zero-based index of the parameter under the cursor. */
     activeArg: number;
 }
@@ -25,6 +27,7 @@ export interface CurrentCall {
 interface Frame {
     kind: '(' | '[' | '{' | '"';
     callee?: string;
+    calleeStart?: number;
     /**
      * For `(` frames: -1 while we are still reading the callee token,
      * otherwise the count of completed arg tokens. For `[` / `{` frames the
@@ -122,6 +125,7 @@ export function findCurrentCall(source: string, offset: number): CurrentCall | n
                 end++;
             }
             top.callee = source.slice(i, end);
+            top.calleeStart = i;
             top.argIndex = 0;
             top.inArg = false;
             i = end;
@@ -137,7 +141,11 @@ export function findCurrentCall(source: string, offset: number): CurrentCall | n
     for (let k = stack.length - 1; k >= 0; k--) {
         const f = stack[k];
         if (f.kind === '(' && f.callee) {
-            return { callee: f.callee, activeArg: f.argIndex < 0 ? 0 : f.argIndex };
+            return {
+                callee: f.callee,
+                calleeStart: f.calleeStart ?? 0,
+                activeArg: f.argIndex < 0 ? 0 : f.argIndex,
+            };
         }
     }
     return null;

--- a/src/phelSignatureHelpProvider.ts
+++ b/src/phelSignatureHelpProvider.ts
@@ -9,6 +9,7 @@ import {
     parseSignatureParams,
     pickActiveSignature,
 } from './phelSignatureHelp';
+import { resolveLocalAt } from './phelScope';
 import { combineDocs } from './phelWorkspaceIndex';
 import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
 
@@ -20,15 +21,23 @@ export class PhelSignatureHelpProvider implements vscode.SignatureHelpProvider {
         position: vscode.Position
     ): vscode.ProviderResult<vscode.SignatureHelp> {
         const offset = document.offsetAt(position);
-        const call = findCurrentCall(document.getText(), offset);
+        const src = document.getText();
+        const call = findCurrentCall(src, offset);
         if (!call) {
+            return null;
+        }
+
+        // A local in callee position — `(f x)` where `f` is a let-bound fn —
+        // has no signature of its own, and most short names collide with a
+        // `phel.core` function whose signature would be simply wrong here.
+        if (resolveLocalAt(src, call.calleeStart)) {
             return null;
         }
 
         const merged = this.indexer
             ? combineDocs(this.indexer.index.allDocs(), PHEL_DOCS)
             : [...PHEL_DOCS];
-        const aliases = aliasMapFromSource(document.getText());
+        const aliases = aliasMapFromSource(src);
         const doc = lookupSymbol(call.callee, merged, aliases);
         if (!doc) {
             return null;

--- a/src/test/phelDocsLookup.test.ts
+++ b/src/test/phelDocsLookup.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import type { PhelDoc } from '../phelDocs';
-import { lookupSymbol, renderDocMarkdown } from '../phelDocsLookup';
+import { lookupSymbol, renderDocMarkdown, renderLocalMarkdown } from '../phelDocsLookup';
 
 const corpus: PhelDoc[] = [
     {
@@ -157,5 +157,24 @@ describe('renderDocMarkdown', function () {
         assert.ok(!md.includes('Example'));
         assert.ok(!md.includes('See also'));
         assert.ok(!md.includes('View source'));
+    });
+});
+
+describe('renderLocalMarkdown', function () {
+    it('labels a parameter and shows its declaring line', function () {
+        const md = renderLocalMarkdown({ name: 'name', param: true }, '(defn greet [name]');
+        assert.ok(md.startsWith('**`name`** _parameter_'));
+        assert.ok(md.includes('```phel\n(defn greet [name]\n```'));
+    });
+
+    it('labels a non-parameter binding as a local', function () {
+        const md = renderLocalMarkdown({ name: 'acc' }, '  (let [acc 0]');
+        assert.ok(md.startsWith('**`acc`** _local binding_'));
+        assert.ok(md.includes('(let [acc 0]'));
+    });
+
+    it('omits the code block when there is no declaring line', function () {
+        assert.strictEqual(renderLocalMarkdown({ name: 'x' }), '**`x`** _local binding_');
+        assert.strictEqual(renderLocalMarkdown({ name: 'x' }, '   '), '**`x`** _local binding_');
     });
 });

--- a/src/test/phelSignatureHelp.test.ts
+++ b/src/test/phelSignatureHelp.test.ts
@@ -22,13 +22,14 @@ describe('findCurrentCall', function () {
     it('reports the callee on the first arg before any space', function () {
         const { source, offset } = at('(map |');
         const r = findCurrentCall(source, offset);
-        assert.deepStrictEqual(r, { callee: 'map', activeArg: 0 });
+        assert.deepStrictEqual(r, { callee: 'map', calleeStart: 1, activeArg: 0 });
     });
 
     it('keeps activeArg=0 while typing the first argument', function () {
         const { source, offset } = at('(map inc|');
         assert.deepStrictEqual(findCurrentCall(source, offset), {
             callee: 'map',
+            calleeStart: 1,
             activeArg: 0,
         });
     });
@@ -37,6 +38,7 @@ describe('findCurrentCall', function () {
         const { source, offset } = at('(map inc |');
         assert.deepStrictEqual(findCurrentCall(source, offset), {
             callee: 'map',
+            calleeStart: 1,
             activeArg: 1,
         });
     });
@@ -45,6 +47,7 @@ describe('findCurrentCall', function () {
         const { source, offset } = at('(reduce + 0 [1 2 3] |');
         assert.deepStrictEqual(findCurrentCall(source, offset), {
             callee: 'reduce',
+            calleeStart: 1,
             activeArg: 3,
         });
     });
@@ -53,6 +56,7 @@ describe('findCurrentCall', function () {
         const { source, offset } = at('(map (filter pred |xs) ys)');
         assert.deepStrictEqual(findCurrentCall(source, offset), {
             callee: 'filter',
+            calleeStart: 6,
             activeArg: 1,
         });
     });
@@ -61,6 +65,7 @@ describe('findCurrentCall', function () {
         const { source, offset } = at('(println "hello (world)" |');
         assert.deepStrictEqual(findCurrentCall(source, offset), {
             callee: 'println',
+            calleeStart: 1,
             activeArg: 1,
         });
     });
@@ -69,6 +74,7 @@ describe('findCurrentCall', function () {
         const { source, offset } = at('(reduce + ;; comment\n0 |[1 2])');
         assert.deepStrictEqual(findCurrentCall(source, offset), {
             callee: 'reduce',
+            calleeStart: 1,
             activeArg: 2,
         });
     });
@@ -89,6 +95,7 @@ describe('findCurrentCall', function () {
         const { source, offset } = at('(phel.test/is |x)');
         assert.deepStrictEqual(findCurrentCall(source, offset), {
             callee: 'phel.test/is',
+            calleeStart: 1,
             activeArg: 0,
         });
     });


### PR DESCRIPTION
Seventh in the series after #82–#87.

## Why

Go-to-definition, find-references, rename and document-highlight all consult `phelScope` before falling back to the symbol corpus. **Hover and signature help did not** — they were the only two providers left looking the name up globally.

So both described a global whenever a local shadowed one. That is not an edge case:

```
$ common param names that also exist in phel.core
name, map, key, count, str, first, type, next, get, list,
keys, vals, set, max, min, val, rest, last, apply, print   (20 of 20 checked)
```

Hovering the `name` in `(defn greet [name] (str "hi " name))` documented `phel.core/name` — wrong, and confidently so.

## What

**Hover** resolves the local first:

```
**`name`** _parameter_

```phel
(defn greet [name]
```
```

instead of the `phel.core/name` docs. It reports whether the binding is a parameter or a local, and shows the line it is bound on.

**Signature help** stands down for a local in callee position — `(f x)` where `f` is a let-bound function — rather than describing whatever global shares the name. `findCurrentCall` gained a `calleeStart` offset so the callee can be resolved against the analyzer; the existing `deepStrictEqual` assertions were updated to cover the new field.

The renderer lives in `phelDocsLookup`, beside `renderDocMarkdown`, so it stays unit-testable without booting the editor.

## Verification

- 3 new tests for `renderLocalMarkdown` (parameter vs local, declaring line present/absent/blank), plus the 8 updated `findCurrentCall` assertions.
- Checked end to end against the real analyzer: the `name` use in `(defn greet [name] …)` resolves to a `param: true` binding and renders as a parameter.
- `npm run pretest` + `npm test`: **462 passing**. `npm run check:changelog` green.
- `docs/refactoring.md` "Locals vs globals" now covers hover and signature help, with the collision list spelled out.