### PR TITLE
feat(diagnostics): back inline diagnostics with phel lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Diagnostics
+
+- **`phel lint` now backs inline diagnostics.** It reports everything `phel analyze` does plus rule-based findings — unused bindings, shadowed bindings, arity problems, and whatever `phel-lint.phel` configures. On a file with one undefined symbol and one unused binding, `analyze` reported 1 diagnostic where `lint` reports 2.
+- New `phel.diagnostics.engine` setting (`auto` | `lint` | `analyze`, default `auto`). `lint` is newer than `analyze`, so `auto` uses it and falls back the first time a CLI rejects the subcommand, remembering that for the session; changing the executable or the setting retries. Nothing breaks for anyone on an older Phel.
+- New **Phel: Lint Workspace** command runs `phel lint` over the configured source dirs and fills the Problems panel for every file, including ones never opened. On-save diagnostics stay scoped to the saved file.
+
 ### Fixed (hover & signature help)
 
 - **Hover on a local showed an unrelated core function.** Go-to-definition, find-references, rename and document-highlight all consult the scope analyzer; hover did not, and looked the name up in the symbol corpus instead. Every one of the 20 most common parameter names — `name`, `map`, `key`, `count`, `str`, `first`, `type`, `next`, `get`, `list`, `keys`, `vals`, `set`, `max`, `min`, `val`, `rest`, `last`, `apply`, `print` — is also a `phel.core` function, so hovering the `name` in `(defn greet [name] …)` documented `phel.core/name`. It now reports the parameter and the line it is bound on.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -9,7 +9,7 @@ The extension shells out to the Phel CLI for diagnostics, formatting, the test r
 | Setting | Type | Default | Description |
 |---|---|---|---|
 | `phel.executablePath` | string | `vendor/bin/phel` | Workspace-wide CLI path. Used by all subsystems unless overridden. Relative paths resolve against the workspace folder; absolute paths are used as-is. |
-| `phel.diagnostics.command` | string | `""` | Override `phel.executablePath` for `phel analyze`. Empty string → fall back to `phel.executablePath`. |
+| `phel.diagnostics.command` | string | `""` | Override `phel.executablePath` for `phel lint` / `phel analyze`. Empty string → fall back to `phel.executablePath`. |
 | `phel.format.command` | string | `""` | Override `phel.executablePath` for `phel format`. Empty string → fall back to `phel.executablePath`. |
 | `phel.test.command` | string | `""` | Override `phel.executablePath` for the test CodeLens / Test Explorer. Empty string → fall back to `phel.executablePath`. |
 | `phel.repl.command` | string | `""` | Override `phel.executablePath` for the REPL terminal. Empty string → fall back to `phel.executablePath`. |
@@ -53,7 +53,8 @@ The default CLI for everything is `bin/phel`, but the test runner uses a wrapper
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
-| `phel.diagnostics.enabled` | boolean | `true` | Run `phel analyze` on save and surface inline diagnostics. |
+| `phel.diagnostics.enabled` | boolean | `true` | Run the diagnostics engine on open/save and surface inline diagnostics. |
+| `phel.diagnostics.engine` | `auto` \| `lint` \| `analyze` | `auto` | Which CLI subcommand backs diagnostics. See [Diagnostics engine](#diagnostics-engine). |
 | `phel.format.enabled` | boolean | `true` | Use `phel format` as the document formatter. |
 | `phel.tests.codeLensEnabled` | boolean | `true` | Show inline `▶ Run test` CodeLens above each `deftest`. |
 | `phel.paredit.enabled` | boolean | `true` | Register paredit commands (slurp / barf / raise / wrap). |
@@ -97,3 +98,21 @@ Reader conditionals carry a `meta.reader-conditional.phel` scope so themes can d
 ```
 
 The full scope vocabulary used by the grammar lives in [docs/syntax.md](syntax.md).
+
+## Diagnostics engine
+
+`phel lint` reports everything `phel analyze` does **plus** rule-based findings — unused bindings, shadowed bindings, arity problems, and whatever `phel-lint.phel` configures. On a file with one undefined symbol and one unused binding, `analyze` reports 1 diagnostic and `lint` reports 2.
+
+`lint` arrived after `analyze`, so the default is `auto`: use `lint`, and if the CLI rejects the subcommand (an older Phel), fall back to `analyze` and remember that for the session. Changing the executable or this setting retries `lint`.
+
+| Value | Behaviour |
+|---|---|
+| `auto` (default) | `phel lint`, falling back to `phel analyze` on an older CLI |
+| `lint` | Always `phel lint --format=json` |
+| `analyze` | Always `phel analyze` — semantic errors for the single file only |
+
+A non-zero exit is expected from both: they exit 1 when they found errors and still print the diagnostics.
+
+### Phel: Lint Workspace
+
+`phel lint` also walks the configured source dirs, so the **Phel: Lint Workspace** command runs it over the whole project and populates the Problems panel for every file — including ones never opened in the editor. On-save diagnostics stay scoped to the file you saved.

--- a/package.json
+++ b/package.json
@@ -375,6 +375,10 @@
                 "command": "phel.selection.shrink",
                 "title": "Phel: Shrink Selection",
                 "category": "Phel"
+            },
+            {
+                "command": "phel.lintWorkspace",
+                "title": "Phel: Lint Workspace"
             }
         ],
         "keybindings": [
@@ -512,7 +516,22 @@
                 "phel.diagnostics.enabled": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Run `phel analyze` on save and surface the result as inline diagnostics."
+                    "description": "Run the diagnostics engine on open/save and surface the result as inline diagnostics."
+                },
+                "phel.diagnostics.engine": {
+                    "type": "string",
+                    "enum": [
+                        "auto",
+                        "lint",
+                        "analyze"
+                    ],
+                    "enumDescriptions": [
+                        "Use `phel lint` when the CLI provides it, otherwise fall back to `phel analyze`.",
+                        "Always use `phel lint --format=json`. Reports rule-based findings (unused bindings, arity, anything configured in `phel-lint.phel`) on top of what `analyze` reports.",
+                        "Always use `phel analyze`. Semantic errors for the single file only."
+                    ],
+                    "default": "auto",
+                    "description": "Which Phel CLI subcommand backs inline diagnostics."
                 },
                 "phel.diagnostics.command": {
                     "type": "string",

--- a/src/phelDiagnostics.ts
+++ b/src/phelDiagnostics.ts
@@ -68,6 +68,44 @@ export function parsePhelAnalyzeOutput(stdout: string): PhelDiagnostic[] {
     return out;
 }
 
+/**
+ * Group diagnostics by the file they belong to. `phel lint` accepts whole
+ * directories and reports on every file it walked, so a run has to be split
+ * before it can be handed to a `DiagnosticCollection` per URI.
+ *
+ * Entries without a `uri` fall under `fallbackUri`, which the caller sets to
+ * the file it asked about.
+ */
+export function groupDiagnosticsByUri(
+    diagnostics: readonly PhelDiagnostic[],
+    fallbackUri?: string
+): Map<string, PhelDiagnostic[]> {
+    const out = new Map<string, PhelDiagnostic[]>();
+    for (const diag of diagnostics) {
+        const uri = diag.uri || fallbackUri;
+        if (!uri) {
+            continue;
+        }
+        const bucket = out.get(uri);
+        if (bucket) {
+            bucket.push(diag);
+        } else {
+            out.set(uri, [diag]);
+        }
+    }
+    return out;
+}
+
+/**
+ * True when the CLI rejected the subcommand itself rather than the file —
+ * a Phel older than the one that introduced `phel lint`. Symfony Console
+ * writes `Command "lint" is not defined.` to stderr, exits non-zero, and
+ * produces no stdout.
+ */
+export function isUnknownCommandError(stderr: string): boolean {
+    return /Command ".*" is not defined/i.test(stderr);
+}
+
 function normaliseEntry(raw: unknown): PhelDiagnostic | null {
     if (!raw || typeof raw !== 'object') {
         return null;

--- a/src/phelDiagnosticsProvider.ts
+++ b/src/phelDiagnosticsProvider.ts
@@ -1,16 +1,33 @@
 import { execFile } from 'node:child_process';
 import * as vscode from 'vscode';
-import { parsePhelAnalyzeOutput, toZeroBasedRange, PhelDiagnostic } from './phelDiagnostics';
+import {
+    groupDiagnosticsByUri,
+    isUnknownCommandError,
+    parsePhelAnalyzeOutput,
+    toZeroBasedRange,
+    PhelDiagnostic,
+} from './phelDiagnostics';
 import { affectsPhelExecutable, resolvePhelExecutable } from './phelExecutable';
 
 const COLLECTION_NAME = 'phel';
 
+type Engine = 'auto' | 'lint' | 'analyze';
+
 /**
- * Runs `phel analyze <file>` on every `.phel` open / save and surfaces the
- * results as VS Code diagnostics.
+ * `phel lint` reports everything `phel analyze` does plus rule-based findings
+ * (unused bindings, arity, the rules configured in `phel-lint.phel`), so it is
+ * preferred where available. It arrived after `analyze`, so `auto` falls back
+ * the first time a CLI rejects the subcommand and remembers that per session.
+ */
+let lintUnavailable = false;
+
+/**
+ * Runs `phel lint` (or `phel analyze`) on every `.phel` open / save and
+ * surfaces the results as VS Code diagnostics.
  *
  * Configuration:
  *   - `phel.diagnostics.enabled` (default `true`)
+ *   - `phel.diagnostics.engine` (`auto` | `lint` | `analyze`, default `auto`)
  *   - `phel.diagnostics.command` (overrides `phel.executablePath`; default
  *     `vendor/bin/phel`, resolved relative to the workspace folder when
  *     not absolute)
@@ -49,16 +66,22 @@ export function registerDiagnostics(context: vscode.ExtensionContext): void {
         const folder = vscode.workspace.getWorkspaceFolder(document.uri);
         const command = resolvePhelExecutable('diagnostics.command', folder);
         const cwd = folder?.uri.fsPath;
-        analyzeFile(command, document.uri.fsPath, cwd)
+        checkFile(command, document.uri.fsPath, cwd)
             .then((diagnostics) => {
                 if (!isOpen(document.uri)) {
                     collection.delete(document.uri);
                     return;
                 }
-                collection.set(document.uri, toVscodeDiagnostics(diagnostics));
+                // `phel lint` may report on files the linted one requires, so
+                // only the entries for this document belong to it.
+                const byUri = groupDiagnosticsByUri(diagnostics, document.uri.fsPath);
+                collection.set(
+                    document.uri,
+                    toVscodeDiagnostics(byUri.get(document.uri.fsPath) ?? [])
+                );
             })
             .catch((err) => {
-                console.error(`phel analyze failed for ${document.uri.fsPath}:`, err);
+                console.error(`phel diagnostics failed for ${document.uri.fsPath}:`, err);
                 collection.delete(document.uri);
             })
             .finally(() => {
@@ -74,12 +97,56 @@ export function registerDiagnostics(context: vscode.ExtensionContext): void {
             });
     };
 
+    // `phel lint` walks the configured source dirs, so one run can populate
+    // diagnostics for files that were never opened.
+    const lintWorkspace = async () => {
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        if (!folder) {
+            void vscode.window.showWarningMessage('Phel: open a folder to lint a workspace.');
+            return;
+        }
+        const command = resolvePhelExecutable('diagnostics.command', folder);
+        await vscode.window.withProgress(
+            { location: vscode.ProgressLocation.Window, title: 'Phel: linting workspace…' },
+            async () => {
+                try {
+                    const diagnostics = await runPhel(
+                        command,
+                        ['lint', '--format=json'],
+                        folder.uri.fsPath
+                    );
+                    collection.clear();
+                    let files = 0;
+                    for (const [fsPath, forFile] of groupDiagnosticsByUri(diagnostics)) {
+                        collection.set(vscode.Uri.file(fsPath), toVscodeDiagnostics(forFile));
+                        files++;
+                    }
+                    void vscode.window.showInformationMessage(
+                        diagnostics.length === 0
+                            ? 'Phel lint: no issues found.'
+                            : `Phel lint: ${diagnostics.length} issue(s) in ${files} file(s).`
+                    );
+                } catch (err) {
+                    const detail = err instanceof Error ? err.message : String(err);
+                    void vscode.window.showErrorMessage(`Phel lint failed: ${detail}`);
+                }
+            }
+        );
+    };
+
     context.subscriptions.push(
+        vscode.commands.registerCommand('phel.lintWorkspace', lintWorkspace),
         vscode.workspace.onDidOpenTextDocument(runForDocument),
         vscode.workspace.onDidSaveTextDocument(runForDocument),
         vscode.workspace.onDidCloseTextDocument((doc) => collection.delete(doc.uri)),
         vscode.workspace.onDidChangeConfiguration((e) => {
-            if (e.affectsConfiguration('phel.diagnostics.enabled') || affectsPhelExecutable(e)) {
+            if (
+                e.affectsConfiguration('phel.diagnostics.enabled') ||
+                e.affectsConfiguration('phel.diagnostics.engine') ||
+                affectsPhelExecutable(e)
+            ) {
+                // A different executable may well have `lint`.
+                lintUnavailable = false;
                 collection.clear();
                 vscode.workspace.textDocuments.forEach(runForDocument);
             }
@@ -93,24 +160,60 @@ function isEnabled(): boolean {
     return vscode.workspace.getConfiguration('phel').get<boolean>('diagnostics.enabled', true);
 }
 
-function analyzeFile(
+function configuredEngine(): Engine {
+    return vscode.workspace.getConfiguration('phel').get<Engine>('diagnostics.engine', 'auto');
+}
+
+/** Run the configured engine over one path, falling back when `lint` is missing. */
+async function checkFile(
     command: string,
-    filePath: string,
+    targetPath: string,
+    cwd: string | undefined
+): Promise<PhelDiagnostic[]> {
+    const engine = configuredEngine();
+    if (engine === 'analyze') {
+        return runPhel(command, ['analyze', targetPath], cwd);
+    }
+    if (engine === 'lint') {
+        return runPhel(command, ['lint', '--format=json', targetPath], cwd);
+    }
+
+    if (lintUnavailable) {
+        return runPhel(command, ['analyze', targetPath], cwd);
+    }
+    try {
+        return await runPhel(command, ['lint', '--format=json', targetPath], cwd);
+    } catch (err) {
+        if (!(err instanceof UnknownCommandError)) {
+            throw err;
+        }
+        lintUnavailable = true;
+        return runPhel(command, ['analyze', targetPath], cwd);
+    }
+}
+
+/** Thrown when the CLI does not know the subcommand, so a fallback can retry. */
+class UnknownCommandError extends Error {}
+
+function runPhel(
+    command: string,
+    args: string[],
     cwd: string | undefined
 ): Promise<PhelDiagnostic[]> {
     return new Promise((resolve, reject) => {
-        execFile(
-            command,
-            ['analyze', filePath],
-            { maxBuffer: 8 * 1024 * 1024, cwd },
-            (err, stdout, stderr) => {
-                if (err && !stdout) {
-                    reject(new Error(stderr || err.message));
+        execFile(command, args, { maxBuffer: 8 * 1024 * 1024, cwd }, (err, stdout, stderr) => {
+            // A non-zero exit is normal: both subcommands exit 1 when they
+            // found errors, and still print the diagnostics on stdout.
+            if (err && !stdout) {
+                if (isUnknownCommandError(stderr)) {
+                    reject(new UnknownCommandError(stderr.trim()));
                     return;
                 }
-                resolve(parsePhelAnalyzeOutput(stdout));
+                reject(new Error(stderr || err.message));
+                return;
             }
-        );
+            resolve(parsePhelAnalyzeOutput(stdout));
+        });
     });
 }
 

--- a/src/test/phelDiagnostics.test.ts
+++ b/src/test/phelDiagnostics.test.ts
@@ -1,5 +1,11 @@
 import * as assert from 'assert';
-import { parsePhelAnalyzeOutput, toZeroBasedRange, PhelDiagnostic } from '../phelDiagnostics';
+import {
+    groupDiagnosticsByUri,
+    isUnknownCommandError,
+    parsePhelAnalyzeOutput,
+    toZeroBasedRange,
+    PhelDiagnostic,
+} from '../phelDiagnostics';
 
 describe('parsePhelAnalyzeOutput', function () {
     it('returns an empty array for an empty string', function () {
@@ -127,5 +133,55 @@ describe('toZeroBasedRange', function () {
     it('clamps negative phel positions to zero', function () {
         const r = toZeroBasedRange(diag({ startLine: 0, startCol: 0, endLine: 0, endCol: 0 }));
         assert.deepStrictEqual(r, { startLine: 0, startCol: 0, endLine: 0, endCol: 1 });
+    });
+});
+
+describe('groupDiagnosticsByUri', function () {
+    const diag = (uri: string | undefined, message: string): PhelDiagnostic => ({
+        message,
+        severity: 'error',
+        startLine: 1,
+        startCol: 0,
+        endLine: 1,
+        endCol: 1,
+        ...(uri ? { uri } : {}),
+    });
+
+    it('splits a multi-file lint run by file', function () {
+        const grouped = groupDiagnosticsByUri([
+            diag('/a.phel', 'one'),
+            diag('/b.phel', 'two'),
+            diag('/a.phel', 'three'),
+        ]);
+        assert.deepStrictEqual([...grouped.keys()], ['/a.phel', '/b.phel']);
+        assert.deepStrictEqual(
+            grouped.get('/a.phel')?.map((d) => d.message),
+            ['one', 'three']
+        );
+    });
+
+    it('attributes entries without a uri to the fallback', function () {
+        const grouped = groupDiagnosticsByUri([diag(undefined, 'no uri')], '/fallback.phel');
+        assert.deepStrictEqual([...grouped.keys()], ['/fallback.phel']);
+    });
+
+    it('drops entries with no uri and no fallback', function () {
+        assert.strictEqual(groupDiagnosticsByUri([diag(undefined, 'orphan')]).size, 0);
+    });
+
+    it('returns an empty map for an empty run', function () {
+        assert.strictEqual(groupDiagnosticsByUri([]).size, 0);
+    });
+});
+
+describe('isUnknownCommandError', function () {
+    it('recognises the Symfony Console message for a missing subcommand', function () {
+        // What a Phel older than `phel lint` prints on stderr.
+        assert.strictEqual(isUnknownCommandError('  Command "lint" is not defined.  '), true);
+    });
+
+    it('does not treat a normal failure as a missing subcommand', function () {
+        assert.strictEqual(isUnknownCommandError('Cannot parse file: /tmp/x.phel'), false);
+        assert.strictEqual(isUnknownCommandError(''), false);
     });
 });


### PR DESCRIPTION
Eighth in the series after #82–#88.

## Why

The extension shells out to `phel analyze` for inline diagnostics. Phel v0.49 also ships `phel lint`, which the extension never used — and it reports strictly more, in the **same JSON schema** `parsePhelAnalyzeOutput` already handles:

```
$ phel analyze core.phel          → 1 diagnostic  (PHEL001 unresolved symbol)
$ phel lint --format=json core.phel → 2 diagnostics (+ phel/unused-binding warning)
```

Beyond unused bindings it covers shadowed bindings, arity problems, and whatever `phel-lint.phel` configures — and it accepts directories, so one run can cover a whole project.

## What

**`phel.diagnostics.engine`** — `auto` (default) | `lint` | `analyze`.

`lint` is newer than `analyze`, so `auto` prefers it and falls back the first time a CLI rejects the subcommand, remembering that for the session. Nothing breaks for anyone on an older Phel. Changing the executable or the setting clears the flag and retries, since a different binary may well have `lint`.

The fallback matches Symfony Console's `Command "lint" is not defined.` specifically — verified against the real CLI (exit 1, empty stdout, message on stderr) — so a genuine failure still surfaces as a failure rather than being silently retried.

**Phel: Lint Workspace** — runs `phel lint` over the configured source dirs and fills the Problems panel for every file, including ones never opened. Verified end to end against the phel-lang repo itself, which returns grouped multi-file JSON.

Per-file runs group output by URI and keep only the saved file's entries, because a lint run can also report on files the saved one requires.

## Failure handling

A config or startup failure leaves stdout empty and exits non-zero. That rejects rather than parsing to an empty array, so the workspace command reports the error instead of a false "no issues found" — checked against a deliberately broken `phel-config.php`.

A *non-zero exit on its own* is not an error: both subcommands exit 1 when they found problems and still print the diagnostics on stdout. That path is preserved.

## Verification

- 6 new tests for the two new pure helpers (`groupDiagnosticsByUri`, `isUnknownCommandError`), including the no-uri and no-fallback cases.
- `npm run pretest` + `npm test`: **468 passing**. `npm run check:changelog` green, `package.json` re-validated after the contribution edits.
- `docs/settings.md` gains a "Diagnostics engine" section with the comparison, the fallback rule, and the workspace command.