### PR TITLE
ref: hoist the duplicated provider helpers into shared modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Internal
+
+- **De-duplicated the provider boilerplate**, net −28 lines. The Phel symbol-token regex existed as seven byte-identical copies (so the gensym change earlier in this release would have needed seven edits to stay consistent); it now lives in `phelSymbolToken.ts` with tests pinning what it matches, including the two long-standing apostrophe edges — a leading `'` is part of the token, a trailing one is not. The `combineDocs(indexer, PHEL_DOCS)` merge and the `MarkdownString` + `isTrusted`/`supportHtml` construction each had five copies and are now `mergedDocs()` and `plainMarkdown()` in `phelProviderSupport.ts`. Behaviour is unchanged.
+
 ### Diagnostics
 
 - **`phel lint` now backs inline diagnostics.** It reports everything `phel analyze` does plus rule-based findings — unused bindings, shadowed bindings, arity problems, and whatever `phel-lint.phel` configures. On a file with one undefined symbol and one unused binding, `analyze` reported 1 diagnostic where `lint` reports 2.

--- a/src/phelCodeActionsProvider.ts
+++ b/src/phelCodeActionsProvider.ts
@@ -10,11 +10,9 @@ import * as vscode from 'vscode';
 import { threadForm, unthreadForm, cycleCollection, type RefactorEdit } from './phelRefactor';
 import { lookupSymbol } from './phelDocsLookup';
 import { parseNsForm, buildRequireEdit } from './phelNsAnalyzer';
-import { combineDocs } from './phelWorkspaceIndex';
-import { PHEL_DOCS } from './phelCoreDocs';
 import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
-
-const SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;
+import { PHEL_SYMBOL_RE } from './phelSymbolToken';
+import { mergedDocs } from './phelProviderSupport';
 
 export class PhelCodeActionProvider implements vscode.CodeActionProvider {
     static readonly kinds = [vscode.CodeActionKind.RefactorRewrite, vscode.CodeActionKind.QuickFix];
@@ -61,7 +59,7 @@ export class PhelCodeActionProvider implements vscode.CodeActionProvider {
         range: vscode.Range,
         src: string
     ): vscode.CodeAction | null {
-        const wordRange = document.getWordRangeAtPosition(range.start, SYMBOL_RE);
+        const wordRange = document.getWordRangeAtPosition(range.start, PHEL_SYMBOL_RE);
         if (!wordRange) {
             return null;
         }
@@ -75,7 +73,7 @@ export class PhelCodeActionProvider implements vscode.CodeActionProvider {
         if (!nsForm) {
             return null;
         }
-        const merged = combineDocs(this.indexer.index.allDocs(), PHEL_DOCS);
+        const merged = mergedDocs(this.indexer);
         const doc = lookupSymbol(word, merged);
         if (!doc || !doc.ns) {
             return null;

--- a/src/phelCompletionProvider.ts
+++ b/src/phelCompletionProvider.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import { PHEL_DOCS } from './phelCoreDocs';
 import { CORE_FNS, MACROS, SPECIAL_FORMS } from './phelCoreSymbols';
 import { buildCallSnippet, isCalleePosition } from './phelCallSnippet';
 import { lookupSymbol, renderDocMarkdown } from './phelDocsLookup';
@@ -11,11 +10,10 @@ import {
     NS_CLAUSES,
     NS_ENTRY_OPTIONS,
 } from './phelCompletionContext';
-import { combineDocs } from './phelWorkspaceIndex';
 import { localsInScopeAt } from './phelScope';
 import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
-
-const SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;
+import { PHEL_SYMBOL_RE } from './phelSymbolToken';
+import { mergedDocs, plainMarkdown } from './phelProviderSupport';
 
 interface ItemSpec {
     label: string;
@@ -118,9 +116,7 @@ function buildItem(
     item.detail = spec.detail;
     const doc = lookupSymbol(spec.label, docs);
     if (doc) {
-        const md = new vscode.MarkdownString(renderDocMarkdown(doc));
-        md.isTrusted = false;
-        md.supportHtml = false;
+        const md = plainMarkdown(renderDocMarkdown(doc));
         item.documentation = md;
         if (callee) {
             const snippet = buildCallSnippet(spec.label, doc.signature);
@@ -165,11 +161,9 @@ export class PhelCompletionProvider implements vscode.CompletionItemProvider {
         document: vscode.TextDocument,
         position: vscode.Position
     ): vscode.ProviderResult<vscode.CompletionItem[]> {
-        const range = document.getWordRangeAtPosition(position, SYMBOL_RE);
+        const range = document.getWordRangeAtPosition(position, PHEL_SYMBOL_RE);
         const src = document.getText();
-        const merged = this.indexer
-            ? combineDocs(this.indexer.index.allDocs(), PHEL_DOCS)
-            : [...PHEL_DOCS];
+        const merged = mergedDocs(this.indexer);
         const linePrefix = document.lineAt(position.line).text.slice(0, position.character);
         const context = completionContextAt(src, document.offsetAt(position), linePrefix);
 
@@ -186,9 +180,7 @@ export class PhelCompletionProvider implements vscode.CompletionItemProvider {
                 item.detail = cand.detail;
                 const doc = merged.find((d) => d.qualifiedName === `${context.ns}/${cand.name}`);
                 if (doc) {
-                    const md = new vscode.MarkdownString(renderDocMarkdown(doc));
-                    md.isTrusted = false;
-                    md.supportHtml = false;
+                    const md = plainMarkdown(renderDocMarkdown(doc));
                     item.documentation = md;
                 }
                 if (range) {

--- a/src/phelDefinitionProvider.ts
+++ b/src/phelDefinitionProvider.ts
@@ -2,11 +2,9 @@ import * as vscode from 'vscode';
 import { lookupSymbol } from './phelDocsLookup';
 import { aliasMapFromSource } from './phelNsAnalyzer';
 import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
-import { combineDocs } from './phelWorkspaceIndex';
-import { PHEL_DOCS } from './phelCoreDocs';
 import { resolveLocalAt } from './phelScope';
-
-const SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;
+import { PHEL_SYMBOL_RE } from './phelSymbolToken';
+import { mergedDocs } from './phelProviderSupport';
 
 export class PhelDefinitionProvider implements vscode.DefinitionProvider {
     constructor(private readonly indexer: PhelWorkspaceIndexer) {}
@@ -15,7 +13,7 @@ export class PhelDefinitionProvider implements vscode.DefinitionProvider {
         document: vscode.TextDocument,
         position: vscode.Position
     ): vscode.ProviderResult<vscode.Definition | vscode.LocationLink[]> {
-        const range = document.getWordRangeAtPosition(position, SYMBOL_RE);
+        const range = document.getWordRangeAtPosition(position, PHEL_SYMBOL_RE);
         if (!range) {
             return null;
         }
@@ -35,7 +33,7 @@ export class PhelDefinitionProvider implements vscode.DefinitionProvider {
             );
         }
 
-        const merged = combineDocs(this.indexer.index.allDocs(), PHEL_DOCS);
+        const merged = mergedDocs(this.indexer);
         const aliases = aliasMapFromSource(document.getText());
         const doc = lookupSymbol(word, merged, aliases);
         if (!doc) {

--- a/src/phelDocumentHighlight.ts
+++ b/src/phelDocumentHighlight.ts
@@ -5,15 +5,14 @@
 import * as vscode from 'vscode';
 import { findOccurrences } from './phelReferences';
 import { resolveLocalAt, localOccurrences } from './phelScope';
-
-const SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;
+import { PHEL_SYMBOL_RE } from './phelSymbolToken';
 
 export class PhelDocumentHighlightProvider implements vscode.DocumentHighlightProvider {
     provideDocumentHighlights(
         document: vscode.TextDocument,
         position: vscode.Position
     ): vscode.ProviderResult<vscode.DocumentHighlight[]> {
-        const range = document.getWordRangeAtPosition(position, SYMBOL_RE);
+        const range = document.getWordRangeAtPosition(position, PHEL_SYMBOL_RE);
         if (!range) {
             return null;
         }

--- a/src/phelHoverProvider.ts
+++ b/src/phelHoverProvider.ts
@@ -1,12 +1,10 @@
 import * as vscode from 'vscode';
-import { PHEL_DOCS } from './phelCoreDocs';
 import { lookupSymbol, renderDocMarkdown, renderLocalMarkdown } from './phelDocsLookup';
 import { aliasMapFromSource } from './phelNsAnalyzer';
 import { resolveLocalAt } from './phelScope';
-import { combineDocs } from './phelWorkspaceIndex';
 import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
-
-const SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;
+import { PHEL_SYMBOL_RE } from './phelSymbolToken';
+import { mergedDocs, plainMarkdown } from './phelProviderSupport';
 
 export class PhelHoverProvider implements vscode.HoverProvider {
     constructor(private readonly indexer?: PhelWorkspaceIndexer) {}
@@ -15,7 +13,7 @@ export class PhelHoverProvider implements vscode.HoverProvider {
         document: vscode.TextDocument,
         position: vscode.Position
     ): vscode.ProviderResult<vscode.Hover> {
-        const range = document.getWordRangeAtPosition(position, SYMBOL_RE);
+        const range = document.getWordRangeAtPosition(position, PHEL_SYMBOL_RE);
         if (!range) {
             return null;
         }
@@ -28,23 +26,17 @@ export class PhelHoverProvider implements vscode.HoverProvider {
         const local = resolveLocalAt(src, document.offsetAt(range.start));
         if (local) {
             const declLine = document.lineAt(document.positionAt(local.declStart).line).text;
-            const md = new vscode.MarkdownString(renderLocalMarkdown(local, declLine));
-            md.isTrusted = false;
-            md.supportHtml = false;
+            const md = plainMarkdown(renderLocalMarkdown(local, declLine));
             return new vscode.Hover(md, range);
         }
 
-        const merged = this.indexer
-            ? combineDocs(this.indexer.index.allDocs(), PHEL_DOCS)
-            : [...PHEL_DOCS];
+        const merged = mergedDocs(this.indexer);
         const aliases = aliasMapFromSource(src);
         const doc = lookupSymbol(word, merged, aliases);
         if (!doc) {
             return null;
         }
-        const md = new vscode.MarkdownString(renderDocMarkdown(doc));
-        md.isTrusted = false;
-        md.supportHtml = false;
+        const md = plainMarkdown(renderDocMarkdown(doc));
         return new vscode.Hover(md, range);
     }
 }

--- a/src/phelProviderSupport.ts
+++ b/src/phelProviderSupport.ts
@@ -1,0 +1,27 @@
+// Small shared pieces every language provider needs — kept here so a change
+// lands once rather than in five copies.
+
+import * as vscode from 'vscode';
+import { PHEL_DOCS } from './phelCoreDocs';
+import type { PhelDoc } from './phelDocs';
+import { combineDocs } from './phelWorkspaceIndex';
+import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
+
+/**
+ * Workspace symbols layered over the bundled core corpus, or just the corpus
+ * when no indexer is running.
+ */
+export function mergedDocs(indexer?: PhelWorkspaceIndexer): PhelDoc[] {
+    return indexer ? combineDocs(indexer.index.allDocs(), PHEL_DOCS) : [...PHEL_DOCS];
+}
+
+/**
+ * Markdown for a hover / completion popup, with command links and raw HTML
+ * disabled — docstrings come from user source and are not trusted input.
+ */
+export function plainMarkdown(text: string): vscode.MarkdownString {
+    const md = new vscode.MarkdownString(text);
+    md.isTrusted = false;
+    md.supportHtml = false;
+    return md;
+}

--- a/src/phelReferenceProvider.ts
+++ b/src/phelReferenceProvider.ts
@@ -7,8 +7,7 @@ import * as vscode from 'vscode';
 import { findOccurrences } from './phelReferences';
 import { resolveLocalAt, localOccurrences } from './phelScope';
 import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
-
-const SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;
+import { PHEL_SYMBOL_RE } from './phelSymbolToken';
 
 export class PhelReferenceProvider implements vscode.ReferenceProvider {
     constructor(private readonly indexer: PhelWorkspaceIndexer) {}
@@ -17,7 +16,7 @@ export class PhelReferenceProvider implements vscode.ReferenceProvider {
         document: vscode.TextDocument,
         position: vscode.Position
     ): Promise<vscode.Location[]> {
-        const range = document.getWordRangeAtPosition(position, SYMBOL_RE);
+        const range = document.getWordRangeAtPosition(position, PHEL_SYMBOL_RE);
         if (!range) {
             return [];
         }

--- a/src/phelRenameProvider.ts
+++ b/src/phelRenameProvider.ts
@@ -10,8 +10,7 @@ import { findReferenceLocations } from './phelReferenceProvider';
 import { isValidSymbolName } from './phelReferences';
 import { resolveLocalAt, localOccurrences } from './phelScope';
 import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
-
-const SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;
+import { PHEL_SYMBOL_RE } from './phelSymbolToken';
 
 export class PhelRenameProvider implements vscode.RenameProvider {
     constructor(private readonly indexer: PhelWorkspaceIndexer) {}
@@ -20,7 +19,7 @@ export class PhelRenameProvider implements vscode.RenameProvider {
         document: vscode.TextDocument,
         position: vscode.Position
     ): vscode.ProviderResult<vscode.Range | { range: vscode.Range; placeholder: string }> {
-        const range = document.getWordRangeAtPosition(position, SYMBOL_RE);
+        const range = document.getWordRangeAtPosition(position, PHEL_SYMBOL_RE);
         if (!range) {
             throw new Error('No symbol at cursor.');
         }
@@ -35,7 +34,7 @@ export class PhelRenameProvider implements vscode.RenameProvider {
         if (!isValidSymbolName(newName)) {
             throw new Error(`'${newName}' is not a valid Phel symbol name.`);
         }
-        const range = document.getWordRangeAtPosition(position, SYMBOL_RE);
+        const range = document.getWordRangeAtPosition(position, PHEL_SYMBOL_RE);
         if (!range) {
             return undefined;
         }

--- a/src/phelSignatureHelpProvider.ts
+++ b/src/phelSignatureHelpProvider.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import { PHEL_DOCS } from './phelCoreDocs';
 import { lookupSymbol } from './phelDocsLookup';
 import { aliasMapFromSource } from './phelNsAnalyzer';
 import {
@@ -10,8 +9,8 @@ import {
     pickActiveSignature,
 } from './phelSignatureHelp';
 import { resolveLocalAt } from './phelScope';
-import { combineDocs } from './phelWorkspaceIndex';
 import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
+import { mergedDocs, plainMarkdown } from './phelProviderSupport';
 
 export class PhelSignatureHelpProvider implements vscode.SignatureHelpProvider {
     constructor(private readonly indexer?: PhelWorkspaceIndexer) {}
@@ -34,9 +33,7 @@ export class PhelSignatureHelpProvider implements vscode.SignatureHelpProvider {
             return null;
         }
 
-        const merged = this.indexer
-            ? combineDocs(this.indexer.index.allDocs(), PHEL_DOCS)
-            : [...PHEL_DOCS];
+        const merged = mergedDocs(this.indexer);
         const aliases = aliasMapFromSource(src);
         const doc = lookupSymbol(call.callee, merged, aliases);
         if (!doc) {
@@ -64,9 +61,7 @@ function buildSignature(signature: string, docstring?: string): vscode.Signature
         (label) => new vscode.ParameterInformation(label)
     );
     if (docstring) {
-        const md = new vscode.MarkdownString(docstring);
-        md.isTrusted = false;
-        md.supportHtml = false;
+        const md = plainMarkdown(docstring);
         info.documentation = md;
     }
     return info;

--- a/src/phelSymbolToken.ts
+++ b/src/phelSymbolToken.ts
@@ -1,0 +1,24 @@
+// The shape of a Phel symbol token, as the providers see it.
+//
+// `vscode.TextDocument.getWordRangeAtPosition` needs a regex describing what
+// counts as one "word". Phel symbols are far wider than the editor default:
+// they may start with punctuation (`->>`, `*ns*`, `+`), carry `?` / `!`
+// suffixes (`blank?`, `swap!`), be namespace-qualified (`str/join`, `php/->`),
+// and end in `#` (gensyms such as `x#`).
+//
+// Two known edges, both long-standing and pinned by tests so a change is a
+// deliberate one:
+//   * a leading `'` is part of the token, so the word at `'sym` is `'sym`;
+//   * a trailing `'` is not, so `a'` yields `a`, even though the lexer accepts
+//     the apostrophe as an atom character.
+//
+// Kept `vscode`-free and in one place: seven providers used to carry a
+// byte-identical copy, so any change to what counts as a symbol had to be made
+// seven times to stay consistent.
+
+/**
+ * One Phel symbol token. The first character class excludes the delimiters a
+ * symbol can never start with; the tail additionally excludes whitespace and
+ * the bracket / quote characters that end a token.
+ */
+export const PHEL_SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;

--- a/src/test/phelSymbolToken.test.ts
+++ b/src/test/phelSymbolToken.test.ts
@@ -1,0 +1,72 @@
+// Pins the token shape seven providers share for `getWordRangeAtPosition`.
+// It used to exist as seven byte-identical copies with no test at all.
+
+import * as assert from 'node:assert/strict';
+import { PHEL_SYMBOL_RE } from '../phelSymbolToken';
+
+/** What the editor would treat as the word at `offset`. */
+function wordAt(text: string, offset: number): string | null {
+    const re = new RegExp(PHEL_SYMBOL_RE.source, 'g');
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(text)) !== null) {
+        const start = match.index;
+        const end = start + match[0].length;
+        if (offset >= start && offset < end) {
+            return match[0];
+        }
+        if (start > offset) {
+            return null;
+        }
+    }
+    return null;
+}
+
+describe('PHEL_SYMBOL_RE', () => {
+    const whole = (token: string) => {
+        const m = PHEL_SYMBOL_RE.exec(token);
+        return m && m[0] === token;
+    };
+
+    it('matches plain and punctuation-suffixed names', () => {
+        for (const token of ['map', 'blank?', 'swap!', 'my-fn', 'a1', 'x#']) {
+            assert.ok(whole(token), token);
+        }
+    });
+
+    it('matches names that start with punctuation', () => {
+        for (const token of ['->', '->>', 'some->>', '+', '-', '*ns*', '=', '<=', '%']) {
+            assert.ok(whole(token), token);
+        }
+    });
+
+    it('matches qualified symbols and keywords', () => {
+        for (const token of ['str/join', 'php/->', 'phel.test/is', ':keyword', ':my.ns/name']) {
+            assert.ok(whole(token), token);
+        }
+    });
+
+    it('stops at the delimiters that end a token', () => {
+        assert.equal(wordAt('(map inc xs)', 1), 'map');
+        assert.equal(wordAt('[a b]', 1), 'a');
+        assert.equal(wordAt('{:a 1}', 1), ':a');
+        assert.equal(wordAt('(f "s")', 1), 'f');
+        assert.equal(wordAt('`(x)', 2), 'x');
+    });
+
+    it('stops at a comma, which Phel reads as unquote rather than whitespace', () => {
+        assert.equal(wordAt('a,b', 0), 'a');
+    });
+
+    it('documents the two apostrophe edges', () => {
+        // Long-standing behaviour of the shared pattern, pinned so that
+        // changing it has to be deliberate rather than incidental.
+        assert.equal(wordAt("'sym", 1), "'sym", 'a leading quote is part of the token');
+        assert.equal(wordAt("(a' 1)", 1), 'a', 'a trailing quote is not');
+    });
+
+    it('keeps a gensym suffix in the token', () => {
+        // Regression guard: the grammar treats a trailing `#` as part of the
+        // symbol, and word selection has to agree.
+        assert.equal(wordAt('(let [x# 1] x#)', 6), 'x#');
+    });
+});


### PR DESCRIPTION
Ninth in the series after #82–#89, and the code-quality pass I flagged while shipping #82.

## Why

Three pieces of boilerplate had drifted into copy-paste across the language providers:

| Duplicated | Copies |
| --- | --- |
| The Phel symbol-token regex | **7**, byte-identical |
| `combineDocs(indexer.index.allDocs(), PHEL_DOCS)` | 5 |
| `new MarkdownString(…)` + `isTrusted` / `supportHtml` opt-out | 5 |

The first one is not hypothetical: #82 widened what counts as a Phel symbol (a trailing `#` is now part of a gensym), which would have needed seven consistent edits. The third is a small security-shaped hazard — miss one of the two opt-out lines and command links become live in text taken from user docstrings.

## What

- `src/phelSymbolToken.ts` — the regex, kept `vscode`-free so it is testable. It had **no tests at all** despite seven consumers.
- `src/phelProviderSupport.ts` — `mergedDocs()` and `plainMarkdown()`.
- Unused imports removed from the five providers that no longer need `PHEL_DOCS` / `combineDocs`.

Net **−28 lines** across 8 provider files.

## Two edges the new tests found

Writing the tests contradicted my own summary comment, so both are now pinned as-is rather than quietly changed:

- a **leading** `'` is part of the token — the word at `'sym` is `'sym`;
- a **trailing** `'` is not — `a'` yields `a`, even though the lexer accepts the apostrophe as an atom character.

The second is arguably a real limitation, but altering the shared pattern would change behaviour in all seven providers. That belongs in its own change, not in a refactor labelled as behaviour-preserving.

I also dropped a `symbolTokenAt()` helper I had written for this module once it turned out nothing consumed it — shipping unused API in a cleanup PR would defeat the point.

## Verification

- 7 new tests for the shared regex (plain names, punctuation-leading names, qualified symbols and keywords, delimiters, comma-as-unquote, the apostrophe edges, the gensym suffix).
- `npm run pretest` + `npm test`: **475 passing**. `npm run bundle` (esbuild) green. `npm run check:changelog` green.
- No behaviour change intended or observed.