### PR TITLE
fix(references): treat a trailing apostrophe as part of the symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed (prime-suffixed symbols)
+
+- **Renaming `a` corrupted `a'`.** The apostrophe was treated as a symbol terminator on both sides, so the leading `a` of `a'` looked like a complete token: find-references reported it, and rename rewrote it, leaving a stray `'`. `a'` and `foo''` are single symbols to the Phel lexer — verified by running one — and are now matched as such. Renaming *to* `a'` is allowed; a leading `'` is still rejected, because there it is the quote reader macro.
+- Word selection splits the quote macro off what it quotes: the word at `'sym` and `#'sym` is now `sym`, so hover and go-to-definition resolve a quoted symbol instead of looking up `'sym` and finding nothing.
+
 ### Internal
 
-- **De-duplicated the provider boilerplate**, net −28 lines. The Phel symbol-token regex existed as seven byte-identical copies (so the gensym change earlier in this release would have needed seven edits to stay consistent); it now lives in `phelSymbolToken.ts` with tests pinning what it matches, including the two long-standing apostrophe edges — a leading `'` is part of the token, a trailing one is not. The `combineDocs(indexer, PHEL_DOCS)` merge and the `MarkdownString` + `isTrusted`/`supportHtml` construction each had five copies and are now `mergedDocs()` and `plainMarkdown()` in `phelProviderSupport.ts`. Behaviour is unchanged.
+- **De-duplicated the provider boilerplate**, net −28 lines. The Phel symbol-token regex existed as seven byte-identical copies (so the gensym change earlier in this release would have needed seven edits to stay consistent); it now lives in `phelSymbolToken.ts` with tests pinning what it matches. The `combineDocs(indexer, PHEL_DOCS)` merge and the `MarkdownString` + `isTrusted`/`supportHtml` construction each had five copies and are now `mergedDocs()` and `plainMarkdown()` in `phelProviderSupport.ts`. Behaviour is unchanged.
 
 ### Diagnostics
 

--- a/src/phelReferences.ts
+++ b/src/phelReferences.ts
@@ -67,7 +67,7 @@ export function findOccurrences(src: string, name: string): Occurrence[] {
             const end = i + name.length;
             const before = i === 0 ? '' : src[i - 1];
             const after = end >= len ? '' : src[end];
-            if (isBoundary(before) && isBoundary(after)) {
+            if (isBoundaryBefore(before) && isBoundaryAfter(after)) {
                 out.push({ start: i, end });
                 i = end;
                 continue;
@@ -122,9 +122,28 @@ function matchesAt(src: string, i: number, name: string): boolean {
     return true;
 }
 
-function isBoundary(c: string): boolean {
+/**
+ * `'` is the one terminator that only works on the *left*. The lexer treats a
+ * leading apostrophe as the quote reader macro but keeps a mid or trailing one
+ * inside the atom, so `a'` and `foo''` are single symbols while `'sym` is a
+ * quote followed by `sym`.
+ *
+ * Using the symmetric test for both sides made the `a` in `a'` look like a
+ * whole token, so renaming `a` rewrote part of `a'`.
+ */
+function isBoundaryBefore(c: string): boolean {
     if (c === '') {
         return true;
+    }
+    return SYMBOL_TERMINATOR.has(c);
+}
+
+function isBoundaryAfter(c: string): boolean {
+    if (c === '') {
+        return true;
+    }
+    if (c === "'") {
+        return false; // part of the symbol being scanned
     }
     return SYMBOL_TERMINATOR.has(c);
 }
@@ -132,12 +151,21 @@ function isBoundary(c: string): boolean {
 /**
  * Validate that `name` is a legal Phel symbol token (no whitespace, no
  * delimiter chars). Used by the rename provider before applying edits.
+ *
+ * A trailing `'` is legal — `a'` is a single symbol — but a leading one is the
+ * quote reader macro, so it is rejected.
  */
 export function isValidSymbolName(name: string): boolean {
     if (!name) {
         return false;
     }
+    if (name.startsWith("'")) {
+        return false;
+    }
     for (const c of name) {
+        if (c === "'") {
+            continue;
+        }
         if (SYMBOL_TERMINATOR.has(c)) {
             return false;
         }

--- a/src/phelSymbolToken.ts
+++ b/src/phelSymbolToken.ts
@@ -6,11 +6,11 @@
 // suffixes (`blank?`, `swap!`), be namespace-qualified (`str/join`, `php/->`),
 // and end in `#` (gensyms such as `x#`).
 //
-// Two known edges, both long-standing and pinned by tests so a change is a
-// deliberate one:
-//   * a leading `'` is part of the token, so the word at `'sym` is `'sym`;
-//   * a trailing `'` is not, so `a'` yields `a`, even though the lexer accepts
-//     the apostrophe as an atom character.
+// The apostrophe is the awkward one, and the lexer settles it: leading, it is
+// the quote reader macro, so `'sym` is a quote followed by the symbol `sym`;
+// mid or trailing, it stays inside the atom, so `a'` and `foo''` are single
+// symbols. The pattern excludes `'` from the first character and allows it in
+// the tail.
 //
 // Kept `vscode`-free and in one place: seven providers used to carry a
 // byte-identical copy, so any change to what counts as a symbol had to be made
@@ -21,4 +21,4 @@
  * symbol can never start with; the tail additionally excludes whitespace and
  * the bracket / quote characters that end a token.
  */
-export const PHEL_SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.':$&%][^\s(){}[\]"',`]*/;
+export const PHEL_SYMBOL_RE = /[A-Za-z0-9_!?*+<>=/\-.:$&%][^\s(){}[\]"`,]*/;

--- a/src/test/phelReferences.test.ts
+++ b/src/test/phelReferences.test.ts
@@ -68,3 +68,32 @@ describe('phelReferences.isValidSymbolName', () => {
         assert.equal(isValidSymbolName('"foo"'), false);
     });
 });
+
+describe('phelReferences apostrophe handling', () => {
+    it('does not match a bare name inside a prime-suffixed symbol', () => {
+        // Regression: `'` used to terminate a symbol on both sides, so the
+        // leading `a` of `a'` looked like a whole token and renaming `a`
+        // rewrote part of `a'`.
+        const src = "(def a' 41)\n(def a 1)\n(+ a' a)";
+        assert.deepEqual(offsets(findOccurrences(src, 'a')), [
+            src.indexOf('(def a 1)') + 5,
+            src.lastIndexOf('a'),
+        ]);
+    });
+
+    it('finds every occurrence of a prime-suffixed symbol', () => {
+        const src = "(def a' 41)\n(def a 1)\n(+ a' a)";
+        assert.deepEqual(offsets(findOccurrences(src, "a'")), [5, src.indexOf("a'", 12)]);
+    });
+
+    it('still finds a symbol that a quote reader macro precedes', () => {
+        const src = "(def sym 1)\n'sym";
+        assert.deepEqual(offsets(findOccurrences(src, 'sym')), [5, src.lastIndexOf('sym')]);
+    });
+
+    it('accepts a trailing apostrophe as a rename target but not a leading one', () => {
+        assert.equal(isValidSymbolName("a'"), true);
+        assert.equal(isValidSymbolName("foo''"), true);
+        assert.equal(isValidSymbolName("'sym"), false);
+    });
+});

--- a/src/test/phelSymbolToken.test.ts
+++ b/src/test/phelSymbolToken.test.ts
@@ -28,7 +28,7 @@ describe('PHEL_SYMBOL_RE', () => {
     };
 
     it('matches plain and punctuation-suffixed names', () => {
-        for (const token of ['map', 'blank?', 'swap!', 'my-fn', 'a1', 'x#']) {
+        for (const token of ['map', 'blank?', 'swap!', 'my-fn', 'a1', 'x#', "a'", "foo''"]) {
             assert.ok(whole(token), token);
         }
     });
@@ -57,11 +57,16 @@ describe('PHEL_SYMBOL_RE', () => {
         assert.equal(wordAt('a,b', 0), 'a');
     });
 
-    it('documents the two apostrophe edges', () => {
-        // Long-standing behaviour of the shared pattern, pinned so that
-        // changing it has to be deliberate rather than incidental.
-        assert.equal(wordAt("'sym", 1), "'sym", 'a leading quote is part of the token');
-        assert.equal(wordAt("(a' 1)", 1), 'a', 'a trailing quote is not');
+    it('splits the quote reader macro off the symbol it quotes', () => {
+        // `'sym` is a quote followed by `sym`, so the word is `sym`.
+        assert.equal(wordAt("'sym", 1), 'sym');
+        assert.equal(wordAt("#'sym", 2), 'sym');
+    });
+
+    it('keeps a mid or trailing apostrophe inside the symbol', () => {
+        // `a'` and `foo''` are single atoms to the lexer.
+        assert.equal(wordAt("(a' 1)", 1), "a'");
+        assert.equal(wordAt("(foo'' 1)", 1), "foo''");
     });
 
     it('keeps a gensym suffix in the token', () => {


### PR DESCRIPTION
Tenth in the series after #82–#90, and a direct follow-up to #90.

## Why

In #90 I hoisted the symbol-token regex into a shared module and wrote its first tests. Those tests contradicted my own summary comment and surfaced two apostrophe edges, which I pinned as-is rather than change inside a refactor. This is that change, made deliberately.

`a'` and `foo''` are **legal Phel symbols** — confirmed by running one rather than assuming:

```phel
(ns t)
(def a' 41)
(def foo'' 1)
(php/var_dump (+ a' foo''))   ;; => int(42)
```

Both the shared token pattern and `findOccurrences` treated `'` as a terminator on **either** side, so the leading `a` of `a'` looked like a complete token:

```
src: (def a' 41)\n(def a 1)\n(+ a' a)

before → occurrences of "a": [5, 17, 25, 28]   ← 5 and 25 are inside a'
after  → occurrences of "a": [17, 28]
```

That is data loss, not cosmetics: find-references reported those positions and **rename rewrote them**, turning `a'` into `<newname>'`.

## What

The lexer settles the ambiguity — leading `'` is the quote reader macro, mid or trailing `'` stays inside the atom — so the boundary test is now asymmetric:

- `isBoundaryBefore` keeps `'` (so `'sym` still finds `sym`);
- `isBoundaryAfter` drops it (so `a` no longer matches inside `a'`).

The token pattern drops `'` from its first character class and allows it in the tail. A useful side effect: the word at `'sym` and `#'sym` is now `sym`, so hover and go-to-definition resolve a quoted symbol instead of looking up `'sym` and finding nothing.

`isValidSymbolName` accepts a trailing apostrophe as a rename target and keeps rejecting a leading one.

## Note on #90

Two tests added there asserted the old behaviour as "long-standing, pinned so a change is deliberate". This is that deliberate change, so those assertions are replaced and the changelog line from #90 is reconciled.

## Verification

- 4 new regression tests in `phelReferences.test.ts` (the corruption case, finding the prime-suffixed symbol itself, the quote-macro case still working, and the rename-target validation), plus updated token tests covering `a'`, `foo''`, `'sym`, `#'sym`.
- `npm run pretest` + `npm test`: **480 passing**. `npm run bundle` and `npm run check:changelog` green.