### PR TITLE
fix(syntax): keep a trailing apostrophe inside the symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed (prime-suffixed symbols)
 
 - **Renaming `a` corrupted `a'`.** The apostrophe was treated as a symbol terminator on both sides, so the leading `a` of `a'` looked like a complete token: find-references reported it, and rename rewrote it, leaving a stray `'`. `a'` and `foo''` are single symbols to the Phel lexer — verified by running one — and are now matched as such. Renaming *to* `a'` is allowed; a leading `'` is still rejected, because there it is the quote reader macro.
+- The grammar had the same split: `a'` highlighted as the symbol `a` followed by a quote reader macro. An apostrophe now stays inside the symbol in any position but the first, and a leading `'` is still the quote macro.
 - Word selection splits the quote macro off what it quotes: the word at `'sym` and `#'sym` is now `sym`, so hover and go-to-definition resolve a quoted symbol instead of looking up `'sym` and finding nothing.
 
 ### Internal

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -44,6 +44,7 @@ The rest:
 - Regex literals: `#"^\d+$"` → `string.regexp.phel` (distinct from the `#regex "…"` tagged literal)
 - Collections: `[1 2]`, `{:a 1}`, `#{1 2}`, `'(a b)`, PHP arrays `@[1 2]` / `@{:a 1}`
 - Gensyms: a trailing `#` belongs to the symbol (`x#`), so `` `(let [x# ~x] …) `` highlights as code rather than opening a comment
+- Prime-suffixed names: an apostrophe belongs to the symbol in any position but the first (`a'`, `foo''`), while a leading `'` stays the quote reader macro (`'sym`)
 
 ## Anonymous functions
 

--- a/scripts/sample.phel
+++ b/scripts/sample.phel
@@ -14,6 +14,7 @@
 (def radixes [2r1010 16rFF 36rZZ])
 (def bigs [123N 1_000N 1.5M -2.5e3M])
 (def symbolic [##Inf ##-Inf ##NaN])
+(def primes [a' foo''])   ;; trailing apostrophe is part of the symbol
 (def chars [\A \1 \( \space \newline \tab \u00e9 \o101])
 
 (defn greet

--- a/src/test/grammar.test.ts
+++ b/src/test/grammar.test.ts
@@ -135,6 +135,21 @@ describe('phel.tmLanguage reader syntax', () => {
         assertScoped('# legacy comment', '# legacy comment'.slice(1), 'comment.line.phel');
     });
 
+    it('keeps a mid or trailing apostrophe inside the symbol', () => {
+        // `a'` and `foo''` are single atoms to the lexer; the apostrophe must
+        // not scope as the quote reader macro.
+        assertScoped("(def a' 41)", "a'", 'meta.symbol.phel');
+        assertScoped("(def foo'' 1)", "foo''", 'meta.symbol.phel');
+    });
+
+    it('still scopes a leading apostrophe as the quote reader macro', () => {
+        const tokens = tokenize("('quoted)");
+        const quote = tokens.find((t) => t.text === "'");
+        assert.ok(quote, 'expected a standalone quote token');
+        assert.ok(quote.scopes.includes('punctuation.other.phel'));
+        assertScoped("('quoted)", 'quoted', 'meta.symbol.phel');
+    });
+
     it('scopes phel.router/compiled-router as a keyword', () => {
         assertScoped('(compiled-router routes)', 'compiled-router', 'keyword.control.phel');
     });

--- a/syntaxes/phel.tmLanguage.json
+++ b/syntaxes/phel.tmLanguage.json
@@ -163,9 +163,9 @@
 			"match": ":[^\\s\\#\\(\\)\\{\\}\\[\\]\\'\\\"\\,\\`]+"
 		},
 		"symbol": {
-			"comment": "Mirrors the lexer's atom rule: a trailing `#` is part of the symbol (gensym syntax, e.g. `x#`), so it must not fall through to the bare-`#` comment rule.",
+			"comment": "Mirrors the lexer's atom rule: a trailing `#` is part of the symbol (gensym syntax, e.g. `x#`), so it must not fall through to the bare-`#` comment rule. An apostrophe is likewise part of the symbol in any position but the first (`a'`, `foo''`), while a leading one is the quote reader macro (`'sym`) and is left to #readermac.",
 			"name": "meta.symbol.phel",
-			"match": "(?<![\\-])[^\\s\\#\\(\\)\\{\\}\\[\\]\\'\\\"\\,\\`]+\\#?"
+			"match": "(?<![\\-])[^\\s\\#\\(\\)\\{\\}\\[\\]\\'\\\"\\,\\`][^\\s\\#\\(\\)\\{\\}\\[\\]\\\"\\,\\`]*\\#?"
 		},
 		"char": {
 			"comment": "Character literals: \\a, \\A, \\1, \\(, \\space, \\newline, \\uNNNN, \\oNNN. The lookahead lets `\\Phel\\Lang\\Symbol` stay a symbol, matching the lexer.",


### PR DESCRIPTION
Eleventh in the series, and the grammar half of #91.

## Why

#91 fixed the occurrence scanner and the shared token pattern so `a'` and `foo''` are single symbols. The TextMate grammar had the identical split — its symbol rule excluded `'` outright:

```
before, tokenizing (def a' 41):
  "def"  keyword.control.phel
  "a"    meta.symbol.phel
  "'"    punctuation.other.phel      ← rendered as a quote reader macro

  (def foo'' 1) split into "foo" + "'" + "'"
```

So a prime-suffixed name was coloured as if the apostrophe quoted the next form.

## What

Split the rule's character class in two: the **first** character still excludes `'`, the **tail** no longer does.

```
- [^\s\#\(\)\{\}\[\]\'\"\,\`]+\#?
+ [^\s\#\(\)\{\}\[\]\'\"\,\`][^\s\#\(\)\{\}\[\]\"\,\`]*\#?
```

An apostrophe is now part of the symbol in every position but the first, and a leading one is still left to `#readermac`. Because the symbol rule starts earlier in the line than the readermac match would, longest-leftmost keeps `'sym` scoping as a quote followed by `sym`:

```
after, tokenizing ('quoted):
  "'"       punctuation.other.phel
  "quoted"  meta.symbol.phel
```

## Verification

- Tokenizing `scripts/sample.phel` **before and after produces byte-identical output** — nothing else moved.
- 2 new cases in `src/test/grammar.test.ts`: the trailing apostrophe stays in the symbol, the leading one still scopes as the quote macro.
- `scripts/sample.phel` gains a `(def primes [a' foo''])` line so `npm run tokenize` shows the case.
- `npm run pretest` + `npm test`: **482 passing**. `npm run check:changelog` green.
- `docs/syntax.md` documents the rule alongside the gensym one.