### PR TITLE
fix(completion): offer the referred namespace's names inside :refer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 ### Completion
 
 - **`alias/…` completes.** After `(:require [phel.string :as str])`, typing `str/` now offers every public symbol of that namespace with its docs. Hover, go-to-definition and signature help already resolved alias-qualified symbols; completion offered nothing, because every candidate label is a bare name.
+- **`:refer [ … ]` offers the namespace's own names.** Completing inside a refer vector suggested `:as` / `:refer` — the entry options — instead of the symbols being referred. It now lists the public names of the namespace on that entry, for both require shapes and either separator, and without mistaking an `:as` alias for the namespace.
 - **The `(ns …)` form gets its own candidates** instead of all 576 core symbols: `:require` / `:use` / `:require-file` directly inside `(ns …)`, the requirable namespaces inside a `(:require …)` clause, and `:as` / `:refer` inside an entry vector.
 
 ### Fixed

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -29,6 +29,7 @@ Two positions get their own, much smaller list instead of the flat core one:
 | Directly inside `(ns …)` | `:require`, `:use`, `:require-file` |
 | Inside `(:require …)` | Every namespace in the corpus or workspace, minus this file's own and the ones already required |
 | Inside a `[some.ns …]` entry | `:as`, `:refer` |
+| Inside that entry's `:refer [ … ]` | Every public name of the namespace being required |
 
 ### Bundled providers vs. the language server
 

--- a/src/phelCompletionContext.ts
+++ b/src/phelCompletionContext.ts
@@ -11,7 +11,7 @@
 // Pure: no `vscode` import, so the decisions are unit-testable.
 
 import { parseAll, pathAt, type Form } from './phelParedit';
-import { aliasMapFromSource } from './phelNsAnalyzer';
+import { aliasMapFromSource, normalizeNs } from './phelNsAnalyzer';
 import type { PhelDoc } from './phelDocs';
 
 /** Clause heads a `(ns …)` form accepts, per the compiler's `NsSymbol`. */
@@ -28,7 +28,9 @@ export type CompletionContext =
     /** Inside `(:require …)` / `(:use …)`, outside any entry vector. */
     | { kind: 'ns-namespace' }
     /** Inside a `[some.ns …]` entry, past the namespace symbol. */
-    | { kind: 'ns-entry-option' };
+    | { kind: 'ns-entry-option' }
+    /** Inside a `:refer [...]` vector; `ns` is the namespace being referred. */
+    | { kind: 'ns-refer'; ns: string };
 
 /**
  * The alias being typed, when the token under the cursor looks like
@@ -51,6 +53,50 @@ function atomText(src: string, form: Form): string {
 function headText(src: string, form: Form): string | null {
     const head = form.children[0];
     return head && head.kind === 'atom' ? atomText(src, head) : null;
+}
+
+/**
+ * When `vec` is the argument of a `:refer` keyword, the namespace whose names
+ * it lists; otherwise null.
+ *
+ * Both require shapes are handled, because `:refer` sits in a different parent
+ * in each: inside the entry vector for `[some.ns :refer [a]]`, and directly
+ * inside the clause for the flat `some.ns :refer [a]`. In both, the namespace
+ * is the last plain symbol before the `:refer`.
+ */
+function referTargetNs(src: string, parent: Form | undefined, vec: Form): string | null {
+    if (!parent || (parent.kind !== 'vector' && parent.kind !== 'list')) {
+        return null;
+    }
+    const kids = parent.children;
+    const index = kids.indexOf(vec);
+    if (index < 1) {
+        return null;
+    }
+    const keyword = kids[index - 1];
+    if (keyword.kind !== 'atom' || atomText(src, keyword) !== ':refer') {
+        return null;
+    }
+    // Scan forward so an option's *argument* is never mistaken for the
+    // namespace: in `[some.ns :as x :refer [...]]` the atom directly before
+    // `:refer` is `x`, the alias.
+    let ns: string | null = null;
+    // For the flat shape the parent is the `(:require …)` list, whose head is
+    // a keyword but not an option, so it takes no argument.
+    const start = parent.kind === 'list' ? 1 : 0;
+    for (let i = start; i < index - 1; i++) {
+        const kid = kids[i];
+        if (kid.kind !== 'atom') {
+            continue;
+        }
+        const text = atomText(src, kid);
+        if (text.startsWith(':')) {
+            i++; // skip this option's argument
+            continue;
+        }
+        ns = normalizeNs(text);
+    }
+    return ns;
 }
 
 /**
@@ -83,6 +129,12 @@ export function completionContextAt(
     for (let i = path.length - 1; i > nsIndex; i--) {
         const form = path[i];
         if (form.kind === 'vector') {
+            // `:refer [a b]` — the names come from the entry's namespace, not
+            // from the option keywords.
+            const referNs = referTargetNs(src, path[i - 1], form);
+            if (referNs !== null) {
+                return { kind: 'ns-refer', ns: referNs };
+            }
             // `[some.ns :as x]` — past the namespace symbol, options are next.
             return { kind: 'ns-entry-option' };
         }
@@ -151,6 +203,17 @@ export function requirableNamespaces(
     for (const doc of docs) {
         if (doc.ns && !skip.has(doc.ns)) {
             out.add(doc.ns);
+        }
+    }
+    return [...out].sort();
+}
+
+/** Public names of `ns`, offerable inside its `:refer [...]` vector. */
+export function referableNames(ns: string, docs: readonly PhelDoc[]): string[] {
+    const out = new Set<string>();
+    for (const doc of docs) {
+        if (doc.ns === ns && !doc.private) {
+            out.add(doc.name);
         }
     }
     return [...out].sort();

--- a/src/phelCompletionProvider.ts
+++ b/src/phelCompletionProvider.ts
@@ -6,6 +6,7 @@ import { buildRequireEdit, parseNsForm, type NsForm } from './phelNsAnalyzer';
 import {
     aliasQualifiedCandidates,
     completionContextAt,
+    referableNames,
     requirableNamespaces,
     NS_CLAUSES,
     NS_ENTRY_OPTIONS,
@@ -183,6 +184,17 @@ export class PhelCompletionProvider implements vscode.CompletionItemProvider {
                     const md = plainMarkdown(renderDocMarkdown(doc));
                     item.documentation = md;
                 }
+                if (range) {
+                    item.range = range;
+                }
+                return item;
+            });
+        }
+        // `:refer [ … ]` lists names from the entry's own namespace.
+        if (context.kind === 'ns-refer') {
+            return referableNames(context.ns, merged).map((name) => {
+                const item = new vscode.CompletionItem(name, vscode.CompletionItemKind.Function);
+                item.detail = `${context.ns}/${name}`;
                 if (range) {
                     item.range = range;
                 }

--- a/src/test/phelCompletionContext.test.ts
+++ b/src/test/phelCompletionContext.test.ts
@@ -3,6 +3,7 @@ import {
     aliasPrefix,
     aliasQualifiedCandidates,
     completionContextAt,
+    referableNames,
     requirableNamespaces,
 } from '../phelCompletionContext';
 import type { PhelDoc } from '../phelDocs';
@@ -129,5 +130,50 @@ describe('phelCompletionContext.requirableNamespaces', () => {
             'phel.string',
             'phel.test',
         ]);
+    });
+});
+
+describe('phelCompletionContext :refer vectors', () => {
+    const referCtx = (src: string) =>
+        completionContextAt(src, src.indexOf(':refer [') + ':refer ['.length, ' :refer [');
+
+    it('resolves the namespace for every require shape', () => {
+        const cases: [string, string][] = [
+            ['(ns a (:require [phel.string :as str :refer []]))', 'phel.string'],
+            ['(ns a (:require [phel.string :refer []]))', 'phel.string'],
+            ['(ns a (:require phel.test :as t :refer []))', 'phel.test'],
+            ['(ns a (:require phel.test :refer []))', 'phel.test'],
+            ['(ns a (:require [phel\\string :as s :refer []]))', 'phel.string'],
+            ['(ns a (:require phel.html :as h phel.test :as t :refer []))', 'phel.test'],
+            ['(ns a (:require phel.html :as h [phel.test :refer []]))', 'phel.test'],
+        ];
+        for (const [src, ns] of cases) {
+            assert.deepEqual(referCtx(src), { kind: 'ns-refer', ns }, src);
+        }
+    });
+
+    it('does not mistake the :as alias for the namespace', () => {
+        // The atom directly before `:refer` is the alias, not the namespace.
+        const ctx = referCtx('(ns a (:require [phel.string :as str :refer []]))');
+        assert.equal(ctx.kind === 'ns-refer' && ctx.ns, 'phel.string');
+    });
+
+    it('still reports an option position outside the refer vector', () => {
+        const src = '(ns a (:require [phel.string ]))';
+        const offset = src.indexOf('phel.string ') + 'phel.string '.length;
+        assert.deepEqual(completionContextAt(src, offset, '  (:require [phel.string '), {
+            kind: 'ns-entry-option',
+        });
+    });
+});
+
+describe('phelCompletionContext.referableNames', () => {
+    it('lists the public names of the namespace, sorted', () => {
+        assert.deepEqual(referableNames('phel.string', DOCS), ['blank?', 'join']);
+    });
+
+    it('skips private names and other namespaces', () => {
+        assert.ok(!referableNames('phel.string', DOCS).includes('hidden'));
+        assert.deepEqual(referableNames('phel.test', DOCS), ['is']);
     });
 });


### PR DESCRIPTION
Twelfth in the series, and a fix for a gap I introduced in #86.

## Why

The ns-form contexts added in #86 classified *anything* inside a vector as an entry-option position. So completing inside a `:refer` vector suggested `:as` and `:refer` — the two keywords that cannot appear there — instead of the symbols being referred:

```
(ns a (:require [phel.string :as str :refer [|]]))
                                             ^ offered :as / :refer
```

## What

Detect the refer vector by the keyword immediately before it in its parent, then resolve the namespace from that parent.

Two things the scan has to get right, both found by testing and both pinned:

1. **The `:as` alias is not the namespace.** In `[some.ns :as x :refer [...]]` the atom directly before `:refer` is `x`. Scanning backwards for "the nearest plain symbol" returns the alias — my first attempt did exactly that. Scanning forward and skipping each option's argument returns `some.ns`.
2. **The flat shape's parent is the clause itself.** `(:require phel.test :refer [...])` puts `:refer` in the `(:require …)` list, whose head is a keyword but takes no argument. Treating it like an option consumed the namespace as its argument and broke the flat case — the scan now starts past the head.

Resolves correctly for all seven shapes:

| Source | Namespace |
| --- | --- |
| `[phel.string :as str :refer []]` | `phel.string` |
| `[phel.string :refer []]` | `phel.string` |
| `phel.test :as t :refer []` | `phel.test` |
| `phel.test :refer []` | `phel.test` |
| `[phel\string :as s :refer []]` | `phel.string` |
| `phel.html :as h phel.test :as t :refer []` | `phel.test` |
| `phel.html :as h [phel.test :refer []]` | `phel.test` |

## Verification

- 5 new tests, including the alias trap and a guard that an option position outside the refer vector still reports as one.
- `npm run pretest` + `npm test`: **487 passing**. `npm run check:changelog` green.
- `docs/completion.md` gains the row to its ns-context table.