### PR TITLE
fix(completion): stop offering Phel namespaces inside :use and :require-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 ### Completion
 
 - **`alias/…` completes.** After `(:require [phel.string :as str])`, typing `str/` now offers every public symbol of that namespace with its docs. Hover, go-to-definition and signature help already resolved alias-qualified symbols; completion offered nothing, because every candidate label is a bare name.
+- **`:use` and `:require-file` no longer offer Phel namespaces.** All three clauses were treated alike, but `:use` imports a **PHP class** (`(:use Symfony.Component.Console.Application)`) and `:require-file` takes a path string. `:use` now offers only `:as`, which is the single option its registrar accepts — `:refer` there is a compile error — and `:require-file` offers nothing rather than a list that could never be right.
 - **`:refer [ … ]` offers the namespace's own names.** Completing inside a refer vector suggested `:as` / `:refer` — the entry options — instead of the symbols being referred. It now lists the public names of the namespace on that entry, for both require shapes and either separator, and without mistaking an `:as` alias for the namespace.
 - **The `(ns …)` form gets its own candidates** instead of all 576 core symbols: `:require` / `:use` / `:require-file` directly inside `(ns …)`, the requirable namespaces inside a `(:require …)` clause, and `:as` / `:refer` inside an entry vector.
 

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -28,6 +28,8 @@ Two positions get their own, much smaller list instead of the flat core one:
 |---|---|
 | Directly inside `(ns …)` | `:require`, `:use`, `:require-file` |
 | Inside `(:require …)` | Every namespace in the corpus or workspace, minus this file's own and the ones already required |
+| Inside `(:use …)` | `:as` only — `:use` imports a **PHP class**, which the extension cannot enumerate, and the compiler rejects `:refer` there |
+| Inside `(:require-file …)` | Nothing — it takes a path string |
 | Inside a `[some.ns …]` entry | `:as`, `:refer` |
 | Inside that entry's `:refer [ … ]` | Every public name of the namespace being required |
 

--- a/src/phelCompletionContext.ts
+++ b/src/phelCompletionContext.ts
@@ -18,6 +18,11 @@ import type { PhelDoc } from './phelDocs';
 export const NS_CLAUSES: readonly string[] = [':require', ':use', ':require-file'];
 /** Options a single `:require` entry accepts, per the same source. */
 export const NS_ENTRY_OPTIONS: readonly string[] = [':as', ':refer'];
+/**
+ * Options a `:use` entry accepts. `:use` imports a PHP class, not a Phel
+ * namespace, and `UseAliasRegistrar` rejects anything but `:as`.
+ */
+export const NS_USE_OPTIONS: readonly string[] = [':as'];
 
 export type CompletionContext =
     | { kind: 'normal' }
@@ -25,8 +30,12 @@ export type CompletionContext =
     | { kind: 'alias-qualified'; alias: string; ns: string }
     /** Inside `(ns …)`: a clause head like `(:require …)` is expected. */
     | { kind: 'ns-clause' }
-    /** Inside `(:require …)` / `(:use …)`, outside any entry vector. */
-    | { kind: 'ns-namespace' }
+    /**
+     * Inside a clause body, outside any entry vector. `clause` says which one,
+     * because they take different things: `:require` a Phel namespace,
+     * `:use` a PHP class, `:require-file` a path string.
+     */
+    | { kind: 'ns-namespace'; clause: string }
     /** Inside a `[some.ns …]` entry, past the namespace symbol. */
     | { kind: 'ns-entry-option' }
     /** Inside a `:refer [...]` vector; `ns` is the namespace being referred. */
@@ -141,7 +150,7 @@ export function completionContextAt(
         if (form.kind === 'list') {
             const head = headText(src, form);
             if (head && NS_CLAUSES.includes(head)) {
-                return { kind: 'ns-namespace' };
+                return { kind: 'ns-namespace', clause: head };
             }
         }
     }

--- a/src/phelCompletionProvider.ts
+++ b/src/phelCompletionProvider.ts
@@ -10,6 +10,7 @@ import {
     requirableNamespaces,
     NS_CLAUSES,
     NS_ENTRY_OPTIONS,
+    NS_USE_OPTIONS,
 } from './phelCompletionContext';
 import { localsInScopeAt } from './phelScope';
 import type { PhelWorkspaceIndexer } from './phelWorkspaceIndexProvider';
@@ -202,7 +203,7 @@ export class PhelCompletionProvider implements vscode.CompletionItemProvider {
             });
         }
         if (context.kind !== 'normal') {
-            return this.nsFormItems(context.kind, src, merged, range);
+            return this.nsFormItems(context, src, merged, range);
         }
 
         const specs = [
@@ -230,7 +231,10 @@ export class PhelCompletionProvider implements vscode.CompletionItemProvider {
 
     /** Candidates inside a `(ns …)` form: clause heads, entry options, namespaces. */
     private nsFormItems(
-        kind: 'ns-clause' | 'ns-namespace' | 'ns-entry-option',
+        context: Extract<
+            ReturnType<typeof completionContextAt>,
+            { kind: 'ns-clause' | 'ns-namespace' | 'ns-entry-option' }
+        >,
         src: string,
         docs: readonly import('./phelDocs').PhelDoc[],
         range: vscode.Range | undefined
@@ -242,19 +246,36 @@ export class PhelCompletionProvider implements vscode.CompletionItemProvider {
             return item;
         };
 
-        if (kind === 'ns-clause') {
+        if (context.kind === 'ns-clause') {
             return NS_CLAUSES.map((clause) => {
                 const item = new vscode.CompletionItem(clause, vscode.CompletionItemKind.Keyword);
                 item.detail = 'ns clause';
                 return withRange(item);
             });
         }
-        if (kind === 'ns-entry-option') {
+        if (context.kind === 'ns-entry-option') {
             return NS_ENTRY_OPTIONS.map((option) => {
                 const item = new vscode.CompletionItem(option, vscode.CompletionItemKind.Keyword);
                 item.detail = 'require option';
                 return withRange(item);
             });
+        }
+
+        const keywordItems = (options: readonly string[], detail: string) =>
+            options.map((option) => {
+                const item = new vscode.CompletionItem(option, vscode.CompletionItemKind.Keyword);
+                item.detail = detail;
+                return withRange(item);
+            });
+
+        // `:use` imports a PHP class and `:require-file` takes a path string;
+        // neither is something this extension can enumerate, so offering the
+        // Phel namespace list there would be plainly wrong.
+        if (context.clause === ':use') {
+            return keywordItems(NS_USE_OPTIONS, 'use option');
+        }
+        if (context.clause === ':require-file') {
+            return [];
         }
 
         const nsForm = parseNsForm(src);
@@ -266,13 +287,6 @@ export class PhelCompletionProvider implements vscode.CompletionItemProvider {
         });
         // `[ns :as x]` is the shape the auto-import edit writes, so offer the
         // options here too: the cursor may sit right after a namespace symbol.
-        return [
-            ...namespaces,
-            ...NS_ENTRY_OPTIONS.map((option) => {
-                const item = new vscode.CompletionItem(option, vscode.CompletionItemKind.Keyword);
-                item.detail = 'require option';
-                return withRange(item);
-            }),
-        ];
+        return [...namespaces, ...keywordItems(NS_ENTRY_OPTIONS, 'require option')];
     }
 }

--- a/src/test/phelCompletionContext.test.ts
+++ b/src/test/phelCompletionContext.test.ts
@@ -70,6 +70,7 @@ describe('phelCompletionContext.completionContextAt', () => {
         const offset = inClause.indexOf('(:require ') + '(:require '.length;
         assert.deepEqual(completionContextAt(inClause, offset, '  (:require '), {
             kind: 'ns-namespace',
+            clause: ':require',
         });
     });
 
@@ -175,5 +176,27 @@ describe('phelCompletionContext.referableNames', () => {
     it('skips private names and other namespaces', () => {
         assert.ok(!referableNames('phel.string', DOCS).includes('hidden'));
         assert.deepEqual(referableNames('phel.test', DOCS), ['is']);
+    });
+});
+
+describe('phelCompletionContext clause discrimination', () => {
+    const inClause = (src: string, marker: string) =>
+        completionContextAt(src, src.indexOf(marker) + marker.length, '  ' + marker);
+
+    it('reports which clause the cursor is in', () => {
+        // The three clauses take different things — a Phel namespace, a PHP
+        // class, and a path string — so the provider has to tell them apart.
+        assert.deepEqual(inClause('(ns a (:require ))', '(:require '), {
+            kind: 'ns-namespace',
+            clause: ':require',
+        });
+        assert.deepEqual(inClause('(ns a (:use ))', '(:use '), {
+            kind: 'ns-namespace',
+            clause: ':use',
+        });
+        assert.deepEqual(inClause('(ns a (:require-file ))', '(:require-file '), {
+            kind: 'ns-namespace',
+            clause: ':require-file',
+        });
     });
 });


### PR DESCRIPTION
Thirteenth in the series, and the second follow-up to my own #86.

## Why

`(ns …)` has three clause heads and #86 treated all three bodies alike — offering the Phel namespace list in each. Only one of them takes a Phel namespace.

Checked what the compiler actually does with each, and what phel's own sources write:

```phel
;; src/phel/cli.phel
(:use InvalidArgumentException)
(:use Symfony.Component.Console.Application)
```

`:use` imports a **PHP class**, registered by `UseAliasRegistrar`, which accepts `:as` and rejects anything else — `Unexpected keyword %s encountered in %s. Expected :as.` So the old behaviour offered a list of Phel namespaces (never valid there) *and* `:refer` (a compile error).

`:require-file` takes a path string, so the namespace list was equally wrong.

## What

The context now carries which clause the cursor is in, and the provider branches:

| Clause | Offers |
| --- | --- |
| `:require` | Requirable namespaces + `:as` / `:refer` |
| `:use` | `:as` only |
| `:require-file` | Nothing |

Returning nothing for `:require-file` is deliberate: a path is not something the extension can enumerate, and an empty list lets VS Code fall back to its own word suggestions, which beats a confidently wrong one.

## Verification

- New test asserting all three clauses are distinguished; the #86 test that asserted the old shape is updated rather than deleted, so the field is covered.
- `npm run pretest` + `npm test`: **488 passing**. `npm run check:changelog` green.
- `docs/completion.md` ns-context table gains both rows, with the reason.