### PR TITLE
docs: bring the README feature list back in line with the extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - The grammar had the same split: `a'` highlighted as the symbol `a` followed by a quote reader macro. An apostrophe now stays inside the symbol in any position but the first, and a leading `'` is still the quote macro.
 - Word selection splits the quote macro off what it quotes: the word at `'sym` and `#'sym` is now `sym`, so hover and go-to-definition resolve a quoted symbol instead of looking up `'sym` and finding nothing.
 
+### Docs
+
+- README feature list refreshed. It had drifted well behind the extension: it still described paredit as "slurp / barf / raise / wrap, sexp selection" (0.11 added drag / splice / kill, folding and native expand-selection), listed snippets as "`defn`, `let`, `cond`, `try`, `deftest`, `->`, …" when there are 60, and never mentioned scope-aware navigation, semantic highlighting, unused-local hints, the refactorings, or the outline coverage. Now grounded in the actual contributions in `package.json`.
+
 ### Internal
 
 - **De-duplicated the provider boilerplate**, net −28 lines. The Phel symbol-token regex existed as seven byte-identical copies (so the gensym change earlier in this release would have needed seven edits to stay consistent); it now lives in `phelSymbolToken.ts` with tests pinning what it matches. The `combineDocs(indexer, PHEL_DOCS)` merge and the `MarkdownString` + `isTrusted`/`supportHtml` construction each had five copies and are now `mergedDocs()` and `plainMarkdown()` in `phelProviderSupport.ts`. Behaviour is unchanged.

--- a/README.md
+++ b/README.md
@@ -14,17 +14,21 @@ VS Code support for [Phel](https://phel-lang.org/), a functional Lisp that compi
 
 ## Features
 
-- **Highlighting** for forms, macros, reader macros, tagged literals, and reader conditionals.
-- **Language server** (`phel lsp`, opt-in via `phel.lsp.enabled`): completion, hover, signature help, go-to-definition, find references, rename, symbols, formatting, and diagnostics straight from the Phel compiler — including PHP-interop intelligence for `php/->`, `php/::`, and `php/new`. Off by default; enable it once your Phel ships a stable server (older `phel lsp` builds exit on idle, in which case the extension falls back to its bundled providers).
-- **Go to / Find / Rename** (`F12`, `shift+F12`, `F2`, `cmd+T`).
-- **Diagnostics** and **format** on save.
+- **Highlighting** for every literal the Phel reader accepts — characters (`\A`, `\space`, `\u00e9`), regex literals (`#"…"`), radix / BigInt / BigDecimal / ratio numbers (`16rFF`, `123N`, `1.5M`, `3/4`), symbolic numbers (`##Inf`, `##NaN`), gensyms (`x#`), prime-suffixed names (`a'`), tagged literals including namespaced ones (`#my.app/Person`), reader conditionals, and metadata tags.
+- **Scope-aware navigation.** Go-to-definition, find-references, rename, document-highlight, hover and signature help resolve a *local* to its own binding, so renaming a parameter never touches a same-named global. Covers `fn` / `let` / `loop` / `binding` / `for` / `doseq` / `foreach` / `letfn` / `as->` / `catch`, destructuring, and protocol-method parameters.
+- **Semantic highlighting** of parameters and locals, plus faded **unused-local** hints.
+- **Completion** over special forms, macros, core functions, and workspace symbols, with docs and call snippets. Understands `alias/…` after a `:require`, and the `(ns …)` form itself — clause heads, requirable namespaces, `:as` / `:refer`, and the names inside a `:refer` vector. Accepting a workspace symbol can auto-add its `:require`.
+- **Outline & workspace symbols** for every defining form — `defn`, `def`, `defmacro`, `defstruct`, `defrecord`, `deftype`, `defprotocol`, `definterface`, `defenum`, `defexception`, `defmulti`, `defonce`, `deftest` — each with a matching icon.
+- **Refactorings** (`Ctrl+.`): thread first / last, unwind thread, cycle collection delimiters, and add a missing `:require`.
+- **Diagnostics** backed by `phel lint` (falling back to `phel analyze` on older CLIs), plus a **Lint Workspace** command that fills the Problems panel for the whole project. **Format** on save via `phel format`.
+- **Language server** (`phel lsp`, opt-in via `phel.lsp.enabled`): the same features straight from the Phel compiler, including PHP-interop intelligence for `php/->`, `php/::`, and `php/new`. Off by default; enable it once your Phel ships a stable server (older `phel lsp` builds exit on idle, in which case the extension falls back to its bundled providers).
 - **REPL** in an integrated terminal with `(in-ns)` follow and history.
-- **nREPL client** (`phel nrepl`): structured eval results, reload changed namespaces, and run a namespace's tests or the test under the cursor against the live runtime.
+- **nREPL client** (`phel nrepl`): structured eval results, inline `=> …` results at the end of the form, reload changed namespaces, and run a namespace's tests or the test under the cursor against the live runtime.
 - **Test Explorer + CodeLens** for `deftest`, with per-test results and a **Run with Coverage** profile (`phel test --coverage=clover`, VS Code 1.88+).
-- **Paredit**: slurp / barf / raise / wrap, sexp selection.
+- **Paredit**: slurp / barf / raise / wrap, drag / splice / kill form, form-aware folding, and native expand-selection (`Shift+Alt+→`).
 - **Native debug adapter** with breakpoints in `.phel` files.
 - **CLI commands**: Doctor (`phel doctor`), Show Effective Configuration (`phel config`), Watch Tests, Build, and Init Project (with a template picker).
-- **Snippets** for `defn`, `let`, `cond`, `try`, `deftest`, `->`, …
+- **60 snippets** covering the binding, conditional, threading, protocol, and test forms.
 
 ## Install
 


### PR DESCRIPTION
Fourteenth in the series. The README is the Marketplace listing, so its drift is the most user-visible of anything fixed in this run.

## Why

Checked the feature list against `package.json`'s `contributes` block and the shipped behaviour. It had fallen behind by two releases, not just by this run:

| README said | Reality |
| --- | --- |
| "Paredit: slurp / barf / raise / wrap, sexp selection" | 0.11 also added drag forward/backward, splice, kill form, form-aware folding, native expand-selection |
| "Snippets for `defn`, `let`, `cond`, `try`, `deftest`, `->`, …" | 60 snippets |
| "Diagnostics and format on save" | Diagnostics are `phel lint`-backed with a workspace command |
| — | Scope-aware navigation, semantic highlighting, unused-local hints, the four code actions, and outline coverage were absent entirely |

Most of those gaps predate this run — they were 0.10/0.11 features that never reached the README.

## What

Feature list rewritten from the actual contributions, and extended with this release's work: full literal coverage, `alias/…` and `(ns …)` completion, `phel lint` diagnostics, and the ten extra defining forms in the outline.

No behaviour change — documentation only.

## Verification

- Command and setting names cross-checked against `package.json` (41 contributed commands) rather than written from memory.
- `npm run pretest` + `npm test`: **488 passing**. `npm run check:changelog` green.
- Also ran `npm run package` on `main` beforehand as a smoke test: 12 files, 288 KB, grammar / snippets / corpus / bundle all present.