### PR TITLE
perf(scope): memoise the parse and occurrence scan behind the analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - The grammar had the same split: `a'` highlighted as the symbol `a` followed by a quote reader macro. An apostrophe now stays inside the symbol in any position but the first, and a leading `'` is still the quote macro.
 - Word selection splits the quote macro off what it quotes: the word at `'sym` and `#'sym` is now `sym`, so hover and go-to-definition resolve a quoted symbol instead of looking up `'sym` and finding nothing.
 
+### Performance
+
+- **Semantic tokens and unused-local hints are ~14x faster**, 591 ms → 43 ms on phel's own 56 KB `test.phel`. Both run the scope analyzer on every edit, and `resolveLocalAt` re-parsed the whole document once per candidate occurrence — hundreds of full parses per keystroke. The parse is now memoised on the source string, and the per-name occurrence scan alongside it (410 bindings share 158 distinct names in that file, so each scan was repeated two to three times). Both caches are keyed on the source text, so a stale buffer cannot be served; tests cover switching sources and cold-vs-warm results.
+
 ### Docs
 
 - README feature list refreshed. It had drifted well behind the extension: it still described paredit as "slurp / barf / raise / wrap, sexp selection" (0.11 added drag / splice / kill, folding and native expand-selection), listed snippets as "`defn`, `let`, `cond`, `try`, `deftest`, `->`, …" when there are 60, and never mentioned scope-aware navigation, semantic highlighting, unused-local hints, the refactorings, or the outline coverage. Now grounded in the actual contributions in `package.json`.

--- a/src/phelScope.ts
+++ b/src/phelScope.ts
@@ -19,6 +19,48 @@
 import { parseAll, pathAt, type Form } from './phelParedit';
 import { findOccurrences, type Occurrence } from './phelReferences';
 
+/**
+ * One-entry parse cache.
+ *
+ * A semantic-tokens or unused-locals pass calls `resolveLocalAt` once per
+ * candidate occurrence, and each call used to re-parse the whole document.
+ * Every call in a pass sees the identical source, so caching the last result
+ * collapses hundreds of parses into one. Keyed by the source string itself, so
+ * a stale buffer can never be served.
+ */
+let cachedSrc: string | null = null;
+let cachedForms: Form[] | null = null;
+
+function parseCached(src: string): Form[] {
+    if (cachedSrc === src && cachedForms) {
+        return cachedForms;
+    }
+    const forms = parseAll(src);
+    cachedSrc = src;
+    cachedForms = forms;
+    occurrenceCache.clear();
+    return forms;
+}
+
+/**
+ * Occurrences by name, for the source currently in `cachedSrc`. A pass scans
+ * once per binding, and bindings share names heavily — 410 bindings over 158
+ * distinct names in phel's own `test.phel` — so the same full-text scan was
+ * repeated two to three times on average.
+ */
+const occurrenceCache = new Map<string, readonly Occurrence[]>();
+
+function occurrencesCached(src: string, name: string): readonly Occurrence[] {
+    parseCached(src); // keeps the two caches keyed to the same source
+    const hit = occurrenceCache.get(name);
+    if (hit) {
+        return hit;
+    }
+    const found = findOccurrences(src, name);
+    occurrenceCache.set(name, found);
+    return found;
+}
+
 export interface LocalBinding {
     /** The bound symbol name. */
     name: string;
@@ -519,7 +561,7 @@ function bindingsOnPath(src: string, path: readonly Form[]): LocalBinding[] {
  * global / core symbol).
  */
 export function resolveLocalAt(src: string, offset: number): LocalBinding | null {
-    const forms = parseAll(src);
+    const forms = parseCached(src);
     const path = pathAt(forms, offset);
     const last = path[path.length - 1];
     if (!last || last.kind !== 'atom') {
@@ -556,7 +598,7 @@ export function resolveLocalAt(src: string, offset: number): LocalBinding | null
  */
 export function localOccurrences(src: string, b: LocalBinding): Occurrence[] {
     const out: Occurrence[] = [];
-    for (const occ of findOccurrences(src, b.name)) {
+    for (const occ of occurrencesCached(src, b.name)) {
         if (occ.start === b.declStart) {
             out.push(occ);
             continue;
@@ -582,7 +624,7 @@ export function localOccurrences(src: string, b: LocalBinding): Occurrence[] {
  * de-duplicated. Used to surface in-scope locals in completion.
  */
 export function localsInScopeAt(src: string, offset: number): string[] {
-    const forms = parseAll(src);
+    const forms = parseCached(src);
     const path = pathAt(forms, offset);
     const seen = new Set<string>();
     const out: string[] = [];
@@ -623,7 +665,7 @@ export function collectAllBindings(src: string): LocalBinding[] {
             walk(child);
         }
     };
-    for (const form of parseAll(src)) {
+    for (const form of parseCached(src)) {
         walk(form);
     }
     return out;

--- a/src/test/phelScope.test.ts
+++ b/src/test/phelScope.test.ts
@@ -321,3 +321,34 @@ describe('phelScope.findUnusedLocals', () => {
         assert.deepEqual(findUnusedLocals(src), []);
     });
 });
+
+describe('phelScope caching', () => {
+    // The analyzer memoises the parse and the per-name occurrence scan so a
+    // semantic-tokens pass does not re-parse the document once per occurrence.
+    // Both caches are keyed on the source string, so switching sources must
+    // never serve a stale answer.
+    it('does not serve results from a previous source', () => {
+        const first = '(defn f [alpha] (+ alpha 1))';
+        const second = '(defn g [beta] (+ beta 2))';
+
+        const a1 = resolveLocalAt(first, idx(first, 'alpha', 1));
+        assert.equal(a1?.name, 'alpha');
+
+        const b = resolveLocalAt(second, idx(second, 'beta', 1));
+        assert.equal(b?.name, 'beta');
+
+        // Back to the first source: still correct, not a leftover from the second.
+        const a2 = resolveLocalAt(first, idx(first, 'alpha', 1));
+        assert.deepEqual(a2, a1);
+    });
+
+    it('returns the same occurrences whether or not the cache is warm', () => {
+        const src = '(let [x 1] (+ x x))';
+        const binding = resolveLocalAt(src, idx(src, 'x', 0));
+        assert.ok(binding);
+        const cold = localOccurrences(src, binding).map((o) => o.start);
+        const warm = localOccurrences(src, binding).map((o) => o.start);
+        assert.deepEqual(warm, cold);
+        assert.equal(cold.length, 3);
+    });
+});


### PR DESCRIPTION
Fifteenth in the series.

## Why

Semantic tokens and unused-local hints both run the scope analyzer **on every edit**, and `phelSemanticTokens.ts` already carried a comment admitting the per-binding walk was superlinear (with a 200 KB bail-out as the mitigation).

Measured against phel's own sources rather than a synthetic file:

```
test.phel  56KB  410 bindings  1184 tokens   591 ms per pass
repl.phel  37KB  281 bindings   730 tokens   191 ms
http.phel  20KB   96 bindings   304 tokens    64 ms
```

591 ms recomputed per keystroke is a visible stutter.

## What

Neither cause was algorithmic — both were repeated identical work:

1. **`resolveLocalAt` parses on entry**, and a pass calls it once per candidate occurrence. Hundreds of full-document parses, all of the same source. Memoising the last parse: **591 → 90 ms**.
2. **`findOccurrences` runs a full-text scan per binding**, and bindings share names heavily — 410 bindings over 158 distinct names in that file, so each scan ran two to three times on average. Caching by name: **90 → 43 ms**.

```
test.phel  591 ms → 43 ms   (~14x)
repl.phel  191 ms → 20 ms
http.phel   64 ms →  5 ms
```

## Correctness

The analyzer was a pure module, so the caches need to be provably safe:

- both key on the **source string itself**, so a different buffer can never be served a stale answer — string identity implies identical content;
- the occurrence map is dropped whenever the parse cache misses, so the two can never describe different sources;
- cached arrays are handed out `readonly`, so a caller cannot corrupt them.

Two tests cover it: switching between two sources and back returns each one's own result, and cold-vs-warm calls agree.

## Verification

- `npm run pretest` + `npm test`: **490 passing** (+2), no existing test changed.
- `npm run check:changelog` green.