### PR TITLE
docs: explain why a debug session connects twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@
 
 ### Docs
 
+- `docs/debugging.md` explains why a debug session connects **twice**: Phel re-executes its own PHP process on startup for the opcache file cache, so the launcher connects first and exits, and the replacement process is the one that runs your code and hits breakpoints. "Request completed. Waiting for next connection..." mid-run is normal rather than a failure. Traced against a live Xdebug session, which also confirmed the adapter's reconnect handling is what makes breakpoints work at all — and that the in-flight-command fix earlier in this release applies to every run, since the first connection always closes with `run` outstanding.
+
 - README feature list refreshed. It had drifted well behind the extension: it still described paredit as "slurp / barf / raise / wrap, sexp selection" (0.11 added drag / splice / kill, folding and native expand-selection), listed snippets as "`defn`, `let`, `cond`, `try`, `deftest`, `->`, …" when there are 60, and never mentioned scope-aware navigation, semantic highlighting, unused-local hints, the refactorings, or the outline coverage. Now grounded in the actual contributions in `package.json`.
 
 ### Internal

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -82,11 +82,41 @@ In the container, set `xdebug.client_host=host.docker.internal` (macOS / Windows
 - **Phel: Show Compiled PHP Location** - jump from the current `.phel` line to its compiled PHP equivalent.
 - **Phel: Clear Source Map Cache** - drop cached source maps after a Phel rebuild.
 
+## Why the session connects twice
+
+Phel re-executes its own PHP process on startup to enable the opcache file cache
+(`Phel\Shared\Performance\OpcacheReexec`). Under a debugger that means **two
+Xdebug connections per run**, and the output channel says so:
+
+```
+Xdebug connected!
+Request completed. Waiting for next connection...
+Xdebug connected!
+```
+
+The first connection belongs to the launcher, which exits before running any of
+your code. The second is the process that actually executes it, and that is
+where breakpoints are hit. The adapter handles this: after a connection closes
+it returns to listening and re-applies every breakpoint to the new one.
+
+So "Request completed. Waiting for next connection..." partway through a run is
+normal, not a failure. Traced against a live session, a breakpoint on
+`lib/util.phel:3` is set on connection 1, discarded with it, re-applied on
+connection 2, and hit there:
+
+```
+--- connection #1 ---
+  init, breakpoint_set, closed
+--- connection #2 ---
+  init, breakpoint_set, run -> break at demo.util__a5b0ac5e.php:29
+```
+
 ## Troubleshooting
 
 | Symptom | Likely cause |
 |---|---|
 | Breakpoints show as hollow circles | Phel hasn't been compiled yet, or the cache directory is wrong |
+| The session appears to disconnect mid-run | Expected: Phel re-execs for the opcache, so there are two connections. See [above](#why-the-session-connects-twice) |
 | Adapter reports "no source map for `X.php`" | The `.phel` file was not compiled with source maps enabled |
 | Steps land in unexpected files | `skipPhelInternals` is false, or `skipFiles` is empty - add globs |
 | Container debugging hangs | Missing `pathMappings`, or `xdebug.client_host` not set inside the container |


### PR DESCRIPTION
Closes the question left open since #98: **does a breakpoint actually stop execution end to end?** It does — and the answer explains a confusing bit of the output channel.

## What was happening

Phel re-executes its own PHP process on startup to enable the opcache file cache (`Phel\Shared\Performance\OpcacheReexec`). Under a debugger that means **two Xdebug connections per run**. Traced live:

```
--- connection #1 ---        ← the launcher; re-execs and exits
  init, breakpoint_set, closed     (no response to `run` — the process is gone)
--- connection #2 ---        ← the process that runs your code
  init, breakpoint_set, run -> break at demo.util__a5b0ac5e.php:29
```

A breakpoint on `lib/util.phel:3` maps to `demo.util__a5b0ac5e.php:29`, is set on connection 1, discarded along with it, re-applied on connection 2, and hit there.

In between, the output channel prints `Request completed. Waiting for next connection...`, which reads like a failure and is not one. That is what this documents.

## Why it took a while to see

My earlier probe accepted a single connection, so it only ever saw connection 1 — set the breakpoint, send `run`, socket closes, no break. That looked like a product bug and was not: **the adapter's reconnect handling is correct**, and is precisely what makes breakpoints work.

Before landing on that, I ruled out each alternative by observation rather than argument:

- **the cache file is what executes** — injected a marker into it, saw it fire, restored it;
- **the mapped line is a real statement** — line 29 is `$r_2098 = (\Phel::getDefinition("phel.core", "*"))->__invoke($n, 2);`, inside `__invoke`;
- **that line runs** — injected a marker at exactly line 29, it fired;
- **the path matches** — `__FILE__` at runtime is byte-identical to the `file://` URI sent, and `__LINE__` is 29;
- **not a missing feature negotiation** — `feature_set -n resolved_breakpoints -v 1` changed nothing.

## A side effect worth recording

This also shows the in-flight-command fix (#101) applies to **every** debug run, not an edge case: connection 1 always closes with `run` outstanding, which is exactly the promise that used to hang forever.

## Not included

The source suggests an env var that would skip the re-exec and give a single connection. I could not get a clean run to confirm it, so it is left out rather than documented on a guess.

## Verification

Documentation only — no code change. `npm run check:changelog` green.
