### PR TITLE
test: stop depending on how a spawned stream happens to chunk

### DIFF
--- a/.agnostic-ai/rules/project-conventions.md
+++ b/.agnostic-ai/rules/project-conventions.md
@@ -16,6 +16,7 @@ adapter, and REPL/paredit helpers for `.phel` files.
 - `npm run pretest` runs compile + lint; always green before committing.
 - `npm run bundle` / `bundle:prod` — esbuild → `dist/` (shipped bundle).
 - `npm run tokenize` — tokenize `scripts/sample.phel` against the tmLanguage grammar with the same engine VS Code ships. Run after any `syntaxes/` edit.
+- `npm run sweep` — run every pure analyzer over a real Phel corpus (defaults to `../phel-lang/src/phel`); exits non-zero if one throws. Read the printed counts too — an implausible number is the signal.
 - Never hand-edit `out/` or `dist/`; they are generated.
 
 ## Symbol corpus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@
 
 ### Internal
 
+- New `npm run sweep`: runs every pure analyzer — paredit, scope, folding, references, ns, docs — over a real Phel corpus (defaults to `../phel-lang/src/phel`), probes the offset-driven entry points across each file, and exits non-zero if anything throws. It also prints per-analyzer counts, which is the more useful half: the two unused-local bugs fixed in this release were found by noticing that phel's own stdlib came back with 98 unused bindings. Documented in `CONTRIBUTING.md` next to `npm run tokenize`.
+
 - **De-duplicated the provider boilerplate**, net −28 lines. The Phel symbol-token regex existed as seven byte-identical copies (so the gensym change earlier in this release would have needed seven edits to stay consistent); it now lives in `phelSymbolToken.ts` with tests pinning what it matches. The `combineDocs(indexer, PHEL_DOCS)` merge and the `MarkdownString` + `isTrusted`/`supportHtml` construction each had five copies and are now `mergedDocs()` and `plainMarkdown()` in `phelProviderSupport.ts`. Behaviour is unchanged.
 - Grammar coverage is pinned by `src/test/grammar.test.ts`, which tokenizes with the same `vscode-textmate` engine VS Code ships and asserts scopes, so a grammar regression fails `npm test` instead of needing a manual read of `npm run tokenize`.
 - `scripts/sample.phel` used `0o17`, which is not valid Phel (octal is the leading-zero `017`); fixed and extended with the newly covered literal forms.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@
 
 ### Internal
 
+- Made the CLI stream-decoding test deterministic. It asserted that a *spawned* process's output is corrupted without a `StringDecoder`, which depends on where the runtime happens to chunk the stream — true on macOS under both Node 20 and 22, false on CI's Linux Node 20, so it failed there. The corruption is now demonstrated by splitting the buffer in the test itself; the spawn-based case remains but asserts only what must always hold, that the decoded text equals the payload.
+
 - New `npm run sweep`: runs every pure analyzer — paredit, scope, folding, references, ns, docs — over a real Phel corpus (defaults to `../phel-lang/src/phel`), probes the offset-driven entry points across each file, and exits non-zero if anything throws. It also prints per-analyzer counts, which is the more useful half: the two unused-local bugs fixed in this release were found by noticing that phel's own stdlib came back with 98 unused bindings. Documented in `CONTRIBUTING.md` next to `npm run tokenize`.
 
 - **De-duplicated the provider boilerplate**, net −28 lines. The Phel symbol-token regex existed as seven byte-identical copies (so the gensym change earlier in this release would have needed seven edits to stay consistent); it now lives in `phelSymbolToken.ts` with tests pinning what it matches. The `combineDocs(indexer, PHEL_DOCS)` merge and the `MarkdownString` + `isTrusted`/`supportHtml` construction each had five copies and are now `mergedDocs()` and `plainMarkdown()` in `phelProviderSupport.ts`. Behaviour is unchanged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,19 @@ npm run tokenize
 
 That uses the same `vscode-textmate` + `vscode-oniguruma` engine VS Code ships with to tokenise `scripts/sample.phel` and prints each token with its scope. Add new edge cases to `scripts/sample.phel` when fixing or extending grammar patterns.
 
+### Analyzers, against real Phel (`npm run sweep`)
+
+The unit tests cover the shapes we thought of. To check the analyzers — paredit, scope, folding, references, ns, docs — against the shapes people actually write:
+
+```bash
+npm run sweep                          # defaults to ../phel-lang/src/phel
+npm run sweep -- /path/to/other/src    # or any directory of .phel files
+```
+
+It runs each analyzer over every file, probes the offset-driven entry points across each one, and exits non-zero if anything throws.
+
+**Read the counts, not just the exit code.** A number that looks wrong is worth chasing: the macro-template and sequential-rebinding bugs behind the unused-local hints were found this way, when phel's own stdlib came back reporting 98 unused bindings in code written by the language's authors. It now reports 15, and those are genuine.
+
 ### Completion + docs database (`src/phelCoreDocs.ts`)
 
 `src/phelCoreDocs.ts` lazy-loads `assets/phel-core-docs.json`, a generated array of `PhelDoc` records (one per `defn` / `defmacro` / `def` form) extracted from a phel-lang checkout. It is the single source of truth for completion, hover, signature help, and the `Phel: Show Doc` command.

--- a/package.json
+++ b/package.json
@@ -622,6 +622,7 @@
         "test": "mocha out/test/**/*.test.js",
         "check:changelog": "node scripts/check-changelog.cjs",
         "tokenize": "node scripts/tokenize-sample.mjs",
+        "sweep": "npm run compile && node scripts/sweep-analyzers.mjs",
         "regen-docs": "npm run compile && node scripts/regen-core-docs.cjs",
         "package": "vsce package",
         "publish": "vsce publish",

--- a/scripts/sweep-analyzers.mjs
+++ b/scripts/sweep-analyzers.mjs
@@ -1,0 +1,117 @@
+// Run every pure analyzer over a corpus of real Phel source and report what
+// they produce. The unit tests cover shapes we thought of; this covers the
+// shapes people actually write.
+//
+// It reports two things:
+//
+//   * exceptions — any analyzer throwing on real input is a bug;
+//   * counts — totals per analyzer. A count that looks wrong is worth chasing:
+//     this is how the macro-template and sequential-rebinding bugs behind the
+//     unused-local hints were found, when phel's own stdlib came back with 98
+//     "unused" bindings in code written by the language's authors.
+//
+// Usage: node scripts/sweep-analyzers.mjs [path/to/phel-checkout-or-dir]
+//        Defaults to ../phel-lang/src/phel.
+//
+// Exits non-zero when an analyzer threw.
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve, basename } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const out = join(repoRoot, 'out');
+
+if (!existsSync(out)) {
+    console.error('out/ not found — run `npm run compile` first.');
+    process.exit(2);
+}
+
+const paredit = require(join(out, 'phelParedit.js'));
+const scope = require(join(out, 'phelScope.js'));
+const folding = require(join(out, 'phelFolding.js'));
+const references = require(join(out, 'phelReferences.js'));
+const nsAnalyzer = require(join(out, 'phelNsAnalyzer.js'));
+const docs = require(join(out, 'phelDocs.js'));
+
+const target = resolve(process.argv[2] ?? join(repoRoot, '..', 'phel-lang', 'src', 'phel'));
+if (!existsSync(target)) {
+    console.error(`corpus not found: ${target}`);
+    console.error('Pass a directory of .phel files, e.g. node scripts/sweep-analyzers.mjs ../phel-lang/src/phel');
+    process.exit(2);
+}
+
+const files = [];
+(function walk(dir) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const p = join(dir, entry.name);
+        if (entry.isDirectory()) {
+            walk(p);
+        } else if (p.endsWith('.phel')) {
+            files.push(p);
+        }
+    }
+})(target);
+
+if (files.length === 0) {
+    console.error(`no .phel files under ${target}`);
+    process.exit(2);
+}
+
+const failures = [];
+const totals = { forms: 0, bindings: 0, unused: 0, folds: 0, symbols: 0, requires: 0 };
+
+/** Run one analyzer, recording any throw against the file it happened on. */
+function attempt(file, label, fn) {
+    try {
+        return fn();
+    } catch (err) {
+        failures.push(`${basename(file)}: ${label}: ${err.message}`);
+        return null;
+    }
+}
+
+for (const file of files) {
+    const src = readFileSync(file, 'utf-8');
+
+    const forms = attempt(file, 'parseAll', () => paredit.parseAll(src));
+    totals.forms += forms?.length ?? 0;
+    totals.bindings += attempt(file, 'collectAllBindings', () => scope.collectAllBindings(src))?.length ?? 0;
+    totals.unused += attempt(file, 'findUnusedLocals', () => scope.findUnusedLocals(src))?.length ?? 0;
+    totals.folds += attempt(file, 'computeFoldRanges', () => folding.computeFoldRanges(src))?.length ?? 0;
+    totals.symbols += attempt(file, 'parsePhelFile', () => docs.parsePhelFile(src, 'sweep'))?.length ?? 0;
+    totals.requires +=
+        attempt(file, 'parseNsForm', () => nsAnalyzer.parseNsForm(src))?.requireClause?.entries.length ?? 0;
+    attempt(file, 'aliasMapFromSource', () => nsAnalyzer.aliasMapFromSource(src));
+    attempt(file, 'findOccurrences', () => references.findOccurrences(src, 'map'));
+
+    // Probe positions across the file: the offset-driven entry points are where
+    // an unexpected shape shows up first.
+    const step = Math.max(1, Math.floor(src.length / 40));
+    for (let offset = 0; offset < src.length; offset += step) {
+        attempt(file, `resolveLocalAt@${offset}`, () => scope.resolveLocalAt(src, offset));
+        attempt(file, `pathAt@${offset}`, () => paredit.pathAt(forms ?? [], offset));
+    }
+}
+
+const width = 10;
+console.log(`corpus: ${target}`);
+console.log(`files:  ${files.length}`);
+for (const [name, value] of Object.entries(totals)) {
+    console.log(`  ${name.padEnd(width)} ${value}`);
+}
+
+if (failures.length > 0) {
+    console.log(`\nfailures: ${failures.length}`);
+    for (const failure of failures.slice(0, 20)) {
+        console.log(`  ${failure}`);
+    }
+    if (failures.length > 20) {
+        console.log(`  … and ${failures.length - 20} more`);
+    }
+    process.exit(1);
+}
+
+console.log('\nno analyzer threw.');

--- a/src/test/phelCliStreams.test.ts
+++ b/src/test/phelCliStreams.test.ts
@@ -45,20 +45,19 @@ describe('CLI stream decoding', function () {
     // Spawning a process and pushing 64 KiB through it is slower than a unit test.
     this.timeout(20000);
 
-    it('loses a multi-byte character split across chunks with a naive toString', async () => {
-        // Places the two bytes of `é` either side of the 64 KiB boundary Node
-        // reads at, which is what a large `phel lint` run crosses.
+    it('decodes a large payload with a multi-byte character intact', async () => {
+        // Big enough to arrive in more than one chunk on any runtime. Where
+        // exactly it splits is up to Node and the OS, so this asserts only what
+        // must always hold: the decoded text equals the payload.
         const payload = Buffer.concat([
             Buffer.alloc(65535, 0x78),
             Buffer.from('é', 'utf8'),
             Buffer.alloc(10, 0x79),
         ]);
-        const { naive, decoded, chunks } = await collect(payload);
+        const { decoded } = await collect(payload);
 
-        assert.ok(chunks.length > 1, `expected more than one chunk, got ${chunks.join(',')}`);
-        assert.ok(naive.includes('�'), 'the naive path should corrupt the split character');
-        assert.ok(!decoded.includes('�'), 'StringDecoder must not corrupt it');
         assert.equal(decoded, payload.toString('utf8'));
+        assert.ok(!decoded.includes('\ufffd'), 'StringDecoder must not corrupt the character');
     });
 
     it('agrees with a naive decode when nothing is split', async () => {
@@ -66,6 +65,25 @@ describe('CLI stream decoding', function () {
         const { naive, decoded } = await collect(payload);
         assert.equal(decoded, naive);
         assert.equal(decoded, payload.toString('utf8'));
+    });
+
+    it('corrupts a split character without the decoder, and not with it', () => {
+        // Deterministic counterpart to the spawn test above: the split is made
+        // here rather than left to however the runtime happens to chunk a
+        // stream. How a payload divides depends on the platform as much as the
+        // Node version — an earlier version of this test asserted the naive
+        // path corrupts a spawned stream, which held on macOS (Node 20 and 22
+        // alike) and not on CI's Linux Node 20.
+        const payload = Buffer.from('café', 'utf8');
+        const cut = payload.indexOf(Buffer.from('é', 'utf8')) + 1;
+        const [head, tail] = [payload.subarray(0, cut), payload.subarray(cut)];
+
+        const naive = head.toString() + tail.toString();
+        assert.ok(naive.includes('\ufffd'), 'per-chunk toString should corrupt it');
+
+        const decoder = new StringDecoder('utf8');
+        const decoded = decoder.write(head) + decoder.write(tail) + decoder.end();
+        assert.equal(decoded, 'café');
     });
 
     it('emits nothing for a chunk that is only a partial character', () => {


### PR DESCRIPTION
Fixes a flaky test I introduced in #104. It broke CI on #108, which had nothing to do with it.

## What was wrong

The test asserted that reading a **spawned process's** stdout with a per-chunk `toString()` corrupts a multi-byte character:

```ts
assert.ok(naive.includes('�'), 'the naive path should corrupt the split character');
```

That depends on where the runtime and the OS decide to split the stream — not on anything the code under test controls. I built the payload around a 64 KiB boundary because that is what I observed locally, and treated it as a property.

It isn't:

```
old test, macOS Node 20   → 3 passing      (splits as expected)
old test, macOS Node 22   → 3 passing
old test, Linux Node 20   → FAILS          (CI)
```

Worth being precise: this is **not** a Node-version difference. I installed Node 20 to reproduce and the old test passed there too. It is platform *and* runtime together, which is exactly why it should never have been asserted.

## Fix

The corruption is now shown by splitting the buffer in the test itself, which is deterministic everywhere:

```ts
const payload = Buffer.from('café', 'utf8');
const cut = payload.indexOf(Buffer.from('é', 'utf8')) + 1;
const naive = payload.subarray(0, cut).toString() + payload.subarray(cut).toString();
assert.ok(naive.includes('�'));          // always true
```

The spawn-based test stays — exercising a real child process is worth keeping — but now asserts only what must always hold: the decoded text equals the payload.

## Verification

- `npm test` on **Node 20** and **Node 22**: 549 passing on both. The original only ever ran on 22.
- `npm run pretest` and `npm run check:changelog` green.

#108 is unaffected by this and should go green once this lands.
